### PR TITLE
Fix multiplayer bugs: health sync, disconnect errors, kick race, & more

### DIFF
--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -19,6 +19,22 @@ public partial class Player : CharacterBody3D
   }
   // @formatter:on
 
+  // Replicated via MultiplayerSynchronizer; only the owning player writes it, so every
+  // peer's health bar for this player stays in sync (see issue #20).
+  [Export]
+  public int Health
+  {
+    get => _health;
+    set
+    {
+      var previous = _health;
+      _health = value;
+      if (_healthBar != null) _healthBar.Value = value;
+      if (IsMultiplayerAuthority() || value >= previous) return;
+      FlashHitColor();
+    }
+  }
+
   [Signal] public delegate void HealthChangedEventHandler (int value);
   [Signal] public delegate void ScoredEventHandler (string playerName, string shotPlayerName);
   [Signal] public delegate void RespawnedShotEventHandler (string playerName, string shotByPlayerName);
@@ -55,7 +71,15 @@ public partial class Player : CharacterBody3D
   private int _health;
   private bool _isInputEnabled;
   private static Player? _localPlayer;
-  public override void _Process (double delta) => UpdatePuppetTags();
+  public override void _Process (double delta)
+  {
+    if (!IsMultiplayerActive()) return;
+    UpdatePuppetTags();
+  }
+
+  // Guards against "The multiplayer instance isn't currently active" error spam from
+  // IsMultiplayerAuthority() after the session ends but before player nodes are freed (see issue #22).
+  private bool IsMultiplayerActive() => Multiplayer.MultiplayerPeer != null && Multiplayer.MultiplayerPeer.GetConnectionStatus() == MultiplayerPeer.ConnectionStatus.Connected;
   public override void _EnterTree() => SetMultiplayerAuthority (NetworkId);
   public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
   private bool IsFalling() => !IsOnFloor();
@@ -106,6 +130,7 @@ public partial class Player : CharacterBody3D
 
   public override void _PhysicsProcess (double delta)
   {
+    if (!IsMultiplayerActive()) return;
     if (!IsMultiplayerAuthority()) return;
     var velocity = Velocity;
     if (IsFalling()) Fall (ref velocity, delta);
@@ -164,29 +189,44 @@ public partial class Player : CharacterBody3D
     HitPuppet (result.puppet, energy);
   }
 
+  // The victim is the single owner of its health: the shooter only reports the hit,
+  // the victim applies damage & replicates Health to everyone, & tells the shooter
+  // when it scored a kill (see issue #20).
   private void HitPuppet (Player playerPuppet, float energy)
   {
-    playerPuppet.SetColor (HitColor);
-    playerPuppet._hitRedTimer.Start();
-    playerPuppet._health -= CalculateHealthDecrease (energy);
-    playerPuppet._healthBar.Value = playerPuppet._health;
-    GD.Print ($"{DisplayName}: I hit {playerPuppet.DisplayName}! (Health: {playerPuppet._health})");
+    GD.Print ($"{DisplayName}: I hit {playerPuppet.DisplayName}!");
     playerPuppet.RpcId (playerPuppet.NetworkId, MethodName.ReceiveHit, energy, DisplayName);
-    if (playerPuppet._health > 0) return;
-    playerPuppet._health = MaxHealth;
-    playerPuppet._healthBar.Value = playerPuppet._health;
-    GD.Print ($"{DisplayName}: I scored!");
-    EmitSignal (SignalName.Scored, DisplayName, playerPuppet.DisplayName);
+  }
+
+  private void FlashHitColor()
+  {
+    SetColor (HitColor);
+    _hitRedTimer.Start();
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
   private void ReceiveHit (float energy, string shotByPlayerName)
   {
-    _health -= CalculateHealthDecrease (energy);
-    _healthBar.Value = _health;
-    GD.Print ($"{DisplayName}: I was hit by {shotByPlayerName}! Health {_health}");
-    if (_health <= 0) RespawnShot (shotByPlayerName);
-    EmitSignal (SignalName.HealthChanged, _health);
+    if (!IsMultiplayerAuthority()) return;
+    var shooterId = Multiplayer.GetRemoteSenderId();
+    Health -= CalculateHealthDecrease (energy);
+    GD.Print ($"{DisplayName}: I was hit by {shotByPlayerName}! Health {Health}");
+
+    if (Health <= 0)
+    {
+      GetParent().GetNodeOrNull <Player> ($"{shooterId}")?.RpcId (shooterId, MethodName.NotifyScored, DisplayName);
+      RespawnShot (shotByPlayerName);
+    }
+
+    EmitSignal (SignalName.HealthChanged, Health);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void NotifyScored (string shotPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    GD.Print ($"{DisplayName}: I scored!");
+    EmitSignal (SignalName.Scored, DisplayName, shotPlayerName);
   }
 
   private void HandleCollisions()

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -59,6 +59,9 @@ properties/4/replication_mode = 1
 properties/5/path = NodePath("Camera3D:position")
 properties/5/spawn = true
 properties/5/replication_mode = 1
+properties/6/path = NodePath(".:Health")
+properties/6/spawn = true
+properties/6/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 script = ExtResource("1_nipvj")

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -62,21 +62,28 @@ public partial class World : Node3D
 
     if (duplicateId != null)
     {
-      RpcId (senderId, MethodName.OnKickedFromServer, "You're already in the game.");
-      Multiplayer.MultiplayerPeer.DisconnectPeer (senderId);
+      Kick (senderId, "You're already in the game.");
       GD.PrintErr ($"Server: Disconnected client ID [{senderId}], duplicate ID, [{duplicateId.DisplayName} (ID: {duplicateId.NetworkId})] is already in game");
       return;
     }
 
     if (duplicateName != null)
     {
-      RpcId (senderId, MethodName.OnKickedFromServer, "Your name is already in use by another player.");
-      Multiplayer.MultiplayerPeer.DisconnectPeer (senderId);
+      Kick (senderId, "Your name is already in use by another player.");
       GD.PrintErr ($"Server: Disconnected client ID [{senderId}], duplicate display name, [{duplicateName.DisplayName} (ID: {duplicateName.NetworkId})] is already in game");
       return;
     }
 
     AddPlayer (senderId, playerName);
+  }
+
+  // Delay the disconnect so the kick-reason RPC isn't dropped by an immediate peer disconnect (see issue #23).
+  private async void Kick (int peerId, string reason)
+  {
+    RpcId (peerId, MethodName.OnKickedFromServer, reason);
+    await ToSignal (GetTree().CreateTimer (0.5), SceneTreeTimer.SignalName.Timeout);
+    if (!Multiplayer.GetPeers().Contains (peerId)) return;
+    Multiplayer.MultiplayerPeer.DisconnectPeer (peerId);
   }
 
   private void OnHostGameSuccess (string playerName)

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -1,0 +1,34 @@
+using com.forerunnergames.energyshot.ui.hud;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+[TestSuite]
+public class MessageGeneratorTest
+{
+  [TestCase]
+  public void ShotPlayerMessageUsesYouForSelf()
+  {
+    AssertString (MessageGenerator.OnShotPlayer (isSelf: true, "Alice", "Bob")).IsEqual ("You shot Bob");
+    AssertString (MessageGenerator.OnShotPlayer (isSelf: false, "Alice", "Bob")).IsEqual ("Alice shot Bob");
+  }
+
+  [TestCase]
+  public void RespawnedShotMessageUsesCorrectGrammar()
+  {
+    AssertString (MessageGenerator.OnPlayerRespawnedShot (isSelf: true, "Alice", "Bob")).IsEqual ("You were shot by Bob");
+    AssertString (MessageGenerator.OnPlayerRespawnedShot (isSelf: false, "Alice", "Bob")).IsEqual ("Alice was shot by Bob");
+  }
+
+  [TestCase]
+  public void RespawnedFellMessagesAgreeAcrossPeers()
+  {
+    // The random overload picks a message & returns its index; the indexed overload
+    // must produce the equivalent message for remote peers (modulo you/they wording).
+    var selfMessage = MessageGenerator.OnPlayerRespawnedFell (isSelf: true, "Alice", out var index);
+    var remoteMessage = MessageGenerator.OnPlayerRespawnedFell (isSelf: false, "Alice", index);
+    AssertString (selfMessage).StartsWith ("You ");
+    AssertString (remoteMessage).StartsWith ("Alice ");
+  }
+}

--- a/tests/unit/ToolsTest.cs
+++ b/tests/unit/ToolsTest.cs
@@ -1,0 +1,49 @@
+using com.forerunnergames.energyshot.utilities;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+[TestSuite]
+public class ToolsTest
+{
+  [TestCase]
+  public void ValidPlayerNamesAreAccepted()
+  {
+    AssertBool (Tools.IsValidPlayerName ("Aaron")).IsTrue();
+    AssertBool (Tools.IsValidPlayerName ("a")).IsTrue();
+    AssertBool (Tools.IsValidPlayerName ("Player123")).IsTrue();
+    AssertBool (Tools.IsValidPlayerName ("1234567890123456")).IsTrue(); // 16 chars (max)
+  }
+
+  [TestCase]
+  public void InvalidPlayerNamesAreRejected()
+  {
+    AssertBool (Tools.IsValidPlayerName (string.Empty)).IsFalse();
+    AssertBool (Tools.IsValidPlayerName ("12345678901234567")).IsFalse(); // 17 chars (over max)
+    AssertBool (Tools.IsValidPlayerName ("has space")).IsFalse();
+    AssertBool (Tools.IsValidPlayerName ("emoji😀")).IsFalse();
+    AssertBool (Tools.IsValidPlayerName ("under_score")).IsFalse();
+  }
+
+  [TestCase]
+  public void ValidServerAddressesAreAccepted()
+  {
+    AssertBool (Tools.IsValidServerAddress ("192.168.1.1")).IsTrue();
+    AssertBool (Tools.IsValidServerAddress ("255.255.255.255")).IsTrue();
+    AssertBool (Tools.IsValidServerAddress ("::1")).IsTrue();
+    AssertBool (Tools.IsValidServerAddress ("2001:db8::ff00:42:8329")).IsTrue();
+    AssertBool (Tools.IsValidServerAddress ("example.com")).IsTrue();
+    AssertBool (Tools.IsValidServerAddress ("sub.domain.example.com")).IsTrue();
+  }
+
+  [TestCase]
+  public void InvalidServerAddressesAreRejected()
+  {
+    AssertBool (Tools.IsValidServerAddress (string.Empty)).IsFalse();
+    AssertBool (Tools.IsValidServerAddress ("256.1.1.1")).IsFalse();
+    AssertBool (Tools.IsValidServerAddress ("1.2.3")).IsFalse();
+    AssertBool (Tools.IsValidServerAddress ("not valid")).IsFalse();
+    AssertBool (Tools.IsValidServerAddress ("-bad.com")).IsFalse();
+  }
+}

--- a/ui/dialogs/host/HostGameDialog.cs
+++ b/ui/dialogs/host/HostGameDialog.cs
@@ -44,9 +44,9 @@ public partial class HostGameDialog : Control
     _bottomText.Text = string.Empty;
     UpdateHostGameButtonState();
     Show();
-    await ToSignal (GetTree(), SceneTree.SignalName.ProcessFrame);
-    await ToSignal (GetTree(), SceneTree.SignalName.ProcessFrame);
-    var (success, address, error) = Tools.FindServerAddress (serverPort);
+    // UPnP discovery can take seconds; run it off the main thread so the UI stays responsive (see issue #25).
+    var (success, address, error) = await System.Threading.Tasks.Task.Run (() => Tools.FindServerAddress (serverPort));
+    if (!IsInsideTree()) return;
     _middleText.Text = success ? "Your server address:" : $"Failed to find your server address. Please type it manually\n{error}";
     _serverAddress.Text = address;
     _bottomText.Text = success ? "Please share this with your friends so they can join your game!" : string.Empty;
@@ -75,13 +75,15 @@ public partial class HostGameDialog : Control
     }
 
     var error = _peer.CreateServer (_serverPort);
-    Multiplayer.MultiplayerPeer = _peer;
 
     if (error != Error.Ok)
     {
       OnError ($"Failed to host game, error [{error}]");
       return;
     }
+
+    // Only assign a working peer, so a failed attempt doesn't leave a dead peer active (see issue #24).
+    Multiplayer.MultiplayerPeer = _peer;
 
     GD.Print ($"Successfully hosted server at [{_serverAddress.Text}:{_serverPort}]!");
     Hide();

--- a/ui/dialogs/join/JoinGameDialog.cs
+++ b/ui/dialogs/join/JoinGameDialog.cs
@@ -79,14 +79,15 @@ public partial class JoinGameDialog : Control
     }
 
     var error = _peer.CreateClient (_serverAddress.Text, _serverPort);
-    Multiplayer.MultiplayerPeer = _peer;
 
-    // ReSharper disable once InvertIf
     if (error != Error.Ok)
     {
       OnError ($"Failed to join game, error [{error}]");
-      return; // ReSharper disable once RedundantJumpStatement
+      return;
     }
+
+    // Only assign a working peer, so a failed attempt doesn't leave a dead peer active (see issue #24).
+    Multiplayer.MultiplayerPeer = _peer;
   }
 
   private void OnCloseButtonPressed()


### PR DESCRIPTION
## Summary
Tactical fixes within the current P2P model (the full authoritative-server migration is tracked separately):

- **Health sync (#18, #20)**: the victim is now the single owner of its health. `Health` is an exported property replicated to all peers via the `MultiplayerSynchronizer`, so bystanders' health bars finally update, and kills are attributed by the victim (which sees all incoming damage) instead of each shooter's private copy. Puppets flash red on any replicated health decrease, so hit feedback is visible to everyone too.
- **Disconnect error spam (#22)**: `_Process`/`_PhysicsProcess` now early-out when the multiplayer peer is inactive, eliminating the per-frame `"The multiplayer instance isn't currently active"` errors after a session ends.
- **Kick race (#23)**: the server now waits 0.5 s after sending the kick-reason RPC before disconnecting the peer, so kicked clients actually see why.
- **Dead peer on failed host/join (#24)**: `Multiplayer.MultiplayerPeer` is only assigned after `CreateServer`/`CreateClient` succeeds.
- **UPnP UI freeze (#25)**: UPnP discovery/port-mapping now runs on a background thread; the Host Game dialog stays responsive.
- **Tests**: real unit tests for `Tools` address/name validation and `MessageGenerator` grammar (8 passing total).

Fixes #18. Fixes #20. Fixes #22. Fixes #23. Fixes #24. Fixes #25.

## Testing
- `dotnet build` clean; full gdUnit4 suite passes locally under Godot 4.7.1 (8/8).
- Multiplayer behavior (health bars across 3+ clients, kick reason, host/join failure paths) needs a manual playtest — CI has no multi-instance harness yet (planned as part of the authoritative-server migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)