### PR TITLE
Implement player feedback: visible laser bolts, full-auto, spawn room, & more

### DIFF
--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -39,7 +39,15 @@ public partial class Player : CharacterBody3D
   [Signal] public delegate void ScoredEventHandler (string playerName, string shotPlayerName);
   [Signal] public delegate void RespawnedShotEventHandler (string playerName, string shotByPlayerName);
   [Signal] public delegate void RespawnedFellEventHandler (string playerName);
-  [Export] public int MaxHealth = 100;
+  // Replicated like Health so every peer can render the leaderboard.
+  [Export] public int Score { get; set; }
+  [Export] public int MaxHealth = 200;
+  [Export] public float MouseSensitivity = 0.0025f;
+  [Export] public float FullAutoDurationSeconds = 3.0f;
+  [Export] public float FullAutoCooldownSeconds = 15.0f;
+  [Export] public float FullAutoShotIntervalSeconds = 0.15f;
+  [Export] public float FullAutoEnergy = 0.12f;
+  [Export] public float RespawnInputLockSeconds = 2.0f;
   [Export] public float Speed = 7.0f;
   [Export] public float JumpVelocity = 20.0f;
   [Export] public Vector3 Gravity = new(0.0f, -50.0f, 0.0f);
@@ -55,11 +63,13 @@ public partial class Player : CharacterBody3D
   private static readonly Color NormalColor = new("0027ff");
   private static readonly Color HitColor = Colors.DarkRed;
   private NetworkManager _networkManager = null!;
-  private Area3D _spawnZoneArea = null!;
-  private CylinderShape3D _spawnZoneCylinder = null!;
+  private Node3D _spawnRoom = null!;
   private MeshInstance3D _mesh = null!;
-  private RayCast3D _aim = null!;
+  private PackedScene _laserBoltScene = null!;
   private EnergyWeapon _energyWeapon = null!;
+  private float _fullAutoSecondsLeft;
+  private float _fullAutoCooldownLeft;
+  private float _nextAutoShotIn;
   private Sprite3D _crossHairs = null!;
   private Timer _jumpTimer = null!;
   private Timer _hitRedTimer = null!;
@@ -84,21 +94,20 @@ public partial class Player : CharacterBody3D
   public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
   private bool IsFalling() => !IsOnFloor();
   private bool IsJumping() => _isInputEnabled && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
-  private bool IsChargingWeapon() => _isInputEnabled && Input.IsActionPressed ("shoot");
+  private bool IsFullAutoActive() => _fullAutoSecondsLeft > 0.0f;
+  private bool IsChargingWeapon() => _isInputEnabled && !IsFullAutoActive() && Input.IsActionPressed ("shoot");
   private bool IsDischargingWeapon() => _isInputEnabled && _energyWeapon.IsSpinningUp && Input.IsActionJustReleased ("shoot");
   private void Fall (ref Vector3 velocity, double delta) => velocity += Gravity * (float)delta;
   private void ChargeWeapon() => _energyWeapon.Charge();
   private void DischargeWeapon() => _energyWeapon.Discharge();
   private void SetColor (Color color) => (_mesh.GetSurfaceOverrideMaterial (0) as StandardMaterial3D)!.AlbedoColor = color;
-  private (bool hit, Player? puppet) TryHitPlayerPuppet() => _aim.IsColliding() && _aim.GetCollider() is Player hitPlayer && hitPlayer.NetworkId != NetworkId ? (true, hitPlayer) : (false, null);
   private static int CalculateHealthDecrease (float energyShot) => Mathf.Min (100, Mathf.RoundToInt (energyShot * 100.0f));
 
   public override void _Ready()
   {
-    _spawnZoneArea = GetNode <Area3D> ("/root/World/SpawnZone");
-    _spawnZoneCylinder = (GetNode <CollisionShape3D> ("/root/World/SpawnZone/CollisionShape3D").Shape as CylinderShape3D)!;
+    _spawnRoom = GetNode <Node3D> ("/root/World/SpawnRoom");
+    _laserBoltScene = ResourceLoader.Load <PackedScene> ("res://core/weapons/LaserBolt.tscn");
     _mesh = GetNode <MeshInstance3D> ("MeshInstance3D");
-    _aim = GetNode <RayCast3D> ("Camera3D/Aim");
     _energyWeapon = GetNode <EnergyWeapon> ("Camera3D/EnergyWeapon");
     _crossHairs = GetNode <Sprite3D> ("Camera3D/Crosshairs");
     _jumpTimer = GetNode <Timer> ("JumpTimer");
@@ -106,7 +115,9 @@ public partial class Player : CharacterBody3D
     _nameTag = GetNode <Label3D> ("NameTag");
     _healthTag = GetNode <Sprite3D> ("HealthTag");
     _healthBar = GetNode <ProgressBar> ("SubViewport/HealthBar");
+    _healthBar.MaxValue = MaxHealth;
     _health = MaxHealth;
+    _healthBar.Value = _health;
 
     if (!IsMultiplayerAuthority())
     {
@@ -132,6 +143,7 @@ public partial class Player : CharacterBody3D
   {
     if (!IsMultiplayerActive()) return;
     if (!IsMultiplayerAuthority()) return;
+    UpdateFullAuto (delta);
     var velocity = Velocity;
     if (IsFalling()) Fall (ref velocity, delta);
     if (IsJumping()) Jump (ref velocity);
@@ -139,6 +151,26 @@ public partial class Player : CharacterBody3D
     Velocity = velocity;
     if (!MoveAndSlide()) return;
     HandleCollisions();
+  }
+
+  private void UpdateFullAuto (double delta)
+  {
+    var dt = (float)delta;
+    _fullAutoCooldownLeft = Mathf.Max (0.0f, _fullAutoCooldownLeft - dt);
+
+    if (_isInputEnabled && Input.IsActionJustPressed ("ability") && _fullAutoCooldownLeft <= 0.0f)
+    {
+      _fullAutoSecondsLeft = FullAutoDurationSeconds;
+      _fullAutoCooldownLeft = FullAutoCooldownSeconds;
+      _nextAutoShotIn = 0.0f;
+    }
+
+    if (!IsFullAutoActive()) return;
+    _fullAutoSecondsLeft -= dt;
+    _nextAutoShotIn -= dt;
+    if (!_isInputEnabled || !Input.IsActionPressed ("shoot") || _nextAutoShotIn > 0.0f) return;
+    _nextAutoShotIn = FullAutoShotIntervalSeconds;
+    _energyWeapon.FireLowPower (FullAutoEnergy);
   }
 
   public override void _ExitTree()
@@ -155,8 +187,8 @@ public partial class Player : CharacterBody3D
     if (IsChargingWeapon()) ChargeWeapon();
     if (IsDischargingWeapon()) DischargeWeapon();
     if (@event is not InputEventMouseMotion motionEvent) return;
-    RotateY (-motionEvent.Relative.X * 0.005f);
-    _camera.RotateX (-motionEvent.Relative.Y * 0.005f);
+    RotateY (-motionEvent.Relative.X * MouseSensitivity);
+    _camera.RotateX (-motionEvent.Relative.Y * MouseSensitivity);
     _camera.Rotation = new Vector3 (Mathf.Clamp (_camera.Rotation.X, -Mathf.Pi / 2.0f, Mathf.Pi / 2.0f), _camera.Rotation.Y, _camera.Rotation.Z);
   }
 
@@ -184,9 +216,28 @@ public partial class Player : CharacterBody3D
 
   private void OnWeaponShotFired (float energy)
   {
-    var result = TryHitPlayerPuppet();
-    if (!result.hit || result.puppet == null) return;
-    HitPuppet (result.puppet, energy);
+    var direction = -_camera.GlobalTransform.Basis.Z;
+    var origin = _camera.GlobalPosition + direction * 0.9f;
+    SpawnBolt (origin, direction, energy, isLive: true);
+    Rpc (MethodName.SpawnVisualLaser, origin, direction, energy);
+  }
+
+  // Visual-only copy of the shooter's bolt on every other peer.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void SpawnVisualLaser (Vector3 origin, Vector3 direction, float energy) => SpawnBolt (origin, direction, energy, isLive: false);
+
+  private void SpawnBolt (Vector3 origin, Vector3 direction, float energy, bool isLive)
+  {
+    var bolt = _laserBoltScene.Instantiate <LaserBolt>();
+    GetParent().AddChild (bolt);
+    bolt.Launch (origin, direction, energy, isLive, this);
+    if (isLive) bolt.HitPlayer += OnLaserHitPlayer;
+  }
+
+  private void OnLaserHitPlayer (CharacterBody3D body, float energy)
+  {
+    if (body is not Player victim || victim.NetworkId == NetworkId) return;
+    HitPuppet (victim, energy);
   }
 
   // The victim is the single owner of its health: the shooter only reports the hit,
@@ -225,6 +276,7 @@ public partial class Player : CharacterBody3D
   private void NotifyScored (string shotPlayerName)
   {
     if (!IsMultiplayerAuthority()) return;
+    ++Score;
     GD.Print ($"{DisplayName}: I scored!");
     EmitSignal (SignalName.Scored, DisplayName, shotPlayerName);
   }
@@ -253,19 +305,23 @@ public partial class Player : CharacterBody3D
     EmitSignal (SignalName.RespawnedFell, DisplayName);
   }
 
-  private void Respawn()
+  // Respawn into the spawn room above the arena (drop in to re-enter), with a short
+  // input lock, so respawns are no longer instant teleports into the fight.
+  private async void Respawn()
   {
-    _health = MaxHealth;
-    _healthBar.Value = _health;
+    Health = MaxHealth;
+    Velocity = Vector3.Zero;
     Position = CalculateRandomSpawnPosition();
+    SetInputEnabled (isEnabled: false);
     GD.Print ($"{DisplayName}: I respawned!");
+    await ToSignal (GetTree().CreateTimer (RespawnInputLockSeconds), SceneTreeTimer.SignalName.Timeout);
+    SetInputEnabled (isEnabled: true);
   }
 
   private Vector3 CalculateRandomSpawnPosition()
   {
-    var theta = _rng.RandfRange (0.0f, Mathf.Pi * 2.0f);
-    var r = _spawnZoneCylinder.Radius * Mathf.Sqrt (_rng.Randf());
-    return new Vector3 (r * Mathf.Cos (theta) + _spawnZoneArea.Position.X, _spawnZoneArea.Position.Y, r * Mathf.Sin (theta) + _spawnZoneArea.Position.Z);
+    var offset = new Vector3 (_rng.RandfRange (-4.0f, 4.0f), 1.0f, _rng.RandfRange (-4.0f, 4.0f));
+    return _spawnRoom.Position + offset;
   }
 
   private void UpdatePuppetTags()

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -62,6 +62,9 @@ properties/5/replication_mode = 1
 properties/6/path = NodePath(".:Health")
 properties/6/spawn = true
 properties/6/replication_mode = 2
+properties/7/path = NodePath(".:Score")
+properties/7/spawn = true
+properties/7/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 script = ExtResource("1_nipvj")
@@ -121,10 +124,6 @@ no_depth_test = true
 fixed_size = true
 render_priority = 100
 texture = ExtResource("2_37lxu")
-
-[node name="Aim" type="RayCast3D" parent="Camera3D"]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0)
-target_position = Vector3(0, -50, 0)
 
 [node name="EnergyWeapon" parent="Camera3D" instance=ExtResource("4_pk5hr")]
 transform = Transform3D(-4.37114e-09, 0, 0.1, 0, 0.1, 0, -0.1, 0, -4.37114e-09, 0.5, 0.3, -1.15)

--- a/core/weapons/EnergyWeapon.cs
+++ b/core/weapons/EnergyWeapon.cs
@@ -75,6 +75,14 @@ public partial class EnergyWeapon : Node3D
     SpinDown();
   }
 
+  // Full-auto shots: fixed low energy, no charge-up required.
+  public void FireLowPower (float energy)
+  {
+    PlayShootingSound();
+    EmitSignal (SignalName.ShotFired, energy);
+    StartRecoil (energy);
+  }
+
   private void SpinUp()
   {
     if (IsSpinningUp) return;

--- a/core/weapons/LaserBolt.cs
+++ b/core/weapons/LaserBolt.cs
@@ -1,0 +1,80 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.weapons;
+
+// A visible laser burst that travels through the world. Damage & glow scale with the
+// energy it was fired with. Only the shooter's own bolt is "live" (deals damage);
+// other peers spawn visual-only copies. Hits are detected by sweeping a ray along the
+// path traveled each physics frame, so fast bolts can't tunnel through thin geometry.
+public partial class LaserBolt : Node3D
+{
+  [Export] public float Speed = 90.0f;
+  [Export] public float DropAcceleration = 6.0f;
+  [Export] public float MaxLifetimeSeconds = 4.0f;
+  [Signal] public delegate void HitPlayerEventHandler (CharacterBody3D player, float energy);
+  private static readonly Color LowEnergyColor = new(0.2f, 0.6f, 3.0f);
+  private static readonly Color HighEnergyColor = new(3.0f, 0.2f, 0.2f);
+  private Vector3 _velocity;
+  private float _energy;
+  private float _age;
+  private bool _isLive;
+  private Rid _shooterRid;
+
+  public void Launch (Vector3 origin, Vector3 direction, float energy, bool isLive, CharacterBody3D shooter)
+  {
+    GlobalPosition = origin;
+    _velocity = direction.Normalized() * Speed;
+    _energy = energy;
+    _isLive = isLive;
+    _shooterRid = shooter.GetRid();
+    Orient();
+    ApplyEnergyVisuals();
+  }
+
+  public override void _PhysicsProcess (double delta)
+  {
+    var dt = (float)delta;
+    _age += dt;
+
+    if (_age > MaxLifetimeSeconds)
+    {
+      QueueFree();
+      return;
+    }
+
+    var from = GlobalPosition;
+    _velocity.Y -= DropAcceleration * dt; // ponytail: simple laser drop, no drag
+    var to = from + _velocity * dt;
+    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { _shooterRid });
+    var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
+
+    if (hit.Count > 0)
+    {
+      if (_isLive && hit["collider"].AsGodotObject() is CharacterBody3D player) EmitSignal (SignalName.HitPlayer, player, _energy);
+      QueueFree();
+      return;
+    }
+
+    GlobalPosition = to;
+    Orient();
+  }
+
+  private void Orient()
+  {
+    if (_velocity.LengthSquared() < 0.01f) return;
+    var direction = _velocity.Normalized();
+    LookAt (GlobalPosition + direction, direction.Abs().IsEqualApprox (Vector3.Up) ? Vector3.Forward : Vector3.Up);
+  }
+
+  private void ApplyEnergyVisuals()
+  {
+    var mesh = GetNode <MeshInstance3D> ("Mesh");
+    var material = (StandardMaterial3D)((StandardMaterial3D)mesh.MaterialOverride).Duplicate();
+    mesh.MaterialOverride = material;
+    var color = LowEnergyColor.Lerp (HighEnergyColor, _energy);
+    material.AlbedoColor = color;
+    material.Emission = color;
+    var thickness = 0.5f + _energy;
+    mesh.Scale = new Vector3 (thickness, thickness, 1.0f + _energy * 2.0f);
+  }
+}

--- a/core/weapons/LaserBolt.cs.uid
+++ b/core/weapons/LaserBolt.cs.uid
@@ -1,0 +1,1 @@
+uid://r2xk7wptqfsi

--- a/core/weapons/LaserBolt.tscn
+++ b/core/weapons/LaserBolt.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3 uid="uid://c4lboltenergy17"]
+
+[ext_resource type="Script" path="res://core/weapons/LaserBolt.cs" id="1_lbolt"]
+
+[sub_resource type="CapsuleMesh" id="CapsuleMesh_lbolt"]
+radius = 0.06
+height = 1.2
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_lbolt"]
+shading_mode = 0
+albedo_color = Color(0.2, 0.6, 3, 1)
+emission_enabled = true
+emission = Color(0.2, 0.6, 3, 1)
+emission_energy_multiplier = 2.0
+
+[node name="LaserBolt" type="Node3D"]
+script = ExtResource("1_lbolt")
+
+[node name="Mesh" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0)
+material_override = SubResource("StandardMaterial3D_lbolt")
+mesh = SubResource("CapsuleMesh_lbolt")

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -28,6 +28,7 @@ public partial class World : Node3D
   private int FindPlayerId (string displayName) => FindPlayer (displayName)?.NetworkId ?? 0;
   private Player? FindPlayer (string displayName) => GetChildren().OfType <Player>().FirstOrDefault (player => player.DisplayName == displayName);
   private Player? FindPlayer (int peerId) => GetChildren().OfType <Player>().FirstOrDefault (player => player.NetworkId == peerId);
+  public System.Collections.Generic.IEnumerable <Player> GetPlayers() => GetChildren().OfType <Player>();
   private void OnGamePaused() => _selfPlayer?.SetInputEnabled (isEnabled: false);
   private void OnGameResumed() => _selfPlayer?.SetInputEnabled (isEnabled: true);
   private void OnGameQuit() => GetTree().Quit();

--- a/core/world/World.tscn
+++ b/core/world/World.tscn
@@ -33,10 +33,6 @@ ao_texture = ExtResource("4_5vad1")
 uv1_scale = Vector3(16, 16, 16)
 texture_filter = 5
 
-[sub_resource type="CylinderShape3D" id="CylinderShape3D_vh6ij"]
-height = 1.0
-radius = 45.0
-
 [sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_6x5gn"]
 
 [node name="World" type="Node3D"]
@@ -81,11 +77,32 @@ use_collision = true
 size = Vector3(100, 0.002, 100)
 material = SubResource("StandardMaterial3D_bx300")
 
-[node name="SpawnZone" type="Area3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 0)
+[node name="SpawnRoom" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 30, 0)
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="SpawnZone"]
-shape = SubResource("CylinderShape3D_vh6ij")
+[node name="Floor" type="CSGBox3D" parent="SpawnRoom"]
+use_collision = true
+size = Vector3(12, 0.5, 12)
+
+[node name="WallNorth" type="CSGBox3D" parent="SpawnRoom"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, -6)
+use_collision = true
+size = Vector3(12, 1.5, 0.3)
+
+[node name="WallSouth" type="CSGBox3D" parent="SpawnRoom"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 6)
+use_collision = true
+size = Vector3(12, 1.5, 0.3)
+
+[node name="WallEast" type="CSGBox3D" parent="SpawnRoom"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 1, 0)
+use_collision = true
+size = Vector3(0.3, 1.5, 12)
+
+[node name="WallWest" type="CSGBox3D" parent="SpawnRoom"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 1, 0)
+use_collision = true
+size = Vector3(0.3, 1.5, 12)
 
 [node name="LowerWorldBoundary" type="StaticBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -100, 0)

--- a/project.godot
+++ b/project.godot
@@ -73,6 +73,11 @@ shoot={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(661, 37),"global_position":Vector2(680, 128),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 ]
 }
+ability={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
+]
+}
 quit={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)

--- a/tests/unit/MessageGeneratorTest.cs.uid
+++ b/tests/unit/MessageGeneratorTest.cs.uid
@@ -1,0 +1,1 @@
+uid://dfmn6gmd8vr6b

--- a/tests/unit/ToolsTest.cs.uid
+++ b/tests/unit/ToolsTest.cs.uid
@@ -1,0 +1,1 @@
+uid://cfivxakyjtsov

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using com.forerunnergames.energyshot.core.world;
 using com.forerunnergames.energyshot.ui.dialogs;
 using com.forerunnergames.energyshot.ui.hud.messages;
@@ -17,9 +18,29 @@ public partial class Hud : Control
   private MessageScroller _messageScroller = null!;
   private ConfirmationDialog2 _quitDialog = null!;
   private Label _scoreLabel = null!;
+  private Label _leaderboardEntries = null!;
+  private ShaderMaterial _vignette = null!;
   private string _selfPlayerName = string.Empty;
   private void OnRemoteMessageReceived (string message) => _messageScroller.AddMessage (message);
-  private void OnSelfPlayerHealthChanged (string playerName, int health) => _healthBar.Value = health;
+
+  private void OnSelfPlayerHealthChanged (string playerName, int health)
+  {
+    _healthBar.Value = health;
+    UpdateVignette (health);
+  }
+
+  // Red vignette fades in below 40% health, fully saturated at death's door.
+  private void UpdateVignette (int health)
+  {
+    var threshold = 0.4f * (float)_healthBar.MaxValue;
+    _vignette.SetShaderParameter ("intensity", Mathf.Clamp (1.0f - health / threshold, 0.0f, 1.0f));
+  }
+
+  private void UpdateLeaderboard()
+  {
+    var players = _world.GetPlayers().OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName);
+    _leaderboardEntries.Text = string.Join ("\n", players.Select (player => $"{player.DisplayName}  {player.Score}"));
+  }
   private bool IsSelf (string playerName) => _selfPlayerName == playerName;
   private void OnKickedFromServer (string reason) => Hide();
   private void OnServerShutDown() => Hide();
@@ -32,6 +53,9 @@ public partial class Hud : Control
     _healthBar = GetNode <ProgressBar> ("VBoxContainer/Health/ProgressBar");
     _messageScroller = GetNode <MessageScroller> ("MessageScroller");
     _scoreLabel = GetNode <Label> ("VBoxContainer/Score/Label");
+    _leaderboardEntries = GetNode <Label> ("Leaderboard/MarginContainer/VBoxContainer/Entries");
+    _vignette = (ShaderMaterial)GetNode <ColorRect> ("Vignette").Material;
+    GetNode <Timer> ("LeaderboardTimer").Timeout += UpdateLeaderboard;
     _quitDialog = GetNode <ConfirmationDialog2> ("QuitDialog");
     _quitDialog.Confirmed += () => EmitSignal (SignalName.GameQuit);
     _quitDialog.Canceled += CancelQuit;
@@ -58,6 +82,8 @@ public partial class Hud : Control
   {
     _selfPlayerName = selfPlayerName;
     _messageScroller.Reset();
+    _healthBar.Value = _healthBar.MaxValue;
+    UpdateVignette ((int)_healthBar.MaxValue);
     Show();
   }
 

--- a/ui/hud/Hud.tscn
+++ b/ui/hud/Hud.tscn
@@ -1,8 +1,20 @@
-[gd_scene load_steps=6 format=3 uid="uid://cobme7o27cxru"]
+[gd_scene load_steps=9 format=3 uid="uid://cobme7o27cxru"]
 
 [ext_resource type="Script" path="res://ui/hud/Hud.cs" id="1_5s36p"]
 [ext_resource type="PackedScene" uid="uid://huun2vjv0k1v" path="res://ui/hud/messages/MessageScroller.tscn" id="1_6ovnf"]
 [ext_resource type="PackedScene" uid="uid://bmpjrf8pqokyu" path="res://ui/dialogs/confirm/ConfirmationDialog2.tscn" id="3_v7kl8"]
+[ext_resource type="Shader" path="res://ui/hud/vignette.gdshader" id="4_vgntt"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_vgntt"]
+shader = ExtResource("4_vgntt")
+shader_parameter/intensity = 0.0
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ldrbd"]
+bg_color = Color(0, 0, 0, 0.392157)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+corner_radius_bottom_right = 10
+corner_radius_bottom_left = 10
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wockn"]
 bg_color = Color(1, 0, 0, 0.321569)
@@ -40,6 +52,16 @@ mouse_filter = 2
 script = ExtResource("1_5s36p")
 metadata/_edit_vertical_guides_ = [1918.0]
 
+[node name="Vignette" type="ColorRect" parent="."]
+material = SubResource("ShaderMaterial_vgntt")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
 offset_right = 1336.0
@@ -60,7 +82,8 @@ theme_override_font_sizes/font_size = 20
 theme_override_styles/background = SubResource("StyleBoxFlat_wockn")
 theme_override_styles/fill = SubResource("StyleBoxFlat_uacqx")
 step = 1.0
-value = 100.0
+max_value = 200.0
+value = 200.0
 show_percentage = false
 
 [node name="Score" type="MarginContainer" parent="VBoxContainer"]
@@ -72,6 +95,42 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 60
 text = "Score: 0"
 vertical_alignment = 1
+
+[node name="Leaderboard" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -340.0
+offset_top = 20.0
+offset_right = -20.0
+grow_horizontal = 0
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_ldrbd")
+
+[node name="MarginContainer" type="MarginContainer" parent="Leaderboard"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Leaderboard/MarginContainer"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="Leaderboard/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Leaderboard"
+horizontal_alignment = 1
+
+[node name="Entries" type="Label" parent="Leaderboard/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 26
+text = ""
+
+[node name="LeaderboardTimer" type="Timer" parent="."]
+autostart = true
 
 [node name="MessageScroller" parent="." instance=ExtResource("1_6ovnf")]
 layout_mode = 1

--- a/ui/hud/vignette.gdshader
+++ b/ui/hud/vignette.gdshader
@@ -1,0 +1,9 @@
+shader_type canvas_item;
+
+// Red screen-edge vignette that fades in as the player nears death.
+uniform float intensity : hint_range(0.0, 1.0) = 0.0;
+
+void fragment() {
+	float d = distance(UV, vec2(0.5));
+	COLOR = vec4(0.7, 0.0, 0.0, smoothstep(0.3, 0.75, d) * intensity);
+}

--- a/ui/hud/vignette.gdshader.uid
+++ b/ui/hud/vignette.gdshader.uid
@@ -1,0 +1,1 @@
+uid://dehfkuu3fuotl


### PR DESCRIPTION
## Summary
Implements the playtest feedback batch:

- **Visible laser bursts** (the headline feature): shots are no longer instant hitscan. Each trigger release fires a single visible laser bolt that travels at 90 m/s with slight drop. Damage, glow color (blue → red), and bolt size all scale with charge-up time — exactly the existing charge mechanic, now with a projectile you can see and dodge. Every peer sees visual-only copies of everyone's shots via RPC; the shooter's own bolt is the "live" one that deals damage. Hit detection ray-sweeps the bolt's path each physics frame, so fast bolts can't tunnel through thin geometry (the ground is 2 mm thick!).
- **Full-auto ability**: press **F** for 3 seconds of low-damage rapid fire (hold the trigger), 15 s cooldown.
- **Respawn rework**: death (and initial spawn) now places you in a walled spawn room 30 m above the arena — jump the rail to drop in. 2 s input lock on respawn. No more instant re-engagement from a random arena spot.
- **Leaderboard**: per-player `Score` is now replicated (same mechanism as `Health`), rendered as a sorted top-right panel refreshed every second.
- **More health**: 100 → 200 (a fully-charged bolt now takes half your health; full-auto shots do 12).
- **Lower sensitivity**: mouse sensitivity halved (0.005 → 0.0025), exported for tuning.
- **Low-health vignette**: red screen-edge vignette fades in below 40% health.

Also removes the now-dead `Aim` raycast and `SpawnZone` nodes.

## Testing
- `dotnet build` clean; project imports & boots headless with no errors; gdUnit4 suite 8/8.
- Needs a multiplayer playtest for feel tuning: bolt speed/drop, full-auto rates, spawn-room height, vignette threshold are all exported properties for quick iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)