### PR TITLE
Remember player name & last join address for instant rejoin

### DIFF
--- a/ui/dialogs/host/HostGameDialog.cs
+++ b/ui/dialogs/host/HostGameDialog.cs
@@ -42,6 +42,7 @@ public partial class HostGameDialog : Control
     _middleText.Text = "Finding your server address...";
     _serverAddress.Text = string.Empty;
     _bottomText.Text = string.Empty;
+    if (string.IsNullOrEmpty (_playerName.Text)) _playerName.Text = Settings.PlayerName;
     UpdateHostGameButtonState();
     Show();
     // UPnP discovery can take seconds; run it off the main thread so the UI stays responsive (see issue #25).
@@ -86,6 +87,7 @@ public partial class HostGameDialog : Control
     Multiplayer.MultiplayerPeer = _peer;
 
     GD.Print ($"Successfully hosted server at [{_serverAddress.Text}:{_serverPort}]!");
+    Settings.PlayerName = _playerName.Text;
     Hide();
     EmitSignal (SignalName.HostGameSuccess, _playerName.Text);
   }

--- a/ui/dialogs/join/JoinGameDialog.cs
+++ b/ui/dialogs/join/JoinGameDialog.cs
@@ -53,6 +53,8 @@ public partial class JoinGameDialog : Control
     _peer = peer;
     _serverPort = serverPort;
     _bottomText.Text = string.Empty;
+    if (string.IsNullOrEmpty (_playerName.Text)) _playerName.Text = Settings.PlayerName;
+    if (string.IsNullOrEmpty (_serverAddress.Text)) _serverAddress.Text = Settings.LastJoinAddress;
     UpdateJoinGameButtonState();
     Show();
   }
@@ -101,6 +103,8 @@ public partial class JoinGameDialog : Control
     _connectionTimer.Stop();
     DisconnectSignals();
     Hide();
+    Settings.PlayerName = _playerName.Text;
+    Settings.LastJoinAddress = _serverAddress.Text;
     GD.Print ($"Successfully connected to server at [{_serverAddress.Text}:{_serverPort}]");
     EmitSignal (SignalName.JoinGameSuccess, _playerName.Text);
   }

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -1,0 +1,38 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.utilities;
+
+// Persists small player preferences (name, last joined server) to user://settings.cfg
+// so host/join dialogs come pre-filled & players can rejoin with two clicks.
+public static class Settings
+{
+  private const string FilePath = "user://settings.cfg";
+  private const string Section = "player";
+
+  public static string PlayerName
+  {
+    get => Get ("name");
+    set => Set ("name", value);
+  }
+
+  public static string LastJoinAddress
+  {
+    get => Get ("last_join_address");
+    set => Set ("last_join_address", value);
+  }
+
+  private static string Get (string key)
+  {
+    var config = new ConfigFile();
+    config.Load (FilePath);
+    return (string)config.GetValue (Section, key, string.Empty);
+  }
+
+  private static void Set (string key, string value)
+  {
+    var config = new ConfigFile();
+    config.Load (FilePath);
+    config.SetValue (Section, key, value);
+    config.Save (FilePath);
+  }
+}


### PR DESCRIPTION
## Summary
- New `Settings` helper persisting to `user://settings.cfg` (Godot user data dir).
- Player name is saved on every successful host/join; the last successfully joined server address is saved on join.
- Host & Join dialogs pre-fill both fields, so returning players run the game → Join → click. No retyping.

## Testing
- `dotnet build` clean; gdUnit4 suite 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)