### PR TITLE
Add difficulty handicap: Beginner/Intermediate/Expert health pools

### DIFF
--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -41,7 +41,23 @@ public partial class Player : CharacterBody3D
   [Signal] public delegate void RespawnedFellEventHandler (string playerName);
   // Replicated like Health so every peer can render the leaderboard.
   [Export] public int Score { get; set; }
-  [Export] public int MaxHealth = 200;
+
+  // Difficulty handicap: beginners get a bigger health pool. Replicated so every
+  // peer scales this player's health bar correctly.
+  [Export]
+  public int MaxHealth
+  {
+    get => _maxHealth;
+    set
+    {
+      _maxHealth = value;
+      if (_healthBar != null) _healthBar.MaxValue = value;
+    }
+  }
+
+  // Maps a difficulty selection (0=Beginner, 1=Intermediate, 2=Expert) to a health
+  // pool; anything unrecognized (including spoofed values) gets Expert health.
+  public static int MaxHealthFor (int difficulty) => difficulty switch { 0 => 400, 1 => 300, _ => 200 };
   [Export] public float MouseSensitivity = 0.0025f;
   [Export] public float FullAutoDurationSeconds = 3.0f;
   [Export] public float FullAutoCooldownSeconds = 15.0f;
@@ -79,6 +95,7 @@ public partial class Player : CharacterBody3D
   private ProgressBar _healthBar = null!;
   private string _displayName = string.Empty;
   private int _health;
+  private int _maxHealth = 200;
   private bool _isInputEnabled;
   private static Player? _localPlayer;
   public override void _Process (double delta)

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -65,6 +65,9 @@ properties/6/replication_mode = 2
 properties/7/path = NodePath(".:Score")
 properties/7/spawn = true
 properties/7/replication_mode = 2
+properties/8/path = NodePath(".:MaxHealth")
+properties/8/spawn = true
+properties/8/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 script = ExtResource("1_nipvj")

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -8,7 +8,7 @@ namespace com.forerunnergames.energyshot.core.world;
 
 public partial class World : Node3D
 {
-  [Signal] public delegate void NewGameStartedEventHandler (string selfPlayerName);
+  [Signal] public delegate void NewGameStartedEventHandler (string selfPlayerName, int selfMaxHealth);
   [Signal] public delegate void PlayerJoinedGameEventHandler (string playerName);
   [Signal] public delegate void PlayerLeftGameEventHandler (string playerName);
   [Signal] public delegate void PlayerScoredEventHandler (int score, string playerName, string shotPlayerName);
@@ -53,11 +53,11 @@ public partial class World : Node3D
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void RequestPlayerSlot (string playerName)
+  private void RequestPlayerSlot (string playerName, int difficulty)
   {
     if (!Multiplayer.IsServer()) return;
     var senderId = Multiplayer.GetRemoteSenderId();
-    GD.Print ($"Server: {senderId} {playerName} is requesting to join the game");
+    GD.Print ($"Server: {senderId} {playerName} is requesting to join the game (difficulty {difficulty})");
     var duplicateId = FindPlayer (senderId);
     var duplicateName = FindPlayer (playerName);
 
@@ -75,7 +75,7 @@ public partial class World : Node3D
       return;
     }
 
-    AddPlayer (senderId, playerName);
+    AddPlayer (senderId, playerName, Player.MaxHealthFor (difficulty));
   }
 
   // Delay the disconnect so the kick-reason RPC isn't dropped by an immediate peer disconnect (see issue #23).
@@ -87,18 +87,18 @@ public partial class World : Node3D
     Multiplayer.MultiplayerPeer.DisconnectPeer (peerId);
   }
 
-  private void OnHostGameSuccess (string playerName)
+  private void OnHostGameSuccess (string playerName, int difficulty)
   {
     Multiplayer.PeerConnected += OnClientConnectedToServer;
     Multiplayer.PeerDisconnected += OnClientDisconnectedFromServer;
-    AddPlayer (Multiplayer.GetUniqueId(), playerName);
+    AddPlayer (Multiplayer.GetUniqueId(), playerName, Player.MaxHealthFor (difficulty));
   }
 
-  private void OnJoinGameSuccess (string playerName)
+  private void OnJoinGameSuccess (string playerName, int difficulty)
   {
     _selfPlayerName = playerName;
     Multiplayer.ServerDisconnected += () => EmitSignal (SignalName.ServerShutDown);
-    RpcId (1, MethodName.RequestPlayerSlot, playerName);
+    RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty);
   }
 
   private void OnClientDisconnectedFromServer (long id)
@@ -122,10 +122,11 @@ public partial class World : Node3D
     RegisterSelf (spawnedPlayer);
   }
 
-  private void AddPlayer (int peerId, string playerName)
+  private void AddPlayer (int peerId, string playerName, int maxHealth)
   {
     var player = _playerScene.Instantiate <Player>();
     player.Name = $"{peerId}";
+    player.MaxHealth = maxHealth;
     player.RespawnedShot += (respawnedPlayerName, shotByPlayerName) => _networkManager.NotifyPlayerRespawnedShot (respawnedPlayerName, shotByPlayerName);
     player.RespawnedFell += respawnedPlayerName => _networkManager.NotifyPlayerRespawnedFell (respawnedPlayerName);
     AddChild (player);
@@ -143,7 +144,7 @@ public partial class World : Node3D
     selfPlayer.HealthChanged += value => EmitSignal (SignalName.SelfPlayerHealthChanged, selfPlayer.DisplayName, value);
     selfPlayer.Scored += (playerName, shotPlayerName) => EmitSignal (SignalName.PlayerScored, ++_score, playerName, shotPlayerName);
     GD.Print ($"{_selfPlayer.NetworkId}: Registered my player {_selfPlayer.DisplayName}");
-    EmitSignal (SignalName.NewGameStarted, _selfPlayer.DisplayName);
+    EmitSignal (SignalName.NewGameStarted, _selfPlayer.DisplayName, _selfPlayer.MaxHealth);
   }
 
   private void RemovePlayer (long peerId)

--- a/ui/UI.cs
+++ b/ui/UI.cs
@@ -9,8 +9,8 @@ namespace com.forerunnergames.energyshot.ui;
 public partial class UI : CanvasLayer
 {
   [Signal] public delegate void MessageEventHandler (string message, string excludedPlayerName);
-  [Signal] public delegate void HostGameSuccessEventHandler (string playerName);
-  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName);
+  [Signal] public delegate void HostGameSuccessEventHandler (string playerName, int difficulty);
+  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName, int difficulty);
   [Signal] public delegate void GamePausedEventHandler();
   [Signal] public delegate void GameResumedEventHandler();
   [Signal] public delegate void GameQuitEventHandler();
@@ -35,7 +35,7 @@ public partial class UI : CanvasLayer
     _hud.GamePaused += () => EmitSignal (SignalName.GamePaused);
     _hud.GameResumed += () => EmitSignal (SignalName.GameResumed);
     _hud.GameQuit += () => EmitSignal (SignalName.GameQuit);
-    _hostGameDialog.HostGameSuccess += playerName => EmitSignal (SignalName.HostGameSuccess, playerName);
-    _joinGameDialog.JoinGameSuccess += playerName => EmitSignal (SignalName.JoinGameSuccess, playerName);
+    _hostGameDialog.HostGameSuccess += (playerName, difficulty) => EmitSignal (SignalName.HostGameSuccess, playerName, difficulty);
+    _joinGameDialog.JoinGameSuccess += (playerName, difficulty) => EmitSignal (SignalName.JoinGameSuccess, playerName, difficulty);
   }
 }

--- a/ui/dialogs/host/HostGameDialog.cs
+++ b/ui/dialogs/host/HostGameDialog.cs
@@ -5,11 +5,12 @@ namespace com.forerunnergames.energyshot.ui.dialogs;
 
 public partial class HostGameDialog : Control
 {
-  [Signal] public delegate void HostGameSuccessEventHandler (string playerName);
+  [Signal] public delegate void HostGameSuccessEventHandler (string playerName, int difficulty);
   [Signal] public delegate void ClosedEventHandler();
   private Button _closeButton = null!;
   private Button _hostGameButton = null!;
   private LineEdit _playerName = null!;
+  private OptionButton _difficulty = null!;
   private LineEdit _serverAddress = null!;
   private Label _middleText = null!;
   private Label _bottomText = null!;
@@ -25,6 +26,7 @@ public partial class HostGameDialog : Control
     _closeButton = GetNode <Button> ("PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/CloseButton");
     _hostGameButton = GetNode <Button> ("PanelContainer/MarginContainer/VBoxContainer/HostGameButton");
     _playerName = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/PlayerName");
+    _difficulty = GetNode <OptionButton> ("PanelContainer/MarginContainer/VBoxContainer/Difficulty");
     _serverAddress = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/ServerAddress");
     _middleText = GetNode <Label> ("PanelContainer/MarginContainer/VBoxContainer/MiddleText");
     _bottomText = GetNode <Label> ("PanelContainer/MarginContainer/VBoxContainer/BottomText");
@@ -43,6 +45,7 @@ public partial class HostGameDialog : Control
     _serverAddress.Text = string.Empty;
     _bottomText.Text = string.Empty;
     if (string.IsNullOrEmpty (_playerName.Text)) _playerName.Text = Settings.PlayerName;
+    _difficulty.Selected = Settings.Difficulty;
     UpdateHostGameButtonState();
     Show();
     // UPnP discovery can take seconds; run it off the main thread so the UI stays responsive (see issue #25).
@@ -88,8 +91,9 @@ public partial class HostGameDialog : Control
 
     GD.Print ($"Successfully hosted server at [{_serverAddress.Text}:{_serverPort}]!");
     Settings.PlayerName = _playerName.Text;
+    Settings.Difficulty = _difficulty.Selected;
     Hide();
-    EmitSignal (SignalName.HostGameSuccess, _playerName.Text);
+    EmitSignal (SignalName.HostGameSuccess, _playerName.Text, _difficulty.Selected);
   }
 
   private void OnError (string error)

--- a/ui/dialogs/host/HostGameDialog.tscn
+++ b/ui/dialogs/host/HostGameDialog.tscn
@@ -84,6 +84,19 @@ theme_override_font_sizes/font_size = 100
 alignment = 1
 max_length = 20
 
+[node name="Difficulty" type="OptionButton" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 60
+alignment = 1
+item_count = 3
+selected = 0
+popup/item_0/text = "Beginner (2x health)"
+popup/item_0/id = 0
+popup/item_1/text = "Intermediate (1.5x health)"
+popup/item_1/id = 1
+popup/item_2/text = "Expert (1x health)"
+popup/item_2/id = 2
+
 [node name="HSeparator2" type="HSeparator" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 

--- a/ui/dialogs/join/JoinGameDialog.cs
+++ b/ui/dialogs/join/JoinGameDialog.cs
@@ -5,11 +5,12 @@ namespace com.forerunnergames.energyshot.ui.dialogs;
 
 public partial class JoinGameDialog : Control
 {
-  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName);
+  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName, int difficulty);
   [Signal] public delegate void ClosedEventHandler();
   private Button _closeButton = null!;
   private Button _joinGameButton = null!;
   private LineEdit _playerName = null!;
+  private OptionButton _difficulty = null!;
   private LineEdit _serverAddress = null!;
   private Label _middleText = null!;
   private Label _bottomText = null!;
@@ -35,6 +36,7 @@ public partial class JoinGameDialog : Control
     _closeButton = GetNode <Button> ("PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/CloseButton");
     _joinGameButton = GetNode <Button> ("PanelContainer/MarginContainer/VBoxContainer/JoinGameButton");
     _playerName = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/PlayerName");
+    _difficulty = GetNode <OptionButton> ("PanelContainer/MarginContainer/VBoxContainer/Difficulty");
     _serverAddress = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/ServerAddress");
     _middleText = GetNode <Label> ("PanelContainer/MarginContainer/VBoxContainer/MiddleText");
     _bottomText = GetNode <Label> ("PanelContainer/MarginContainer/VBoxContainer/BottomText");
@@ -55,6 +57,7 @@ public partial class JoinGameDialog : Control
     _bottomText.Text = string.Empty;
     if (string.IsNullOrEmpty (_playerName.Text)) _playerName.Text = Settings.PlayerName;
     if (string.IsNullOrEmpty (_serverAddress.Text)) _serverAddress.Text = Settings.LastJoinAddress;
+    _difficulty.Selected = Settings.Difficulty;
     UpdateJoinGameButtonState();
     Show();
   }
@@ -105,8 +108,9 @@ public partial class JoinGameDialog : Control
     Hide();
     Settings.PlayerName = _playerName.Text;
     Settings.LastJoinAddress = _serverAddress.Text;
+    Settings.Difficulty = _difficulty.Selected;
     GD.Print ($"Successfully connected to server at [{_serverAddress.Text}:{_serverPort}]");
-    EmitSignal (SignalName.JoinGameSuccess, _playerName.Text);
+    EmitSignal (SignalName.JoinGameSuccess, _playerName.Text, _difficulty.Selected);
   }
 
   private void OnError (string error)

--- a/ui/dialogs/join/JoinGameDialog.tscn
+++ b/ui/dialogs/join/JoinGameDialog.tscn
@@ -88,6 +88,19 @@ theme_override_font_sizes/font_size = 100
 alignment = 1
 max_length = 16
 
+[node name="Difficulty" type="OptionButton" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 60
+alignment = 1
+item_count = 3
+selected = 0
+popup/item_0/text = "Beginner (2x health)"
+popup/item_0/id = 0
+popup/item_1/text = "Intermediate (1.5x health)"
+popup/item_1/id = 1
+popup/item_2/text = "Expert (1x health)"
+popup/item_2/id = 2
+
 [node name="HSeparator2" type="HSeparator" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -78,12 +78,13 @@ public partial class Hud : Control
     ToggleQuitDialog();
   }
 
-  private void OnNewGameStarted (string selfPlayerName)
+  private void OnNewGameStarted (string selfPlayerName, int selfMaxHealth)
   {
     _selfPlayerName = selfPlayerName;
     _messageScroller.Reset();
-    _healthBar.Value = _healthBar.MaxValue;
-    UpdateVignette ((int)_healthBar.MaxValue);
+    _healthBar.MaxValue = selfMaxHealth;
+    _healthBar.Value = selfMaxHealth;
+    UpdateVignette (selfMaxHealth);
     Show();
   }
 

--- a/ui/menus/main/MainMenu.cs
+++ b/ui/menus/main/MainMenu.cs
@@ -31,7 +31,7 @@ public partial class MainMenu : Control
     _bottomMainMenuText.Text = string.Empty;
   }
 
-  private void OnNewGameStarted (string selfPlayerName)
+  private void OnNewGameStarted (string selfPlayerName, int selfMaxHealth)
   {
     Hide();
     _bottomMainMenuText.Text = string.Empty;

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -21,6 +21,12 @@ public static class Settings
     set => Set ("last_join_address", value);
   }
 
+  public static int Difficulty
+  {
+    get => GetInt ("difficulty");
+    set => Set ("difficulty", value);
+  }
+
   private static string Get (string key)
   {
     var config = new ConfigFile();
@@ -28,7 +34,14 @@ public static class Settings
     return (string)config.GetValue (Section, key, string.Empty);
   }
 
-  private static void Set (string key, string value)
+  private static int GetInt (string key)
+  {
+    var config = new ConfigFile();
+    config.Load (FilePath);
+    return (int)config.GetValue (Section, key, 0);
+  }
+
+  private static void Set (string key, Variant value)
   {
     var config = new ConfigFile();
     config.Load (FilePath);


### PR DESCRIPTION
## Summary
- Host & Join dialogs get a **difficulty dropdown**: Beginner (2× health, 400 HP), Intermediate (1.5×, 300 HP), Expert (1×, 200 HP). Selection is remembered in `user://settings.cfg` like name/address.
- Difficulty travels with the join request; the **server maps difficulty → health** (`Player.MaxHealthFor`), so a modified client can't request arbitrary pools — unknown values get Expert health.
- `MaxHealth` is now replicated alongside `Health`, so every peer renders that player's health bar at the correct scale.
- Your own HUD health bar and the low-health vignette adapt to your pool.

## Testing
- `dotnet build` clean; headless boot clean; gdUnit4 suite 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)