### PR TITLE
Add automated 3-instance multiplayer playtest harness & fix difficulty sync

### DIFF
--- a/.github/workflows/playtest.yml
+++ b/.github/workflows/playtest.yml
@@ -1,0 +1,47 @@
+# Automated multiplayer playtest: launches a headless host + 2 clients & exercises
+# the full gameplay loop (join, replication, movement, kills, respawn, spawn armor,
+# fire-rate cap, full-auto). See tests/playtest/run-playtest.sh.
+name: Playtest
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  playtest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip duplicate actions
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          cancel_others: true
+          skip_after_successful_duplicate: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Download Godot
+        run: |
+          curl -sSL -o godot.zip https://github.com/godotengine/godot/releases/download/4.7.1-stable/Godot_v4.7.1-stable_mono_linux_x86_64.zip
+          unzip -q godot.zip
+          echo "GODOT_BIN=$PWD/Godot_v4.7.1-stable_mono_linux_x86_64/Godot_v4.7.1-stable_mono_linux.x86_64" >> $GITHUB_ENV
+
+      - name: Run playtest
+        run: ./tests/playtest/run-playtest.sh
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playtest-logs-${{ github.run_id }}
+          path: reports/playtest/

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -23,6 +23,7 @@ public partial class World : Node3D
   private PackedScene _playerScene = null!;
   private Player? _selfPlayer;
   private string _selfPlayerName = string.Empty;
+  private int _selfDifficulty = 2;
   private int _score;
   [Rpc] private void OnKickedFromServer (string reason) => EmitSignal (SignalName.KickedFromServer, reason);
   private int FindPlayerId (string displayName) => FindPlayer (displayName)?.NetworkId ?? 0;
@@ -50,6 +51,29 @@ public partial class World : Node3D
     _networkManager.RemoteMessageReceived += message => EmitSignal (SignalName.RemoteMessageReceived, message);
     _networkManager.PlayerJoinGame += playerName => EmitSignal (SignalName.PlayerJoinedGame, playerName);
     _networkManager.PlayerLeftGame += playerName => EmitSignal (SignalName.PlayerLeftGame, playerName);
+    if (OS.GetCmdlineUserArgs().Contains ("--playtest")) CallDeferred (MethodName.StartPlaytest);
+  }
+
+  private void StartPlaytest() => AddChild (new playtest.PlaytestDriver());
+
+  // Session entry points for the automated playtest harness: same code paths the
+  // host/join dialogs use, minus the UI & UPnP.
+  public void StartHostSession (string playerName, int difficulty, int port)
+  {
+    var peer = new ENetMultiplayerPeer();
+    var error = peer.CreateServer (port);
+    if (error != Error.Ok) GD.PrintErr ($"Playtest host failed: {error}");
+    Multiplayer.MultiplayerPeer = peer;
+    OnHostGameSuccess (playerName, difficulty);
+  }
+
+  public void StartClientSession (string playerName, int difficulty, string address, int port)
+  {
+    var peer = new ENetMultiplayerPeer();
+    var error = peer.CreateClient (address, port);
+    if (error != Error.Ok) GD.PrintErr ($"Playtest join failed: {error}");
+    Multiplayer.MultiplayerPeer = peer;
+    Multiplayer.ConnectedToServer += () => OnJoinGameSuccess (playerName, difficulty);
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
@@ -97,6 +121,7 @@ public partial class World : Node3D
   private void OnJoinGameSuccess (string playerName, int difficulty)
   {
     _selfPlayerName = playerName;
+    _selfDifficulty = difficulty;
     Multiplayer.ServerDisconnected += () => EmitSignal (SignalName.ServerShutDown);
     RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty);
   }
@@ -117,6 +142,10 @@ public partial class World : Node3D
   private void RegisterSpawnedSelfPlayerDeferred (Player spawnedPlayer)
   {
     spawnedPlayer.DisplayName = _selfPlayerName;
+    // This node is the replication authority, so the difficulty health pool must be
+    // set here (client-side) - values set on the server copy get overwritten by sync.
+    spawnedPlayer.MaxHealth = Player.MaxHealthFor (_selfDifficulty);
+    spawnedPlayer.Health = spawnedPlayer.MaxHealth;
     spawnedPlayer.RespawnedShot += (playerName, shotByPlayerName) => _networkManager.NotifyPlayerRespawnedShot (playerName, shotByPlayerName);
     spawnedPlayer.RespawnedFell += playerName => _networkManager.NotifyPlayerRespawnedFell (playerName);
     RegisterSelf (spawnedPlayer);

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using com.forerunnergames.energyshot.core.world;
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.weapons;
+using Godot;
+
+namespace com.forerunnergames.energyshot.playtest;
+
+// Automated multiplayer playtest: three headless instances (host, shooter, victim)
+// drive the real game end-to-end - join, replication, movement, charged laser kills,
+// respawn, spawn armor, fire-rate cap & full-auto - and exit 0/1 for CI.
+// Activated by launching with: godot --headless --path . -- --playtest <role> [--address a] [--port n]
+public partial class PlaytestDriver : Node
+{
+  private const int Port = 55599;
+  private const string HostName = "Host";
+  private const string ShooterName = "Shooter";
+  private const string VictimName = "Victim";
+  private World _world = null!;
+  private string _role = string.Empty;
+  private string _address = "127.0.0.1";
+  private int _boltsSpawned;
+  private Player Self => _world.GetPlayers().First (player => player.IsMultiplayerAuthority());
+  private Player? FindPlayer (string name) => _world.GetPlayers().FirstOrDefault (player => player.DisplayName == name);
+
+  public override void _Ready()
+  {
+    _world = GetNode <World> ("/root/World");
+    _world.ChildEnteredTree += node => _boltsSpawned += node is LaserBolt ? 1 : 0;
+    var args = OS.GetCmdlineUserArgs();
+    _role = ArgValue (args, "--playtest") ?? string.Empty;
+    _address = ArgValue (args, "--address") ?? "127.0.0.1";
+    GD.Print ($"PLAYTEST: starting role [{_role}]");
+    RunScenario();
+  }
+
+  private static string? ArgValue (string[] args, string name)
+  {
+    var index = Array.IndexOf (args, name);
+    return index >= 0 && index + 1 < args.Length ? args[index + 1] : null;
+  }
+
+  private async void RunScenario()
+  {
+    try
+    {
+      await Task.Delay (100); // Let the world finish _Ready wiring.
+
+      switch (_role)
+      {
+        case "host":
+          await RunHost();
+          break;
+        case "shooter":
+          await RunShooter();
+          break;
+        case "victim":
+          await RunVictim();
+          break;
+        default:
+          Fail ($"Unknown playtest role [{_role}]");
+          return;
+      }
+
+      GD.Print ($"PLAYTEST PASS [{_role}]");
+      await Task.Delay (500); // Let final packets flush before quitting.
+      GetTree().Quit (0);
+    }
+    catch (Exception e)
+    {
+      Fail (e.Message);
+    }
+  }
+
+  private void Fail (string reason)
+  {
+    GD.PrintErr ($"PLAYTEST FAIL [{_role}]: {reason}");
+    GetTree().Quit (1);
+  }
+
+  // ---------------------------------------------------------------- roles
+
+  private async Task RunHost()
+  {
+    _world.StartHostSession (HostName, difficulty: 2, Port);
+    await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players joined");
+    // Shooter kills victim once; wait to observe the replicated score.
+    await WaitUntil (() => FindPlayer (ShooterName)?.Score == 1, 120, "shooter's kill replicated to host");
+    // Victim respawns with armor visible to the host too.
+    await WaitUntil (() => FindPlayer (VictimName)?.SpawnArmor == true, 30, "victim respawn armor replicated to host");
+    // Stay up until both clients have finished & disconnected.
+    await WaitUntil (() => _world.GetPlayers().Count() == 1, 120, "clients disconnected");
+  }
+
+  private async Task RunShooter()
+  {
+    _world.StartClientSession (ShooterName, difficulty: 1, _address, Port);
+    await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
+    var victim = FindPlayer (VictimName)!;
+    var host = FindPlayer (HostName)!;
+    Assert (victim.MaxHealth == 400, $"victim MaxHealth replicated as Beginner 400, got {victim.MaxHealth}");
+    Assert (host.MaxHealth == 200, $"host MaxHealth replicated as Expert 200, got {host.MaxHealth}");
+    Assert (Self.MaxHealth == 300, $"own MaxHealth is Intermediate 300, got {Self.MaxHealth}");
+
+    // Movement: hold forward briefly & verify we actually moved.
+    var startPosition = Self.GlobalPosition;
+    Input.ActionPress ("move_forward");
+    await Task.Delay (600);
+    Input.ActionRelease ("move_forward");
+    Assert (Self.GlobalPosition.DistanceTo (startPosition) > 0.3f, "player moved with input");
+
+    // Wait out everyone's initial spawn armor before the damage phase.
+    await WaitUntil (() => !victim.SpawnArmor, 15, "victim's initial spawn armor expired");
+
+    // Charged shots until the victim dies (shooter is told via NotifyScored -> Score).
+    var kills = 0;
+    Self.Scored += (_, _) => ++kills;
+
+    for (var shot = 0; shot < 12 && kills == 0; ++shot)
+    {
+      AimAt (victim.GlobalPosition + Vector3.Up);
+      await ChargeAndFire (chargeSeconds: 2.3f);
+      await Task.Delay (700); // Bolt flight + cooldown before next charge.
+    }
+
+    Assert (kills == 1, "scored a kill with charged shots");
+    Assert (Self.Score == 1, $"own replicated Score is 1, got {Self.Score}");
+
+    // Victim must come back armored in the spawn room.
+    await WaitUntil (() => victim.SpawnArmor, 15, "victim respawned with spawn armor");
+
+    // Fire-rate cap: spamming can spawn at most 1 bolt (cooldown blocks recharging).
+    AimAt (Self.GlobalPosition + new Vector3 (0, 1, 10)); // Aim away from everyone.
+    var boltsBefore = _boltsSpawned;
+
+    for (var i = 0; i < 5; ++i)
+    {
+      await ChargeAndFire (chargeSeconds: 0.05f);
+      await Task.Delay (50);
+    }
+
+    Assert (_boltsSpawned - boltsBefore <= 1, $"fire-rate cap held under spam, got {_boltsSpawned - boltsBefore} bolts");
+
+    // Full-auto: after cooldown, ability + held trigger must fire a burst of bolts.
+    await Task.Delay (1200);
+    boltsBefore = _boltsSpawned;
+    PressAction ("ability");
+    await Task.Delay (50);
+    ReleaseAction ("ability");
+    PressAction ("shoot");
+    await Task.Delay (1300);
+    ReleaseAction ("shoot");
+    Assert (_boltsSpawned - boltsBefore >= 3, $"full-auto fired a burst, got {_boltsSpawned - boltsBefore} bolts");
+  }
+
+  private async Task RunVictim()
+  {
+    _world.StartClientSession (VictimName, difficulty: 0, _address, Port);
+    await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
+    Assert (Self.MaxHealth == 400, $"own MaxHealth is Beginner 400, got {Self.MaxHealth}");
+    Assert (Self.SpawnArmor, "spawned with spawn armor");
+    await WaitUntil (() => !Self.SpawnArmor, 15, "spawn armor expired on its own");
+    // The shooter opens fire once armor drops; verify damage & then a full respawn.
+    await WaitUntil (() => Self.Health < Self.MaxHealth, 120, "took damage from shooter");
+    await WaitUntil (() => Self.SpawnArmor && Self.Health == Self.MaxHealth, 120, "died & respawned with armor & full health");
+    Assert (Self.GlobalPosition.Y > 20.0f, $"respawned up in the spawn room, y={Self.GlobalPosition.Y}");
+    await WaitUntil (() => FindPlayer (ShooterName)?.Score == 1, 30, "shooter's score replicated to victim");
+    // Give the shooter time to finish its solo phases (fire-rate & full-auto) before we vanish.
+    await Task.Delay (8000);
+  }
+
+  // ---------------------------------------------------------------- helpers
+
+  private void AimAt (Vector3 target)
+  {
+    var self = Self;
+    var flatTarget = new Vector3 (target.X, self.GlobalPosition.Y, target.Z);
+    self.LookAt (flatTarget, Vector3.Up);
+    self.RotateY (Mathf.Pi); // LookAt points -Z at the target; the player faces +Z of its basis... flip to match camera forward.
+    var camera = self.GetNode <Camera3D> ("Camera3D");
+    camera.LookAt (target, Vector3.Up);
+  }
+
+  private async Task ChargeAndFire (float chargeSeconds)
+  {
+    PressAction ("shoot");
+    await Task.Delay ((int)(chargeSeconds * 1000));
+    ReleaseAction ("shoot");
+    await Task.Delay (100);
+  }
+
+  private static void PressAction (string action) => Input.ParseInputEvent (new InputEventAction { Action = action, Pressed = true });
+  private static void ReleaseAction (string action) => Input.ParseInputEvent (new InputEventAction { Action = action, Pressed = false });
+
+  private static void Assert (bool condition, string description)
+  {
+    if (condition)
+    {
+      GD.Print ($"PLAYTEST OK: {description}");
+      return;
+    }
+
+    throw new Exception ($"assertion failed: {description}");
+  }
+
+  private async Task WaitUntil (Func <bool> condition, float timeoutSeconds, string description)
+  {
+    var deadline = Time.GetTicksMsec() + (ulong)(timeoutSeconds * 1000);
+
+    while (Time.GetTicksMsec() < deadline)
+    {
+      if (condition())
+      {
+        GD.Print ($"PLAYTEST OK: {description}");
+        return;
+      }
+
+      await Task.Delay (100);
+    }
+
+    throw new Exception ($"timed out after {timeoutSeconds}s waiting for: {description}");
+  }
+}

--- a/tests/playtest/PlaytestDriver.cs.uid
+++ b/tests/playtest/PlaytestDriver.cs.uid
@@ -1,0 +1,1 @@
+uid://btsf8rld5pkoj

--- a/tests/playtest/run-playtest.sh
+++ b/tests/playtest/run-playtest.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Automated multiplayer playtest: launches a host + shooter + victim headless &
+# verifies join, replication, movement, kills, respawn, spawn armor, fire-rate
+# cap & full-auto. Requires GODOT_BIN. Exits 0 only if all three roles pass.
+set -u
+
+GODOT_BIN="${GODOT_BIN:?Set GODOT_BIN to the Godot .NET binary}"
+DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+LOGS="$DIR/reports/playtest"
+mkdir -p "$LOGS"
+
+echo "== Importing & building =="
+"$GODOT_BIN" --headless --path "$DIR" --import > "$LOGS/import.log" 2>&1
+dotnet build "$DIR" > "$LOGS/build.log" 2>&1 || { echo "BUILD FAILED"; tail -20 "$LOGS/build.log"; exit 1; }
+
+echo "== Launching host + 2 clients =="
+"$GODOT_BIN" --headless --path "$DIR" -- --playtest host > "$LOGS/host.log" 2>&1 &
+HOST=$!
+sleep 5
+"$GODOT_BIN" --headless --path "$DIR" -- --playtest victim > "$LOGS/victim.log" 2>&1 &
+VICTIM=$!
+sleep 3
+"$GODOT_BIN" --headless --path "$DIR" -- --playtest shooter > "$LOGS/shooter.log" 2>&1 &
+SHOOTER=$!
+
+# Watchdog: kill everything if the scenario hangs.
+( sleep 300; kill $HOST $VICTIM $SHOOTER 2>/dev/null ) &
+WATCHDOG=$!
+
+FAIL=0
+for role in SHOOTER VICTIM HOST; do
+  pid=${!role}
+  wait "$pid"
+  code=$?
+  echo "$role exited with $code"
+  [ "$code" -ne 0 ] && FAIL=1
+done
+
+kill $WATCHDOG 2>/dev/null
+wait $WATCHDOG 2>/dev/null
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "== PLAYTEST FAILED - logs =="
+  for f in host shooter victim; do
+    echo "--- $f.log (last 40 lines) ---"
+    tail -40 "$LOGS/$f.log"
+  done
+  exit 1
+fi
+
+echo "== PLAYTEST PASSED (host + shooter + victim) =="

--- a/utilities/Settings.cs.uid
+++ b/utilities/Settings.cs.uid
@@ -1,0 +1,1 @@
+uid://badr41qos530y


### PR DESCRIPTION
## Summary
- **Playtest harness** (`tests/playtest/`): three headless instances — host, shooter, victim — drive the *real* game via the same session code paths the dialogs use (`--playtest <role>` CLI mode, input injected through Godot's input pipeline). Asserted end-to-end:
  - all players join & replicate (names, difficulty health pools)
  - movement input actually moves the player
  - charged laser bolts kill across the network; killer's score replicates everywhere
  - victim respawns in the spawn room with spawn armor; armor expires on schedule
  - fire-rate cap holds under click spam (≤1 bolt)
  - full-auto fires a proper burst
- `tests/playtest/run-playtest.sh` orchestrates with timeouts & log aggregation; **Playtest** CI workflow runs it on every push/PR (uploads logs on failure).
- **Real bug found by the harness's first run, fixed here**: difficulty health pools (v0.4.0/v0.4.1) never replicated — the owning client is the `MultiplayerSynchronizer` authority, so `MaxHealth` set server-side was overwritten by the client's default. The authority client now sets its own pool from its chosen difficulty. (Server-side mapping retained for the future authoritative-server model.)

## Testing
- Full harness passes locally on macOS (3/3 roles): join, kill, respawn, armor, rate cap, full-auto.
- `dotnet build` clean; gdUnit4 suite 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)