### PR TITLE
Fix piggyback respawns, speed up cooldowns, & add damage handicap

### DIFF
--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -59,6 +59,10 @@ public partial class Player : CharacterBody3D
   // pool; anything unrecognized (including spoofed values) gets Expert health.
   public static int MaxHealthFor (int difficulty) => difficulty switch { 0 => 400, 1 => 300, _ => 200 };
 
+  // Recovers the difficulty tier (0=Beginner, 1=Intermediate, 2=Expert) from the
+  // replicated health pool, for the damage handicap.
+  private static int TierOf (int maxHealth) => maxHealth switch { 400 => 0, 300 => 1, _ => 2 };
+
   // 5s of invulnerability after every (re)spawn, canceled by firing. Replicated so
   // every peer renders the armored (white) player & the victim rejects damage.
   [Export]
@@ -320,7 +324,13 @@ public partial class Player : CharacterBody3D
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
     var shooterId = Multiplayer.GetRemoteSenderId();
-    Health -= CalculateHealthDecrease (energy);
+    // Difficulty damage handicap: lower-skill attackers hit higher-skill targets harder
+    // (+50% per tier gap: Beginner->Intermediate 1.5x, Beginner->Expert 2x,
+    // Intermediate->Expert 1.5x). Attacking downward is unchanged - the bigger health
+    // pool already is the handicap.
+    var shooter = GetParent().GetNodeOrNull <Player> ($"{shooterId}");
+    var handicap = 1.0f + 0.5f * Mathf.Max (0, TierOf (MaxHealth) - TierOf (shooter?.MaxHealth ?? MaxHealth));
+    Health -= Mathf.RoundToInt (CalculateHealthDecrease (energy) * handicap);
     GD.Print ($"{DisplayName}: I was hit by {shotByPlayerName}! Health {Health}");
 
     if (Health <= 0)

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -73,6 +73,9 @@ properties/9/spawn = true
 properties/9/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
+collision_layer = 2
+collision_mask = 3
+platform_floor_layers = 1
 script = ExtResource("1_nipvj")
 
 [node name="NameTag" type="Label3D" parent="."]
@@ -107,7 +110,7 @@ value = 100.0
 show_percentage = false
 
 [node name="JumpTimer" type="Timer" parent="."]
-wait_time = 3.0
+wait_time = 2.0
 one_shot = true
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]

--- a/core/weapons/EnergyWeapon.cs
+++ b/core/weapons/EnergyWeapon.cs
@@ -18,7 +18,7 @@ public partial class EnergyWeapon : Node3D
   [Export] public float MaxRotationSpeed = 15.0f;
   // Caps fire rate: after a shot, the weapon can't begin a new charge until the
   // cooldown elapses, so fast clicks & auto-clickers can't spam shots.
-  [Export] public float ShotCooldownSeconds = 1.0f;
+  [Export] public float ShotCooldownSeconds = 0.5f;
   [Export] public float RecoilStrength = 5.0f;
   [Export] public float RecoilRecoverySpeed = 5.0f;
   [Signal] public delegate void ShotFiredEventHandler (float energy);

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -123,13 +123,26 @@ public partial class PlaytestDriver : Node
     // (which drives the weapon cooldown) can lag the wall clock these delays use.
     var kills = 0;
     Self.Scored += (_, _) => ++kills;
+    // The 5s respawn-armor window can elapse during the shot loop's waits, so watch
+    // for it continuously instead of only checking after the loop.
+    var respawnArmorSeen = false;
+    WatchForRespawnArmor();
+
+    async void WatchForRespawnArmor()
+    {
+      while (!respawnArmorSeen && IsInsideTree())
+      {
+        respawnArmorSeen = kills > 0 && victim.SpawnArmor;
+        await Task.Delay (50);
+      }
+    }
 
     for (var attempt = 0; attempt < 25 && kills == 0; ++attempt)
     {
       AimAt (victim.GlobalPosition + Vector3.Up);
       var boltsBeforeShot = _boltsSpawned;
       await ChargeAndFire (chargeSeconds: 2.3f);
-      await TryWaitUntil (() => _boltsSpawned > boltsBeforeShot, 3);
+      await TryWaitUntil (() => _boltsSpawned > boltsBeforeShot || kills > 0, 3);
       GD.Print ($"PLAYTEST: shot attempt {attempt}: bolts fired {_boltsSpawned}, victim health {victim.Health}");
     }
 
@@ -137,7 +150,7 @@ public partial class PlaytestDriver : Node
     Assert (Self.Score == 1, $"own replicated Score is 1, got {Self.Score}");
 
     // Victim must come back armored in the spawn room.
-    await WaitUntil (() => victim.SpawnArmor, 15, "victim respawned with spawn armor");
+    await WaitUntil (() => respawnArmorSeen, 15, "victim respawned with spawn armor");
 
     // Fire-rate cap: spamming can spawn at most 1 bolt (cooldown blocks recharging).
     AimAt (Self.GlobalPosition + new Vector3 (0, 1, 10)); // Aim away from everyone.

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -22,11 +22,15 @@ public partial class PlaytestDriver : Node
   private string _role = string.Empty;
   private string _address = "127.0.0.1";
   private int _boltsSpawned;
-  private Player Self => _world.GetPlayers().First (player => player.IsMultiplayerAuthority());
+  private Player? _self;
+  private Player Self => _self ??= _world.GetPlayers().First (player => player.IsMultiplayerAuthority());
   private Player? FindPlayer (string name) => _world.GetPlayers().FirstOrDefault (player => player.DisplayName == name);
 
   public override void _Ready()
   {
+    // Three instances share the CI runner; uncapped frame loops starve physics &
+    // ENet, dilating in-game time far behind the wall clock this driver waits on.
+    Engine.MaxFps = 30;
     _world = GetNode <World> ("/root/World");
     _world.ChildEnteredTree += node => _boltsSpawned += node is LaserBolt ? 1 : 0;
     var args = OS.GetCmdlineUserArgs();
@@ -115,14 +119,18 @@ public partial class PlaytestDriver : Node
     await WaitUntil (() => !victim.SpawnArmor, 15, "victim's initial spawn armor expired");
 
     // Charged shots until the victim dies (shooter is told via NotifyScored -> Score).
+    // Retry until a bolt actually spawns each attempt - under CI load, physics time
+    // (which drives the weapon cooldown) can lag the wall clock these delays use.
     var kills = 0;
     Self.Scored += (_, _) => ++kills;
 
-    for (var shot = 0; shot < 12 && kills == 0; ++shot)
+    for (var attempt = 0; attempt < 25 && kills == 0; ++attempt)
     {
       AimAt (victim.GlobalPosition + Vector3.Up);
+      var boltsBeforeShot = _boltsSpawned;
       await ChargeAndFire (chargeSeconds: 2.3f);
-      await Task.Delay (700); // Bolt flight + cooldown before next charge.
+      await TryWaitUntil (() => _boltsSpawned > boltsBeforeShot, 3);
+      GD.Print ($"PLAYTEST: shot attempt {attempt}: bolts fired {_boltsSpawned}, victim health {victim.Health}");
     }
 
     Assert (kills == 1, "scored a kill with charged shots");
@@ -207,19 +215,35 @@ public partial class PlaytestDriver : Node
 
   private async Task WaitUntil (Func <bool> condition, float timeoutSeconds, string description)
   {
+    if (await TryWaitUntil (condition, timeoutSeconds))
+    {
+      GD.Print ($"PLAYTEST OK: {description}");
+      return;
+    }
+
+    throw new Exception ($"timed out after {timeoutSeconds}s waiting for: {description}");
+  }
+
+  // Non-throwing wait; a throwing condition (e.g. nodes vanishing mid-disconnect)
+  // counts as false so the caller gets a readable timeout instead of a raw exception.
+  private static async Task <bool> TryWaitUntil (Func <bool> condition, float timeoutSeconds)
+  {
     var deadline = Time.GetTicksMsec() + (ulong)(timeoutSeconds * 1000);
 
     while (Time.GetTicksMsec() < deadline)
     {
-      if (condition())
+      try
       {
-        GD.Print ($"PLAYTEST OK: {description}");
-        return;
+        if (condition()) return true;
+      }
+      catch (Exception)
+      {
+        // Treat as not-yet-true; the timeout will surface the failure.
       }
 
       await Task.Delay (100);
     }
 
-    throw new Exception ($"timed out after {timeoutSeconds}s waiting for: {description}");
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- **#32 fix**: players are on their own collision layer now and `platform_floor_layers` only includes world geometry, so a player being stood on no longer drags/launches the rider when they respawn-teleport.
- **Tuning** (playtester feedback): shot cooldown 1.0 s → 0.5 s; jump cooldown 3 s → 2 s.
- **Damage handicap**: attacking up a difficulty tier deals +50% per tier gap (Beginner→Intermediate 1.5×, Intermediate→Expert 1.5×, Beginner→Expert 2×). Attacking down a tier is unchanged — the bigger health pool already is that handicap. Tier is derived from the replicated health pool, applied victim-side.

Fixes #32

## Testing
- Full 3-instance playtest harness passes locally (join/kill/respawn/armor/rate-cap/full-auto).
- `dotnet build` clean; gdUnit4 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)