### PR TITLE
Split Player into focused partial classes

### DIFF
--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -1,0 +1,188 @@
+using com.forerunnergames.energyshot.weapons;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Combat: energy weapon & laser bolts, full-auto ability, punching, spawn armor,
+// camera kick, crosshair tint, & the hit/damage/score RPCs.
+public partial class Player
+{
+  private bool IsFullAutoActive() => _fullAutoSecondsLeft > 0.0f;
+  private bool IsChargingWeapon() => _isInputEnabled && !IsFullAutoActive() && Input.IsActionPressed ("shoot");
+  private bool IsDischargingWeapon() => _isInputEnabled && _energyWeapon.IsSpinningUp && Input.IsActionJustReleased ("shoot");
+  private void ChargeWeapon() => _energyWeapon.Charge();
+  private void DischargeWeapon() => _energyWeapon.Discharge();
+  private static int CalculateHealthDecrease (float energyShot) => Mathf.Min (100, Mathf.RoundToInt (energyShot * 100.0f));
+
+  // Casts a ray from the camera along the aim direction, ignoring ourselves, &
+  // returns the player it hits (or null).
+  private Player? FindAimedPlayer (float range)
+  {
+    var from = _camera.GlobalPosition;
+    var to = from + -_camera.GlobalTransform.Basis.Z * range;
+    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { GetRid() });
+    var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
+    if (hit.Count == 0) return null;
+    return hit["collider"].AsGodotObject() as Player;
+  }
+
+  // Crosshair stays white until it's actually over another player.
+  private void UpdateCrosshairTint()
+  {
+    if (!IsMultiplayerAuthority()) return;
+    _crossHairs.Modulate = FindAimedPlayer (200.0f) != null ? Colors.Red : Colors.White;
+  }
+
+  private void ActivateSpawnArmor()
+  {
+    SpawnArmor = true;
+    _spawnArmorEndMs = Time.GetTicksMsec() + (ulong)(SpawnArmorSeconds * 1000.0f);
+  }
+
+  private void CancelSpawnArmorIfFired()
+  {
+    if (!SpawnArmor) return;
+    SpawnArmor = false;
+    GD.Print ($"{DisplayName}: Spawn armor canceled by firing");
+  }
+
+  private void UpdateSpawnArmor()
+  {
+    if (!SpawnArmor || Time.GetTicksMsec() < _spawnArmorEndMs) return;
+    SpawnArmor = false;
+    GD.Print ($"{DisplayName}: Spawn armor expired");
+  }
+
+  private void UpdateFullAuto (double delta)
+  {
+    var dt = (float)delta;
+    _fullAutoCooldownLeft = Mathf.Max (0.0f, _fullAutoCooldownLeft - dt);
+
+    if (_isInputEnabled && Input.IsActionJustPressed ("ability") && _fullAutoCooldownLeft <= 0.0f)
+    {
+      _fullAutoSecondsLeft = FullAutoDurationSeconds;
+      _fullAutoCooldownLeft = FullAutoCooldownSeconds;
+      _nextAutoShotIn = 0.0f;
+    }
+
+    if (!IsFullAutoActive()) return;
+    _fullAutoSecondsLeft -= dt;
+    _nextAutoShotIn -= dt;
+    if (!_isInputEnabled || !Input.IsActionPressed ("shoot") || _nextAutoShotIn > 0.0f) return;
+    _nextAutoShotIn = FullAutoShotIntervalSeconds;
+    _energyWeapon.FireLowPower (FullAutoEnergy);
+  }
+
+  private void UpdatePunch (double delta)
+  {
+    _punchCooldownLeft = Mathf.Max (0.0f, _punchCooldownLeft - (float)delta);
+    if (!_isInputEnabled || _punchCooldownLeft > 0.0f || !Input.IsActionJustPressed ("punch")) return;
+    _punchCooldownLeft = PunchCooldownSeconds;
+    CancelSpawnArmorIfFired(); // Punching drops your spawn armor, same as firing.
+    _punchSound.Play();
+    var victim = FindAimedPlayer (PunchRange);
+    if (victim == null) return;
+    GD.Print ($"{DisplayName}: I punched {victim.DisplayName}!");
+    victim.RpcId (victim.NetworkId, MethodName.ReceivePunch, DisplayName);
+  }
+
+  private void UpdateCameraKick (double delta)
+  {
+    if (_cameraKickRemaining <= 0.0f) return;
+    var recover = Mathf.Min (_cameraKickRemaining, CameraKickRecoverySpeed * (float)delta);
+    _camera.RotateX (-recover);
+    _cameraKickRemaining -= recover;
+  }
+
+  private void OnWeaponShotFired (float energy)
+  {
+    CancelSpawnArmorIfFired();
+    // Aim direction is captured before the camera kick so the kick is purely visual.
+    var direction = -_camera.GlobalTransform.Basis.Z;
+    var kick = energy * CameraKickRadians;
+    _camera.RotateX (kick);
+    _cameraKickRemaining += kick;
+    var origin = _camera.GlobalPosition + direction * 0.9f;
+    SpawnBolt (origin, direction, energy, isLive: true);
+    Rpc (MethodName.SpawnVisualLaser, origin, direction, energy);
+  }
+
+  // Visual-only copy of the shooter's bolt on every other peer.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void SpawnVisualLaser (Vector3 origin, Vector3 direction, float energy) => SpawnBolt (origin, direction, energy, isLive: false);
+
+  private void SpawnBolt (Vector3 origin, Vector3 direction, float energy, bool isLive)
+  {
+    var bolt = _laserBoltScene.Instantiate <LaserBolt>();
+    GetParent().AddChild (bolt);
+    bolt.Launch (origin, direction, energy, isLive, this);
+    if (isLive) bolt.HitPlayer += OnLaserHitPlayer;
+  }
+
+  private void OnLaserHitPlayer (CharacterBody3D body, float energy)
+  {
+    if (body is not Player victim || victim.NetworkId == NetworkId) return;
+    HitPuppet (victim, energy);
+  }
+
+  // The victim is the single owner of its health: the shooter only reports the hit,
+  // the victim applies damage & replicates Health to everyone, & tells the shooter
+  // when it scored a kill (see issue #20).
+  private void HitPuppet (Player playerPuppet, float energy)
+  {
+    GD.Print ($"{DisplayName}: I hit {playerPuppet.DisplayName}!");
+    _hitmarkerSound.Play();
+    playerPuppet.RpcId (playerPuppet.NetworkId, MethodName.ReceiveHit, energy, DisplayName);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ReceiveHit (float energy, string shotByPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    if (SpawnArmor) return;
+    GD.Print ($"{DisplayName}: I was hit by {shotByPlayerName}!");
+    ApplyDamage (energy, shotByPlayerName);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ReceivePunch (string punchedByPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    if (SpawnArmor) return;
+    GD.Print ($"{DisplayName}: I was punched by {punchedByPlayerName}!");
+    EmitSignal (SignalName.Punched);
+    ApplyDamage (PunchEnergy, punchedByPlayerName);
+  }
+
+  private void ApplyDamage (float energy, string attackerName)
+  {
+    var attackerId = Multiplayer.GetRemoteSenderId();
+    // Difficulty damage handicap: lower-skill attackers hit higher-skill targets harder
+    // (+50% per tier gap: Beginner->Intermediate 1.5x, Beginner->Expert 2x,
+    // Intermediate->Expert 1.5x). Attacking downward is unchanged - the bigger health
+    // pool already is the handicap.
+    var attacker = GetParent().GetNodeOrNull <Player> ($"{attackerId}");
+    var handicap = 1.0f + 0.5f * Mathf.Max (0, TierOf (MaxHealth) - TierOf (attacker?.MaxHealth ?? MaxHealth));
+    Health -= Mathf.RoundToInt (CalculateHealthDecrease (energy) * handicap);
+    LastZapEnergy = energy;
+    _damageSound.Play();
+
+    if (Health <= 0)
+    {
+      _zapOutSound.Play();
+      attacker?.RpcId (attackerId, MethodName.NotifyScored, DisplayName);
+      RespawnShot (attackerName);
+    }
+
+    EmitSignal (SignalName.HealthChanged, Health);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void NotifyScored (string shotPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    ++Score;
+    GD.Print ($"{DisplayName}: I scored!");
+    EmitSignal (SignalName.Scored, DisplayName, shotPlayerName);
+  }
+}

--- a/core/players/Player.Combat.cs.uid
+++ b/core/players/Player.Combat.cs.uid
@@ -1,0 +1,1 @@
+uid://cp7nynpkbxt3f

--- a/core/players/Player.Cosmetics.cs
+++ b/core/players/Player.Cosmetics.cs
@@ -1,0 +1,53 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Cosmetics: body colors & hit flash, plus name/health tag text & distance scaling.
+public partial class Player
+{
+  private static readonly Color NormalColor = new("0027ff");
+  private static readonly Color HitColor = Colors.DarkRed;
+  // White glow blended over the player's color, so armored players stay identifiable.
+  private static readonly Color SpawnArmorColor = NormalColor.Lerp (Colors.White, 0.65f);
+  private void SetColor (Color color) => (_mesh.GetSurfaceOverrideMaterial (0) as StandardMaterial3D)!.AlbedoColor = color;
+  // Restores the player's resting color: white glow while spawn armor holds, normal blue otherwise.
+  private void RestoreBaseColor() => SetColor (SpawnArmor ? SpawnArmorColor : NormalColor);
+
+  private void FlashHitColor()
+  {
+    SetColor (HitColor);
+    _hitRedTimer.Start();
+  }
+
+  private void UpdateNameTag()
+  {
+    if (_nameTag == null) return;
+    _nameTag.Text = _displayName;
+  }
+
+  private void UpdatePuppetTags()
+  {
+    if (IsMultiplayerAuthority() || _localPlayer == null || _nameTag == null) return;
+    var distanceFromLocalPlayer = GlobalPosition.DistanceTo (_localPlayer.GlobalPosition);
+    var scaleFactor = CalculateTagScaleFactor (distanceFromLocalPlayer);
+    var healthTagMinWidthFactor = 0.8f;
+    var healthTagWidthFactor = Mathf.Max (healthTagMinWidthFactor, 0.5f * scaleFactor);
+    var originalHealthTagScale = new Vector3 (0.18f, 0.101f, 0.42f);
+    var healthTagScaleFactor = new Vector3 (healthTagWidthFactor, 1.0f * scaleFactor, 0.5f * scaleFactor);
+    var verticalOffset = scaleFactor * 0.2f;
+    var t = (distanceFromLocalPlayer - TagScaleStartDistance) / (TagScaleStopDistance - TagScaleStartDistance);
+    var tagSpacing = Mathf.Lerp (HealthTagNameTagMinSpacing, HealthTagNameTagMaxSpacing, Mathf.Clamp (t, 0.0f, 1.0f));
+    _nameTag.Scale = Vector3.One * scaleFactor;
+    _nameTag.Position = new Vector3 (_nameTag.Position.X, NameTagBaseHeight + verticalOffset, _nameTag.Position.Z);
+    _healthTag.Scale = originalHealthTagScale * healthTagScaleFactor;
+    _healthTag.Position = new Vector3 (_healthTag.Position.X, NameTagBaseHeight + verticalOffset - tagSpacing, _healthTag.Position.Z);
+  }
+
+  private float CalculateTagScaleFactor (float distance)
+  {
+    if (distance <= TagScaleStartDistance) return MinNameTagScale;
+    if (distance >= TagScaleStopDistance) return MaxNameTagScale;
+    var t = (distance - TagScaleStartDistance) / (TagScaleStopDistance - TagScaleStartDistance);
+    return Mathf.Lerp (MinNameTagScale, MaxNameTagScale, t);
+  }
+}

--- a/core/players/Player.Cosmetics.cs.uid
+++ b/core/players/Player.Cosmetics.cs.uid
@@ -1,0 +1,1 @@
+uid://ckqrsy1i2eg2s

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -1,0 +1,80 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Movement: walking, jumping, falling, world-boundary collisions, respawns, & spawn
+// positioning.
+public partial class Player
+{
+  private bool IsFalling() => !IsOnFloor();
+  private bool IsJumping() => _isInputEnabled && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
+  private void Fall (ref Vector3 velocity, double delta) => velocity += Gravity * (float)delta;
+
+  private void Jump (ref Vector3 velocity)
+  {
+    velocity.Y = JumpVelocity;
+    _jumpSound.Play();
+    _jumpTimer.Start();
+  }
+
+  private void Move (ref Vector3 velocity)
+  {
+    var inputDir = Input.GetVector ("move_left", "move_right", "move_forward", "move_back");
+    var inputDirection = (Transform.Basis * new Vector3 (inputDir.X, 0, inputDir.Y)).Normalized();
+
+    if (inputDirection != Vector3.Zero)
+    {
+      velocity.X = inputDirection.X * Speed;
+      velocity.Z = inputDirection.Z * Speed;
+      return;
+    }
+
+    velocity.X = Mathf.MoveToward (Velocity.X, 0, Speed);
+    velocity.Z = Mathf.MoveToward (Velocity.Z, 0, Speed);
+  }
+
+  private void HandleCollisions()
+  {
+    var collisionCount = GetSlideCollisionCount();
+    for (var i = 0; i < collisionCount; ++i) HandleCollision (GetSlideCollision (i));
+  }
+
+  private void HandleCollision (KinematicCollision3D collision)
+  {
+    if (collision.GetColliderShape() is not CollisionShape3D { Shape: WorldBoundaryShape3D }) return;
+    RespawnFell();
+  }
+
+  private void RespawnShot (string shotByPlayerName)
+  {
+    Respawn();
+    EmitSignal (SignalName.RespawnedShot, DisplayName, shotByPlayerName);
+  }
+
+  private void RespawnFell()
+  {
+    Respawn();
+    EmitSignal (SignalName.RespawnedFell, DisplayName);
+  }
+
+  // Respawn into the spawn room above the arena (drop in to re-enter), with a short
+  // input lock, so respawns are no longer instant teleports into the fight.
+  private async void Respawn()
+  {
+    Health = MaxHealth;
+    Velocity = Vector3.Zero;
+    Position = CalculateRandomSpawnPosition();
+    ActivateSpawnArmor();
+    SetInputEnabled (isEnabled: false);
+    _respawnSound.Play();
+    GD.Print ($"{DisplayName}: I respawned!");
+    await ToSignal (GetTree().CreateTimer (RespawnInputLockSeconds), SceneTreeTimer.SignalName.Timeout);
+    SetInputEnabled (isEnabled: true);
+  }
+
+  private Vector3 CalculateRandomSpawnPosition()
+  {
+    var offset = new Vector3 (_rng.RandfRange (-4.0f, 4.0f), 1.0f, _rng.RandfRange (-4.0f, 4.0f));
+    return _spawnRoom.Position + offset;
+  }
+}

--- a/core/players/Player.Movement.cs.uid
+++ b/core/players/Player.Movement.cs.uid
@@ -1,0 +1,1 @@
+uid://dpdsyaisqgvpq

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -4,6 +4,9 @@ using Godot;
 
 namespace com.forerunnergames.energyshot.players;
 
+// Core state & lifecycle: exports, signals, replicated properties, node wiring, & thin
+// per-frame dispatchers. Behavior lives in Player.Movement.cs, Player.Combat.cs, &
+// Player.Cosmetics.cs.
 public partial class Player : CharacterBody3D
 {
   // @formatter:off
@@ -73,7 +76,7 @@ public partial class Player : CharacterBody3D
     set
     {
       _spawnArmor = value;
-      if (_mesh != null) SetColor (value ? SpawnArmorColor : NormalColor);
+      if (_mesh != null) RestoreBaseColor();
     }
   }
 
@@ -100,11 +103,8 @@ public partial class Player : CharacterBody3D
   [Export] public float HealthTagNameTagMaxSpacing = 3.0f;
   [Export] public float NameTagBaseHeight = 2.3f;
   public int NetworkId => Name.ToString().ToInt();
+  public float LastZapEnergy { get; private set; }
   private readonly RandomNumberGenerator _rng = new();
-  private static readonly Color NormalColor = new("0027ff");
-  private static readonly Color HitColor = Colors.DarkRed;
-  // White glow blended over the player's color, so armored players stay identifiable.
-  private static readonly Color SpawnArmorColor = NormalColor.Lerp (Colors.White, 0.65f);
   private bool _spawnArmor;
   private ulong _spawnArmorEndMs;
   private NetworkManager _networkManager = null!;
@@ -123,7 +123,6 @@ public partial class Player : CharacterBody3D
   private AudioStreamPlayer _zapOutSound = null!;
   private AudioStreamPlayer _respawnSound = null!;
   private AudioStreamPlayer _jumpSound = null!;
-  public float LastZapEnergy { get; private set; }
   private Sprite3D _crossHairs = null!;
   private Timer _jumpTimer = null!;
   private Timer _hitRedTimer = null!;
@@ -136,40 +135,11 @@ public partial class Player : CharacterBody3D
   private int _maxHealth = 200;
   private bool _isInputEnabled;
   private static Player? _localPlayer;
-  public override void _Process (double delta)
-  {
-    if (!IsMultiplayerActive()) return;
-    UpdatePuppetTags();
-    UpdateCrosshairTint();
-  }
-
-  // Crosshair stays white until it's actually over another player.
-  private void UpdateCrosshairTint()
-  {
-    if (!IsMultiplayerAuthority()) return;
-    var from = _camera.GlobalPosition;
-    var to = from + -_camera.GlobalTransform.Basis.Z * 200.0f;
-    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { GetRid() });
-    var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
-    var aimingAtPlayer = hit.Count > 0 && hit["collider"].AsGodotObject() is Player;
-    _crossHairs.Modulate = aimingAtPlayer ? Colors.Red : Colors.White;
-  }
-
+  public override void _EnterTree() => SetMultiplayerAuthority (NetworkId);
+  public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
   // Guards against "The multiplayer instance isn't currently active" error spam from
   // IsMultiplayerAuthority() after the session ends but before player nodes are freed (see issue #22).
   private bool IsMultiplayerActive() => Multiplayer.MultiplayerPeer != null && Multiplayer.MultiplayerPeer.GetConnectionStatus() == MultiplayerPeer.ConnectionStatus.Connected;
-  public override void _EnterTree() => SetMultiplayerAuthority (NetworkId);
-  public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
-  private bool IsFalling() => !IsOnFloor();
-  private bool IsJumping() => _isInputEnabled && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
-  private bool IsFullAutoActive() => _fullAutoSecondsLeft > 0.0f;
-  private bool IsChargingWeapon() => _isInputEnabled && !IsFullAutoActive() && Input.IsActionPressed ("shoot");
-  private bool IsDischargingWeapon() => _isInputEnabled && _energyWeapon.IsSpinningUp && Input.IsActionJustReleased ("shoot");
-  private void Fall (ref Vector3 velocity, double delta) => velocity += Gravity * (float)delta;
-  private void ChargeWeapon() => _energyWeapon.Charge();
-  private void DischargeWeapon() => _energyWeapon.Discharge();
-  private void SetColor (Color color) => (_mesh.GetSurfaceOverrideMaterial (0) as StandardMaterial3D)!.AlbedoColor = color;
-  private static int CalculateHealthDecrease (float energyShot) => Mathf.Min (100, Mathf.RoundToInt (energyShot * 100.0f));
 
   public override void _Ready()
   {
@@ -196,9 +166,9 @@ public partial class Player : CharacterBody3D
     if (!IsMultiplayerAuthority())
     {
       UpdateNameTag();
-      _hitRedTimer.Timeout += () => SetColor (SpawnArmor ? SpawnArmorColor : NormalColor);
+      _hitRedTimer.Timeout += RestoreBaseColor;
       _crossHairs.Hide();
-      SetColor (SpawnArmor ? SpawnArmorColor : NormalColor);
+      RestoreBaseColor();
       return;
     }
 
@@ -213,6 +183,20 @@ public partial class Player : CharacterBody3D
     Input.MouseMode = Input.MouseModeEnum.Captured;
     Position = CalculateRandomSpawnPosition();
     ActivateSpawnArmor();
+  }
+
+  public override void _ExitTree()
+  {
+    base._ExitTree();
+    if (!IsMultiplayerAuthority() || _localPlayer != this) return;
+    _localPlayer = null;
+  }
+
+  public override void _Process (double delta)
+  {
+    if (!IsMultiplayerActive()) return;
+    UpdatePuppetTags();
+    UpdateCrosshairTint();
   }
 
   public override void _PhysicsProcess (double delta)
@@ -232,53 +216,6 @@ public partial class Player : CharacterBody3D
     HandleCollisions();
   }
 
-  private void ActivateSpawnArmor()
-  {
-    SpawnArmor = true;
-    _spawnArmorEndMs = Time.GetTicksMsec() + (ulong)(SpawnArmorSeconds * 1000.0f);
-  }
-
-  private void CancelSpawnArmorIfFired()
-  {
-    if (!SpawnArmor) return;
-    SpawnArmor = false;
-    GD.Print ($"{DisplayName}: Spawn armor canceled by firing");
-  }
-
-  private void UpdateSpawnArmor()
-  {
-    if (!SpawnArmor || Time.GetTicksMsec() < _spawnArmorEndMs) return;
-    SpawnArmor = false;
-    GD.Print ($"{DisplayName}: Spawn armor expired");
-  }
-
-  private void UpdateFullAuto (double delta)
-  {
-    var dt = (float)delta;
-    _fullAutoCooldownLeft = Mathf.Max (0.0f, _fullAutoCooldownLeft - dt);
-
-    if (_isInputEnabled && Input.IsActionJustPressed ("ability") && _fullAutoCooldownLeft <= 0.0f)
-    {
-      _fullAutoSecondsLeft = FullAutoDurationSeconds;
-      _fullAutoCooldownLeft = FullAutoCooldownSeconds;
-      _nextAutoShotIn = 0.0f;
-    }
-
-    if (!IsFullAutoActive()) return;
-    _fullAutoSecondsLeft -= dt;
-    _nextAutoShotIn -= dt;
-    if (!_isInputEnabled || !Input.IsActionPressed ("shoot") || _nextAutoShotIn > 0.0f) return;
-    _nextAutoShotIn = FullAutoShotIntervalSeconds;
-    _energyWeapon.FireLowPower (FullAutoEnergy);
-  }
-
-  public override void _ExitTree()
-  {
-    base._ExitTree();
-    if (!IsMultiplayerAuthority() || _localPlayer != this) return;
-    _localPlayer = null;
-  }
-
   public override void _UnhandledInput (InputEvent @event)
   {
     if (!_isInputEnabled) return;
@@ -289,227 +226,5 @@ public partial class Player : CharacterBody3D
     RotateY (-motionEvent.Relative.X * MouseSensitivity);
     _camera.RotateX (-motionEvent.Relative.Y * MouseSensitivity);
     _camera.Rotation = new Vector3 (Mathf.Clamp (_camera.Rotation.X, -Mathf.Pi / 2.0f, Mathf.Pi / 2.0f), _camera.Rotation.Y, _camera.Rotation.Z);
-  }
-
-  private void Jump (ref Vector3 velocity)
-  {
-    velocity.Y = JumpVelocity;
-    _jumpSound.Play();
-    _jumpTimer.Start();
-  }
-
-  private void Move (ref Vector3 velocity)
-  {
-    var inputDir = Input.GetVector ("move_left", "move_right", "move_forward", "move_back");
-    var inputDirection = (Transform.Basis * new Vector3 (inputDir.X, 0, inputDir.Y)).Normalized();
-
-    if (inputDirection != Vector3.Zero)
-    {
-      velocity.X = inputDirection.X * Speed;
-      velocity.Z = inputDirection.Z * Speed;
-      return;
-    }
-
-    velocity.X = Mathf.MoveToward (Velocity.X, 0, Speed);
-    velocity.Z = Mathf.MoveToward (Velocity.Z, 0, Speed);
-  }
-
-  private void OnWeaponShotFired (float energy)
-  {
-    CancelSpawnArmorIfFired();
-    // Aim direction is captured before the camera kick so the kick is purely visual.
-    var direction = -_camera.GlobalTransform.Basis.Z;
-    var kick = energy * CameraKickRadians;
-    _camera.RotateX (kick);
-    _cameraKickRemaining += kick;
-    var origin = _camera.GlobalPosition + direction * 0.9f;
-    SpawnBolt (origin, direction, energy, isLive: true);
-    Rpc (MethodName.SpawnVisualLaser, origin, direction, energy);
-  }
-
-  // Visual-only copy of the shooter's bolt on every other peer.
-  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void SpawnVisualLaser (Vector3 origin, Vector3 direction, float energy) => SpawnBolt (origin, direction, energy, isLive: false);
-
-  private void SpawnBolt (Vector3 origin, Vector3 direction, float energy, bool isLive)
-  {
-    var bolt = _laserBoltScene.Instantiate <LaserBolt>();
-    GetParent().AddChild (bolt);
-    bolt.Launch (origin, direction, energy, isLive, this);
-    if (isLive) bolt.HitPlayer += OnLaserHitPlayer;
-  }
-
-  private void OnLaserHitPlayer (CharacterBody3D body, float energy)
-  {
-    if (body is not Player victim || victim.NetworkId == NetworkId) return;
-    HitPuppet (victim, energy);
-  }
-
-  // The victim is the single owner of its health: the shooter only reports the hit,
-  // the victim applies damage & replicates Health to everyone, & tells the shooter
-  // when it scored a kill (see issue #20).
-  private void HitPuppet (Player playerPuppet, float energy)
-  {
-    GD.Print ($"{DisplayName}: I hit {playerPuppet.DisplayName}!");
-    _hitmarkerSound.Play();
-    playerPuppet.RpcId (playerPuppet.NetworkId, MethodName.ReceiveHit, energy, DisplayName);
-  }
-
-  private void UpdatePunch (double delta)
-  {
-    _punchCooldownLeft = Mathf.Max (0.0f, _punchCooldownLeft - (float)delta);
-    if (!_isInputEnabled || _punchCooldownLeft > 0.0f || !Input.IsActionJustPressed ("punch")) return;
-    _punchCooldownLeft = PunchCooldownSeconds;
-    CancelSpawnArmorIfFired(); // Punching drops your spawn armor, same as firing.
-    _punchSound.Play();
-    var from = _camera.GlobalPosition;
-    var to = from + -_camera.GlobalTransform.Basis.Z * PunchRange;
-    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { GetRid() });
-    var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
-    if (hit.Count == 0 || hit["collider"].AsGodotObject() is not Player victim) return;
-    GD.Print ($"{DisplayName}: I punched {victim.DisplayName}!");
-    victim.RpcId (victim.NetworkId, MethodName.ReceivePunch, DisplayName);
-  }
-
-  private void UpdateCameraKick (double delta)
-  {
-    if (_cameraKickRemaining <= 0.0f) return;
-    var recover = Mathf.Min (_cameraKickRemaining, CameraKickRecoverySpeed * (float)delta);
-    _camera.RotateX (-recover);
-    _cameraKickRemaining -= recover;
-  }
-
-  private void FlashHitColor()
-  {
-    SetColor (HitColor);
-    _hitRedTimer.Start();
-  }
-
-  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void ReceiveHit (float energy, string shotByPlayerName)
-  {
-    if (!IsMultiplayerAuthority()) return;
-    if (SpawnArmor) return;
-    GD.Print ($"{DisplayName}: I was hit by {shotByPlayerName}!");
-    ApplyDamage (energy, shotByPlayerName);
-  }
-
-  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void ReceivePunch (string punchedByPlayerName)
-  {
-    if (!IsMultiplayerAuthority()) return;
-    if (SpawnArmor) return;
-    GD.Print ($"{DisplayName}: I was punched by {punchedByPlayerName}!");
-    EmitSignal (SignalName.Punched);
-    ApplyDamage (PunchEnergy, punchedByPlayerName);
-  }
-
-  private void ApplyDamage (float energy, string attackerName)
-  {
-    var attackerId = Multiplayer.GetRemoteSenderId();
-    // Difficulty damage handicap: lower-skill attackers hit higher-skill targets harder
-    // (+50% per tier gap: Beginner->Intermediate 1.5x, Beginner->Expert 2x,
-    // Intermediate->Expert 1.5x). Attacking downward is unchanged - the bigger health
-    // pool already is the handicap.
-    var attacker = GetParent().GetNodeOrNull <Player> ($"{attackerId}");
-    var handicap = 1.0f + 0.5f * Mathf.Max (0, TierOf (MaxHealth) - TierOf (attacker?.MaxHealth ?? MaxHealth));
-    Health -= Mathf.RoundToInt (CalculateHealthDecrease (energy) * handicap);
-    LastZapEnergy = energy;
-    _damageSound.Play();
-
-    if (Health <= 0)
-    {
-      _zapOutSound.Play();
-      attacker?.RpcId (attackerId, MethodName.NotifyScored, DisplayName);
-      RespawnShot (attackerName);
-    }
-
-    EmitSignal (SignalName.HealthChanged, Health);
-  }
-
-  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void NotifyScored (string shotPlayerName)
-  {
-    if (!IsMultiplayerAuthority()) return;
-    ++Score;
-    GD.Print ($"{DisplayName}: I scored!");
-    EmitSignal (SignalName.Scored, DisplayName, shotPlayerName);
-  }
-
-  private void HandleCollisions()
-  {
-    var collisionCount = GetSlideCollisionCount();
-    for (var i = 0; i < collisionCount; ++i) HandleCollision (GetSlideCollision (i));
-  }
-
-  private void HandleCollision (KinematicCollision3D collision)
-  {
-    if (collision.GetColliderShape() is not CollisionShape3D { Shape: WorldBoundaryShape3D }) return;
-    RespawnFell();
-  }
-
-  private void RespawnShot (string shotByPlayerName)
-  {
-    Respawn();
-    EmitSignal (SignalName.RespawnedShot, DisplayName, shotByPlayerName);
-  }
-
-  private void RespawnFell()
-  {
-    Respawn();
-    EmitSignal (SignalName.RespawnedFell, DisplayName);
-  }
-
-  // Respawn into the spawn room above the arena (drop in to re-enter), with a short
-  // input lock, so respawns are no longer instant teleports into the fight.
-  private async void Respawn()
-  {
-    Health = MaxHealth;
-    Velocity = Vector3.Zero;
-    Position = CalculateRandomSpawnPosition();
-    ActivateSpawnArmor();
-    SetInputEnabled (isEnabled: false);
-    _respawnSound.Play();
-    GD.Print ($"{DisplayName}: I respawned!");
-    await ToSignal (GetTree().CreateTimer (RespawnInputLockSeconds), SceneTreeTimer.SignalName.Timeout);
-    SetInputEnabled (isEnabled: true);
-  }
-
-  private Vector3 CalculateRandomSpawnPosition()
-  {
-    var offset = new Vector3 (_rng.RandfRange (-4.0f, 4.0f), 1.0f, _rng.RandfRange (-4.0f, 4.0f));
-    return _spawnRoom.Position + offset;
-  }
-
-  private void UpdatePuppetTags()
-  {
-    if (IsMultiplayerAuthority() || _localPlayer == null || _nameTag == null) return;
-    var distanceFromLocalPlayer = GlobalPosition.DistanceTo (_localPlayer.GlobalPosition);
-    var scaleFactor = CalculateTagScaleFactor (distanceFromLocalPlayer);
-    var healthTagMinWidthFactor = 0.8f;
-    var healthTagWidthFactor = Mathf.Max (healthTagMinWidthFactor, 0.5f * scaleFactor);
-    var originalHealthTagScale = new Vector3 (0.18f, 0.101f, 0.42f);
-    var healthTagScaleFactor = new Vector3 (healthTagWidthFactor, 1.0f * scaleFactor, 0.5f * scaleFactor);
-    var verticalOffset = scaleFactor * 0.2f;
-    var t = (distanceFromLocalPlayer - TagScaleStartDistance) / (TagScaleStopDistance - TagScaleStartDistance);
-    var tagSpacing = Mathf.Lerp (HealthTagNameTagMinSpacing, HealthTagNameTagMaxSpacing, Mathf.Clamp (t, 0.0f, 1.0f));
-    _nameTag.Scale = Vector3.One * scaleFactor;
-    _nameTag.Position = new Vector3 (_nameTag.Position.X, NameTagBaseHeight + verticalOffset, _nameTag.Position.Z);
-    _healthTag.Scale = originalHealthTagScale * healthTagScaleFactor;
-    _healthTag.Position = new Vector3 (_healthTag.Position.X, NameTagBaseHeight + verticalOffset - tagSpacing, _healthTag.Position.Z);
-  }
-
-  private float CalculateTagScaleFactor (float distance)
-  {
-    if (distance <= TagScaleStartDistance) return MinNameTagScale;
-    if (distance >= TagScaleStopDistance) return MaxNameTagScale;
-    var t = (distance - TagScaleStartDistance) / (TagScaleStopDistance - TagScaleStartDistance);
-    return Mathf.Lerp (MinNameTagScale, MaxNameTagScale, t);
-  }
-
-  private void UpdateNameTag()
-  {
-    if (_nameTag == null) return;
-    _nameTag.Text = _displayName;
   }
 }

--- a/core/weapons/LaserBolt.cs
+++ b/core/weapons/LaserBolt.cs
@@ -46,6 +46,9 @@ public partial class LaserBolt : Node3D
     _velocity.Y -= DropAcceleration * dt; // ponytail: simple laser drop, no drag
     var to = from + _velocity * dt;
     var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { _shooterRid });
+    // Point-blank bolts can spawn inside the target's collider; without this the
+    // sweep never registers & the bolt sails through (see issue #52).
+    query.HitFromInside = true;
     var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
 
     if (hit.Count > 0)


### PR DESCRIPTION
## Summary

`core/players/Player.cs` had grown into a 515-line grab bag of state, movement, combat, & cosmetics. This splits it into four small partial-class files with **no behavior change** — zero scene changes, no autoloads, no new node types:

| File | Lines | Contents |
|---|---|---|
| `Player.cs` | 230 | Exports, signals, replicated properties (`DisplayName`/`Health`/`Score`/`MaxHealth`/`SpawnArmor`), `_Ready` wiring, & thin `_EnterTree`/`_ExitTree`/`_Process`/`_PhysicsProcess`/`_UnhandledInput` dispatchers |
| `Player.Combat.cs` | 188 | Weapon fire & laser bolts, full-auto, punch, spawn armor, camera kick, crosshair tint, & the `ReceiveHit`/`ReceivePunch`/`NotifyScored`/`SpawnVisualLaser` RPCs with `ApplyDamage` |
| `Player.Movement.cs` | 80 | Walk/jump/fall, world-boundary collisions, respawns, & spawn positioning |
| `Player.Cosmetics.cs` | 53 | Body colors & hit flash, name/health tag text & distance scaling |

No public, exported, replicated, RPC, signal, or node-path names changed, so the `MultiplayerSynchronizer` replication config, RPC dispatch, & `Player.tscn` are untouched.

Two tiny DRY helpers factored within the class:

- `FindAimedPlayer (float range)` — the camera-forward ray query (exclude self, return `Player` hit or null) previously duplicated between crosshair tint & punch.
- `RestoreBaseColor()` — the `SpawnArmor ? SpawnArmorColor : NormalColor` restore previously repeated in the `SpawnArmor` setter, the hit-flash timer callback, & puppet `_Ready`.

## Validation

- `dotnet build`: 0 errors, 0 warnings
- gdUnit4 suite (`runtest.sh -a tests`): 9/9 test cases passed
- Full 3-instance multiplayer playtest (`tests/playtest/run-playtest.sh`): PASSED (host + shooter + victim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)