### PR TITLE
Fall penalty, official server by default, auto-deploy, & respawn feel fix

### DIFF
--- a/.github/workflows/export-and-release.yml
+++ b/.github/workflows/export-and-release.yml
@@ -164,3 +164,27 @@ jobs:
           generateReleaseNotes: true
           tag: ${{ github.ref_name }}
           artifacts: ${{ steps.export.outputs.archive_directory }}/*
+
+      # Deploy the dedicated server build to the official game server droplet.
+      # Skipped gracefully if the deploy secrets are absent.
+      - name: Deploy dedicated server
+        continue-on-error: true
+        if: env.DROPLET_HOST != ''
+        env:
+          DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
+        run: |
+          echo "${{ secrets.DROPLET_SSH_KEY }}" > droplet_key
+          chmod 600 droplet_key
+          ssh -i droplet_key -o StrictHostKeyChecking=accept-new root@"$DROPLET_HOST" bash -s <<'DEPLOY'
+          set -e
+          cd /opt/energy-shot/build
+          rm -rf ./*
+          curl -sL -o server.zip "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/EnergyShot-Linux.Server-${{ github.ref_name }}.zip"
+          unzip -oq server.zip && rm server.zip
+          chmod +x energy-shot-server.x86_64
+          chown -R game:game /opt/energy-shot
+          systemctl restart energy-shot
+          sleep 3
+          systemctl is-active energy-shot
+          DEPLOY
+          rm droplet_key

--- a/.github/workflows/export-and-release.yml
+++ b/.github/workflows/export-and-release.yml
@@ -169,22 +169,35 @@ jobs:
       # Skipped gracefully if the deploy secrets are absent.
       - name: Deploy dedicated server
         continue-on-error: true
-        if: env.DROPLET_HOST != ''
+        if: ${{ secrets.DROPLET_HOST != '' }}
         env:
           DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
         run: |
+          # Key is removed on every exit path; host key is pinned, not trusted-on-first-use.
+          trap 'rm -f droplet_key known_hosts' EXIT
           echo "${{ secrets.DROPLET_SSH_KEY }}" > droplet_key
           chmod 600 droplet_key
-          ssh -i droplet_key -o StrictHostKeyChecking=accept-new root@"$DROPLET_HOST" bash -s <<'DEPLOY'
+          echo "${{ secrets.DROPLET_HOST_KEY }}" > known_hosts
+          # TAG & REPO are passed as environment values (never interpolated into the
+          # remote script) so a hostile ref name can't inject shell commands.
+          ssh -i droplet_key -o UserKnownHostsFile=known_hosts -o StrictHostKeyChecking=yes \
+            root@"$DROPLET_HOST" "REPO='$REPO' TAG='$TAG' bash -s" <<'DEPLOY'
           set -e
-          cd /opt/energy-shot/build
-          rm -rf ./*
-          curl -sL -o server.zip "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/EnergyShot-Linux.Server-${{ github.ref_name }}.zip"
+          # Stage & validate the new build before touching the running server.
+          rm -rf /opt/energy-shot/staging
+          mkdir -p /opt/energy-shot/staging
+          cd /opt/energy-shot/staging
+          curl -sL -o server.zip "https://github.com/$REPO/releases/download/$TAG/EnergyShot-Linux.Server-$TAG.zip"
           unzip -oq server.zip && rm server.zip
+          test -f energy-shot-server.x86_64 || { echo "server binary missing from archive"; exit 1; }
           chmod +x energy-shot-server.x86_64
+          # Swap in the validated build & restart.
+          rm -rf /opt/energy-shot/build
+          mv /opt/energy-shot/staging /opt/energy-shot/build
           chown -R game:game /opt/energy-shot
           systemctl restart energy-shot
           sleep 3
           systemctl is-active energy-shot
           DEPLOY
-          rm droplet_key

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 
 ## Multiplayer
 
-The easiest way to play: **Join Game** — the official dedicated server address is pre-filled, so just pick a name & difficulty and jump in. (Each release deploys to the official server automatically.)
+The easiest way to play: **Join Game** — the official dedicated server address is pre-filled, so just pick a name & difficulty and jump in. (Releases deploy to the official server automatically when deploy credentials are configured.)
 
 Prefer to host your own? Host from the main menu — UPnP discovers your address; enable UPnP on your router or forward UDP port **55556**.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 
 ## Multiplayer
 
-Host or join from the main menu — your name, difficulty, & last server address are remembered. Hosting from home uses UPnP to discover your address; enable UPnP on your router or forward UDP port **55556**. (A hosted dedicated server is in the works.)
+The easiest way to play: **Join Game** — the official dedicated server address is pre-filled, so just pick a name & difficulty and jump in. (Each release deploys to the official server automatically.)
+
+Prefer to host your own? Host from the main menu — UPnP discovers your address; enable UPnP on your router or forward UDP port **55556**.
 
 Grab the latest build from [Releases](https://github.com/forerunnergames/energy-shot/releases) — macOS builds are signed & notarized.
 

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -53,6 +53,7 @@ public partial class Player
 
   private void RespawnFell()
   {
+    --Score; // Falling off the world costs a point.
     Respawn();
     EmitSignal (SignalName.RespawnedFell, DisplayName);
   }

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -86,7 +86,8 @@ public partial class Player : CharacterBody3D
   [Export] public float FullAutoCooldownSeconds = 15.0f;
   [Export] public float FullAutoShotIntervalSeconds = 0.15f;
   [Export] public float FullAutoEnergy = 0.12f;
-  [Export] public float RespawnInputLockSeconds = 2.0f;
+  // Brief - the spawn room & spawn armor already prevent instant re-engagement (#48).
+  [Export] public float RespawnInputLockSeconds = 0.3f;
   [Export] public float PunchCooldownSeconds = 0.6f;
   [Export] public float PunchRange = 2.5f;
   [Export] public float PunchEnergy = 0.2f;

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -148,6 +148,7 @@ public partial class Hud : Control
   private void OnPlayerRespawnedFell (string playerName)
   {
     if (!IsSelf (playerName)) return;
+    UpdateScoreLabel(); // Falling costs a point; show it immediately.
     NotifyMessage (MessageGenerator.OnPlayerRespawnedFell (isSelf: true, playerName, out var messageIndex), MessageGenerator.OnPlayerRespawnedFell (isSelf: false, playerName, messageIndex));
     ++_fallStreak;
     if (_fallStreak >= 3) NotifyMessage (MessageGenerator.OnFallStreak (playerName), MessageGenerator.OnFallStreak (playerName));

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -45,7 +45,11 @@ public partial class Hud : Control
   {
     var players = _world.GetPlayers().OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName);
     _leaderboardEntries.Text = string.Join ("\n", players.Select (player => $"{player.DisplayName}  {player.Score}"));
+    UpdateScoreLabel();
   }
+
+  // Score can also drop (fall penalty), so the label reads the replicated value.
+  private void UpdateScoreLabel() => _scoreLabel.Text = $"Score: {_world.SelfPlayer?.Score ?? 0}";
   private bool IsSelf (string playerName) => _selfPlayerName == playerName;
   private void OnKickedFromServer (string reason) => Hide();
   private void OnServerShutDown() => Hide();
@@ -152,7 +156,7 @@ public partial class Hud : Control
   private void OnPlayerScored (int score, string playerName, string shotPlayerName)
   {
     if (!IsSelf (playerName)) return;
-    _scoreLabel.Text = $"Score: {score}";
+    UpdateScoreLabel();
     _fallStreak = 0;
   }
 

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -15,9 +15,16 @@ public static class Settings
     set => Set ("name", value);
   }
 
+  // First-time players get the official dedicated server pre-filled.
+  public const string OfficialServerAddress = "137.184.43.105";
+
   public static string LastJoinAddress
   {
-    get => Get ("last_join_address");
+    get
+    {
+      var address = Get ("last_join_address");
+      return string.IsNullOrEmpty (address) ? OfficialServerAddress : address;
+    }
     set => Set ("last_join_address", value);
   }
 


### PR DESCRIPTION
## Summary
- **Fall penalty**: falling off the world costs 1 point; the HUD score label now reads the replicated `Score` so decrements show immediately (leaderboard already did).
- **Official dedicated server** (now live at 137.184.43.105, running v0.5.1): the Join dialog pre-fills its address for first-time players; your last-used address is still remembered once you join anywhere else.
- **Auto-deploy**: the release workflow now pushes the Linux server build to the official droplet & restarts the service after publishing a release (skips gracefully if deploy secrets are absent).
- **Respawn feel (#48)**: input lock trimmed 2 s → 0.3 s — the spawn room + spawn armor already prevent instant re-engagement.
- README: joining the official server is the primary flow.

Fixes #48

## Testing
- Full 3-instance playtest green locally; `dotnet build` clean.
- Dedicated server deploy procedure exercised manually on the droplet (service active, UDP 55556 listening, real ENet handshake from a local client verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Players now default to the official dedicated server when no saved address is available.
  * Releases can optionally deploy automatically to a configured dedicated server.
  * Multiplayer guidance now includes official server access and self-hosting requirements, including UPnP or UDP port 55556 forwarding.

* **Bug Fixes**
  * Falling off the world now reduces the player’s score before respawning.
  * Respawn input lock time has been significantly reduced.
  * HUD score displays now update more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->