### PR TITLE
Fix invalid secrets context that broke all releases since v0.5.2

### DIFF
--- a/.github/workflows/export-and-release.yml
+++ b/.github/workflows/export-and-release.yml
@@ -169,12 +169,14 @@ jobs:
       # Skipped gracefully if the deploy secrets are absent.
       - name: Deploy dedicated server
         continue-on-error: true
-        if: ${{ secrets.DROPLET_HOST != '' }}
         env:
           DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
+          # The secrets context isn't available in step `if` expressions, so the
+          # no-credentials case is guarded here instead.
+          if [ -z "$DROPLET_HOST" ]; then echo "Deploy secrets absent; skipping deploy"; exit 0; fi
           # Key is removed on every exit path; host key is pinned, not trusted-on-first-use.
           trap 'rm -f droplet_key known_hosts' EXIT
           echo "${{ secrets.DROPLET_SSH_KEY }}" > droplet_key


### PR DESCRIPTION
## Summary
`if: ${{ secrets.DROPLET_HOST != '' }}` on the deploy step is invalid — the `secrets` context isn't available in step-level `if` expressions — and an invalid expression invalidates the **entire workflow file**, so every `Export & Release` run since v0.5.2 failed instantly ("Unrecognized named-value: 'secrets'") and v0.5.2/v0.6.0/v0.6.1/v0.6.2 were never published.

Fix: the step always runs; the no-credentials case exits 0 inside the script (env-mapped secret), which is the documented-safe pattern.

After merge: tagging **v0.6.3** to publish one release containing everything since v0.5.1 (fall penalty, official-server default + auto-deploy, banana gun, bread, arena cover, shared messages, cooldown bars, full-auto feedback, HUD sizing, slide/crouch/boost/pierce/knockback). The four orphaned tags will be removed since they never produced releases.

## Testing
- YAML validated locally; the failing expression is removed entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)