### PR TITLE
Tab-toggled messages, kill heal, streak effects, slower crouch, more knockback

### DIFF
--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -233,7 +233,11 @@ public partial class Player
   {
     if (!IsMultiplayerAuthority()) return;
     ++Score;
-    GD.Print ($"{DisplayName}: I scored!");
+    ++ZapStreakCount;
+    // Zapping someone out patches you up a bit (see issue #76).
+    Health = Mathf.Min (MaxHealth, Health + KillHealAmount);
+    EmitSignal (SignalName.HealthChanged, Health);
+    GD.Print ($"{DisplayName}: I scored! (streak {ZapStreakCount})");
     EmitSignal (SignalName.Scored, DisplayName, shotPlayerName);
   }
 }

--- a/core/players/Player.Cosmetics.cs
+++ b/core/players/Player.Cosmetics.cs
@@ -13,6 +13,14 @@ public partial class Player
   // Restores the player's resting color: white glow while spawn armor holds, normal blue otherwise.
   private void RestoreBaseColor() => SetColor (SpawnArmor ? SpawnArmorColor : NormalColor);
 
+  // "On fire" glow visible from across the map while on a 3+ streak (see issue #77).
+  private void ApplyStreakGlow()
+  {
+    if (_streakLight == null) return;
+    _streakLight.Visible = IsOnStreak;
+    if (_nameTag != null) _nameTag.Modulate = IsOnStreak ? new Color (1.0f, 0.75f, 0.2f) : Colors.White;
+  }
+
   private void FlashHitColor()
   {
     SetColor (HitColor);

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -146,6 +146,7 @@ public partial class Player
   // input lock, so respawns are no longer instant teleports into the fight.
   private async void Respawn()
   {
+    ZapStreakCount = 0; // Any respawn ends the streak.
     Health = MaxHealth;
     Velocity = Vector3.Zero;
     Position = CalculateRandomSpawnPosition();

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -108,6 +108,21 @@ public partial class Player : CharacterBody3D
     }
   }
 
+  // Current zap streak, replicated so every peer can render the "on fire" glow &
+  // the pulsing leaderboard entry at 3+ (see issue #77).
+  [Export]
+  public int ZapStreakCount
+  {
+    get => _zapStreakCount;
+    set
+    {
+      _zapStreakCount = value;
+      ApplyStreakGlow();
+    }
+  }
+
+  public bool IsOnStreak => ZapStreakCount >= 3;
+
   [Export] public float SpawnArmorSeconds = 5.0f;
   [Export] public float MouseSensitivity = 0.0025f;
   [Export] public float FullAutoDurationSeconds = 3.0f;
@@ -131,10 +146,11 @@ public partial class Player : CharacterBody3D
   [Export] public float SlideCooldownSeconds = 5.0f;
   [Export] public float SlideCameraHeight = 0.6f;
   [Export] public float CrouchHeightScale = 0.6f;
-  [Export] public float CrouchSpeedMultiplier = 0.5f;
+  [Export] public float CrouchSpeedMultiplier = 0.3f;
   [Export] public float RocketBoostMultiplier = 1.5f;
   [Export] public float RocketBoostRange = 3.0f;
-  [Export] public float KnockbackStrength = 10.0f;
+  [Export] public float KnockbackStrength = 16.0f;
+  [Export] public int KillHealAmount = 50;
   [Export] public float PunchKnockbackScale = 0.33f;
   [Export] public float JumpVelocity = 20.0f;
   [Export] public Vector3 Gravity = new(0.0f, -50.0f, 0.0f);
@@ -152,6 +168,8 @@ public partial class Player : CharacterBody3D
   private ulong _spawnArmorEndMs;
   private bool _sliding;
   private bool _crouching;
+  private int _zapStreakCount;
+  private OmniLight3D _streakLight = null!;
   private float _slideSecondsLeft;
   private float _slideCooldownLeft;
   private float _standingCameraHeight;
@@ -209,6 +227,7 @@ public partial class Player : CharacterBody3D
     _hitRedTimer = GetNode <Timer> ("HitRedTimer");
     _nameTag = GetNode <Label3D> ("NameTag");
     _healthTag = GetNode <Sprite3D> ("HealthTag");
+    _streakLight = GetNode <OmniLight3D> ("StreakLight");
     _healthBar = GetNode <ProgressBar> ("SubViewport/HealthBar");
     _punchSound = GetNode <AudioStreamPlayer> ("PunchSound");
     _hitmarkerSound = GetNode <AudioStreamPlayer> ("HitmarkerSound");

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -87,6 +87,9 @@ properties/11/replication_mode = 2
 properties/12/path = NodePath(".:Crouching")
 properties/12/spawn = true
 properties/12/replication_mode = 2
+properties/13/path = NodePath(".:ZapStreakCount")
+properties/13/spawn = true
+properties/13/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2
@@ -100,6 +103,13 @@ billboard = 1
 no_depth_test = true
 text = "PlayerName"
 outline_size = 20
+
+[node name="StreakLight" type="OmniLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+visible = false
+light_color = Color(1, 0.6, 0.15, 1)
+light_energy = 4.0
+omni_range = 9.0
 
 [node name="HealthTag" type="Sprite3D" parent="."]
 transform = Transform3D(-0.18, 0, 6.34182e-08, 0, 0.1008, 0, -2.71793e-08, 0, -0.42, 0, 2.1, 0)

--- a/project.godot
+++ b/project.godot
@@ -108,6 +108,11 @@ crouch={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":67,"key_label":0,"unicode":99,"location":0,"echo":false,"script":null)
 ]
 }
+messages={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 quit={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -18,7 +18,7 @@ public partial class Hud : Control
   private MessageScroller _messageScroller = null!;
   private ConfirmationDialog2 _quitDialog = null!;
   private Label _scoreLabel = null!;
-  private Label _leaderboardEntries = null!;
+  private RichTextLabel _leaderboardEntries = null!;
   private ShaderMaterial _vignette = null!;
   private ShaderMaterial _blur = null!;
   private ProgressBar _shotBar = null!;
@@ -47,9 +47,15 @@ public partial class Hud : Control
   private void UpdateLeaderboard()
   {
     var players = _world.GetPlayers().OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName);
-    _leaderboardEntries.Text = string.Join ("\n", players.Select (player => $"{player.DisplayName}  {player.Score}"));
+    _leaderboardEntries.Text = string.Join ("\n", players.Select (LeaderboardEntry));
     UpdateScoreLabel();
   }
+
+  // 3+ streak entries glow & pulse so the hot player stands out (see issue #77).
+  private static string LeaderboardEntry (players.Player player) =>
+    player.IsOnStreak
+      ? $"[pulse freq=1.5 color=#ffd24d ease=-2.0][wave amp=18.0 freq=4.0][b]{player.DisplayName}  {player.Score}[/b][/wave][/pulse]"
+      : $"{player.DisplayName}  {player.Score}";
 
   // Score can also drop (fall penalty), so the label reads the replicated value.
   private void UpdateScoreLabel() => _scoreLabel.Text = $"Score: {_world.SelfPlayer?.Score ?? 0}";
@@ -65,7 +71,7 @@ public partial class Hud : Control
     _healthBar = GetNode <ProgressBar> ("VBoxContainer/Health/ProgressBar");
     _messageScroller = GetNode <MessageScroller> ("MessageScroller");
     _scoreLabel = GetNode <Label> ("VBoxContainer/Score/Label");
-    _leaderboardEntries = GetNode <Label> ("Leaderboard/MarginContainer/VBoxContainer/Entries");
+    _leaderboardEntries = GetNode <RichTextLabel> ("Leaderboard/MarginContainer/VBoxContainer/Entries");
     _vignette = (ShaderMaterial)GetNode <ColorRect> ("Vignette").Material;
     _blur = (ShaderMaterial)GetNode <ColorRect> ("Blur").Material;
     _shotBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Shot/Bar");

--- a/ui/hud/Hud.tscn
+++ b/ui/hud/Hud.tscn
@@ -199,9 +199,13 @@ theme_override_font_sizes/font_size = 48
 text = "Leaderboard"
 horizontal_alignment = 1
 
-[node name="Entries" type="Label" parent="Leaderboard/MarginContainer/VBoxContainer"]
+[node name="Entries" type="RichTextLabel" parent="Leaderboard/MarginContainer/VBoxContainer"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 38
+theme_override_font_sizes/normal_font_size = 38
+theme_override_font_sizes/bold_font_size = 40
+bbcode_enabled = true
+fit_content = true
+scroll_active = false
 text = ""
 
 [node name="LeaderboardTimer" type="Timer" parent="."]

--- a/ui/hud/messages/MessageScroller.cs
+++ b/ui/hud/messages/MessageScroller.cs
@@ -27,8 +27,6 @@ public partial class MessageScroller : Control
   private Label _messageLabel2 = null!;
   private Label _messageLabel3 = null!;
   private Label _messageLabel4 = null!;
-  private Button _expandMessagesButton = null!;
-  private Button _collapseMessagesButton = null!;
   private MarginContainer _messageContainer = null!;
   private MarginContainer _messageHistoryContainer = null!;
   private RichTextLabel _messageHistoryLabel = null!;
@@ -83,11 +81,7 @@ public partial class MessageScroller : Control
     _messageContainer = GetNode <MarginContainer> ("MarginContainer");
     _messageHistoryContainer = GetNode <MarginContainer> ("History");
     _messageHistoryLabel = GetNode <RichTextLabel> ("History/VBoxContainer/MarginContainer/RichTextLabel");
-    _expandMessagesButton = GetNode <Button> ("MarginContainer/VBoxContainer/Expand/TextureButton");
-    _collapseMessagesButton = GetNode <Button> ("History/VBoxContainer/Collapse/TextureButton");
     _messageTimer = GetNode <Timer> ("MessageTimer");
-    _expandMessagesButton.Pressed += _OnExpandMessagesButtonPressed;
-    _collapseMessagesButton.Pressed += _OnCollapseMessagesButtonPressed;
     _messageTimer.Timeout += _OnMessageTimerTimeout;
     Reset();
   }
@@ -115,16 +109,25 @@ public partial class MessageScroller : Control
     HideMessageHistory();
   }
 
-  private void _OnExpandMessagesButtonPressed()
+  // Tab toggles the full message history - a clickable button can't work while the
+  // mouse is captured for aiming (see issue #74).
+  public override void _UnhandledInput (InputEvent @event)
   {
-    ShowMessageHistory();
-    EmitSignal (SignalName.OnMessageScrollerExpanded);
+    if (!Input.IsActionJustPressed ("messages")) return;
+    ToggleMessageHistory();
   }
 
-  private void _OnCollapseMessagesButtonPressed()
+  private void ToggleMessageHistory()
   {
-    HideMessageHistory();
-    EmitSignal (SignalName.OnMessageScrollerCollapsed);
+    if (IsMessageHistoryVisible())
+    {
+      HideMessageHistory();
+      EmitSignal (SignalName.OnMessageScrollerCollapsed);
+      return;
+    }
+
+    ShowMessageHistory();
+    EmitSignal (SignalName.OnMessageScrollerExpanded);
   }
 
   private void DisplayNextMessage()

--- a/ui/hud/messages/MessageScroller.tscn
+++ b/ui/hud/messages/MessageScroller.tscn
@@ -82,13 +82,14 @@ size_flags_vertical = 3
 size_flags_stretch_ratio = 1.2
 mouse_filter = 2
 
-[node name="TextureButton" type="Button" parent="MarginContainer/VBoxContainer/Expand"]
-custom_minimum_size = Vector2(360, 48)
+[node name="Hint" type="Label" parent="MarginContainer/VBoxContainer/Expand"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 3
-theme_override_font_sizes/font_size = 30
-text = "Messages  ▼"
+modulate = Color(1, 1, 1, 0.45)
+theme_override_font_sizes/font_size = 22
+text = "Tab — messages"
+horizontal_alignment = 1
 
 [node name="History" type="MarginContainer" parent="."]
 visible = false
@@ -179,10 +180,11 @@ size_flags_horizontal = 3
 size_flags_vertical = 9
 mouse_filter = 2
 
-[node name="TextureButton" type="Button" parent="History/VBoxContainer/Collapse"]
-custom_minimum_size = Vector2(360, 48)
+[node name="Hint" type="Label" parent="History/VBoxContainer/Collapse"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 3
-theme_override_font_sizes/font_size = 30
-text = "Messages  ▲"
+modulate = Color(1, 1, 1, 0.45)
+theme_override_font_sizes/font_size = 22
+text = "Tab — close"
+horizontal_alignment = 1


### PR DESCRIPTION
## Summary
- **#74**: message history toggles with **Tab** (a clickable button can't work while the mouse is captured for aiming); giant button replaced with subtle translucent hints.
- **#76**: zapping someone out heals the attacker **+50 HP** (capped at max).
- **#77**: replicated `ZapStreakCount` — at 3+ the player gets an orange **"on fire" omni-light glow** visible from across the map, an orange name tag, and a **pulsing/waving gold leaderboard entry** (RichTextLabel BBCode). Any respawn ends the streak. Knockback 10 → 16.
- **#75**: crouch speed 0.5× → 0.3×.

Fixes #74
Fixes #75
Fixes #76
Fixes #77

## Testing
- `dotnet build` clean; full 3-instance playtest green (one hit of the pre-existing end-of-run Score-replication flake, now tracked in its own issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)