### PR TITLE
Banana lobbing & splatter, boxer fists with stacking stun, & cold respawn weapon

### DIFF
--- a/core/players/Player.Banana.cs
+++ b/core/players/Player.Banana.cs
@@ -21,11 +21,16 @@ public partial class Player
     }
   }
 
+  [Signal] public delegate void SplatteredEventHandler();
+  // 0..1 readiness for the HUD's Banana cooldown bar (1 = ready), see issue #70.
+  public float BananaReadyFraction => _bananaLauncher.CooldownFraction;
+
   private void UpdateWeaponVisibility()
   {
     if (_bananaLauncher == null) return;
     _bananaLauncher.Visible = _isBananaEquipped;
     _energyWeapon.Visible = !_isBananaEquipped;
+    UpdateHandRestPositions(); // Hands follow the visible weapon's grip (issue #71).
   }
 
   private void UpdateWeaponSelection()
@@ -100,6 +105,8 @@ public partial class Player
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
     GD.Print ($"{DisplayName}: I was blasted by {firedByPlayerName}'s banana!");
+    ApplyBananaStun(); // Flat 5s stun synced with the splatter overlay (issue #70).
+    EmitSignal (SignalName.Splattered);
     ApplyBlastKnockback (blastOrigin);
     // Blast knockback is applied radially above; no directional knockback on top.
     ApplyDamage (energy, firedByPlayerName, knockbackScale: 0.0f, isSurvivableAtFullHealth: true);

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -87,9 +87,12 @@ public partial class Player
     if (!_isInputEnabled || _punchCooldownLeft > 0.0f || !Input.IsActionJustPressed ("punch")) return;
     _punchCooldownLeft = PunchCooldownSeconds;
     CancelSpawnArmorIfFired(); // Punching drops your spawn armor, same as firing.
-    _punchSound.Play();
+    var hand = ChooseRandomPunchHand();
+    AnimatePunch (hand);
+    Rpc (MethodName.PlayRemotePunch, hand);
     var victim = FindAimedPlayer (PunchRange);
     if (victim == null) return;
+    _punchSound.Play(); // Connect-only (issue #71): no sound on a whiffed swing.
     GD.Print ($"{DisplayName}: I punched {victim.DisplayName}!");
     victim.RpcId (victim.NetworkId, MethodName.ReceivePunch, DisplayName);
   }
@@ -173,8 +176,26 @@ public partial class Player
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
     GD.Print ($"{DisplayName}: I was punched by {punchedByPlayerName}!");
+    _punchSound.Play(); // The victim hears the connect too (issue #71).
+    ApplyPunchStun(); // Stacking slow; the blur stacks HUD-side via Punched (issues #68 & #71).
+    TryDropWeaponFromPunch();
     EmitSignal (SignalName.Punched);
     ApplyDamage (PunchEnergy, punchedByPlayerName, PunchKnockbackScale);
+  }
+
+  // 20% chance a connect knocks the victim's weapon loose (issue #71). The pickup/drop
+  // system lands in another branch; until DropHeldWeapon() exists, this just logs.
+  private void TryDropWeaponFromPunch()
+  {
+    if (_rng.Randf() >= PunchDropChance) return;
+
+    if (!HasMethod ("DropHeldWeapon"))
+    {
+      GD.Print ($"{DisplayName}: That punch nearly knocked my weapon loose!");
+      return;
+    }
+
+    Call ("DropHeldWeapon");
   }
 
   // One-per-life full heal (issue #62): restocked on every (re)spawn.

--- a/core/players/Player.Hands.cs
+++ b/core/players/Player.Hands.cs
@@ -1,0 +1,68 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Floating sphere hands (issue #71): two translucent player-colored fists on the
+// camera that grip the visible weapon, with a boxer-style punch animation that
+// replicates to every peer (same pattern as SpawnVisualLaser).
+public partial class Player
+{
+  [Export] public float HandRadius = 0.11f;
+  [Export] public float PunchExtendMeters = 1.2f;
+  [Export] public float PunchAnimationSeconds = 0.25f;
+  [Export] public Vector3 EnergyGripLeftOffset = new(0.42f, 0.16f, -1.5f);
+  [Export] public Vector3 EnergyGripRightOffset = new(0.58f, 0.14f, -0.95f);
+  [Export] public Vector3 BananaGripLeftOffset = new(0.38f, -0.42f, -1.25f);
+  [Export] public Vector3 BananaGripRightOffset = new(0.52f, -0.45f, -0.65f);
+  private readonly MeshInstance3D?[] _hands = new MeshInstance3D?[2];
+  private readonly Tween?[] _handTweens = new Tween?[2];
+  private int ChooseRandomPunchHand() => _rng.Randf() < 0.5f ? 0 : 1;
+
+  // Runs on every peer so everyone sees everyone's hands.
+  private void CreateHands()
+  {
+    var camera = GetNode <Node3D> ("Camera3D");
+    var material = new StandardMaterial3D { AlbedoColor = new Color (NormalColor, 0.65f), Transparency = BaseMaterial3D.TransparencyEnum.Alpha, Roughness = 0.4f };
+    for (var i = 0; i < _hands.Length; ++i) _hands[i] = CreateHand (camera, material);
+    UpdateHandRestPositions();
+  }
+
+  private MeshInstance3D CreateHand (Node3D camera, StandardMaterial3D material)
+  {
+    var hand = new MeshInstance3D { Mesh = new SphereMesh { Radius = HandRadius, Height = HandRadius * 2.0f }, MaterialOverride = material };
+    camera.AddChild (hand);
+    return hand;
+  }
+
+  // Hands hold whichever weapon is visible; simple fixed grip offsets (issue #71).
+  private void UpdateHandRestPositions()
+  {
+    if (_hands[0] == null || _hands[1] == null) return;
+    _hands[0]!.Position = RestOffsetFor (hand: 0);
+    _hands[1]!.Position = RestOffsetFor (hand: 1);
+  }
+
+  private Vector3 RestOffsetFor (int hand)
+  {
+    if (hand == 0) return _isBananaEquipped ? BananaGripLeftOffset : EnergyGripLeftOffset;
+    return _isBananaEquipped ? BananaGripRightOffset : EnergyGripRightOffset;
+  }
+
+  // Boxer-style swing: the chosen hand visibly shoots forward & back (issue #71).
+  private void AnimatePunch (int hand)
+  {
+    var handNode = _hands[hand];
+    if (handNode == null) return;
+    _handTweens[hand]?.Kill();
+    var rest = RestOffsetFor (hand);
+    handNode.Position = rest;
+    var tween = handNode.CreateTween();
+    tween.TweenProperty (handNode, "position", rest + Vector3.Forward * PunchExtendMeters, PunchAnimationSeconds * 0.4f).SetTrans (Tween.TransitionType.Quad).SetEase (Tween.EaseType.Out);
+    tween.TweenProperty (handNode, "position", rest, PunchAnimationSeconds * 0.6f).SetTrans (Tween.TransitionType.Quad).SetEase (Tween.EaseType.In);
+    _handTweens[hand] = tween;
+  }
+
+  // Peers replay this player's punch animation on their copy of this node.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void PlayRemotePunch (int hand) => AnimatePunch (hand);
+}

--- a/core/players/Player.Hands.cs.uid
+++ b/core/players/Player.Hands.cs.uid
@@ -1,0 +1,1 @@
+uid://drn65iitf2l7w

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -7,12 +7,13 @@ namespace com.forerunnergames.energyshot.players;
 public partial class Player
 {
   private bool IsFalling() => !IsOnFloor();
-  private bool IsJumping() => _isInputEnabled && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
+  // Stun blocks jumping & sliding (issues #70 & #71).
+  private bool IsJumping() => _isInputEnabled && !IsStunned && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
   private void Fall (ref Vector3 velocity, double delta) => velocity += Gravity * (float)delta;
-  private bool WantsSlide() => _isInputEnabled && Input.IsActionPressed ("slide");
+  private bool WantsSlide() => _isInputEnabled && !IsStunned && Input.IsActionPressed ("slide");
   // Slide wins: crouch is ignored while sliding (see issue #51).
   private bool WantsCrouch() => _isInputEnabled && !Sliding && Input.IsActionPressed ("crouch");
-  private float MoveSpeed() => Sliding ? Speed * SlideSpeedMultiplier : _crouching ? Speed * CrouchSpeedMultiplier : Speed;
+  private float MoveSpeed() => (Sliding ? Speed * SlideSpeedMultiplier : _crouching ? Speed * CrouchSpeedMultiplier : Speed) * StunSpeedMultiplier();
 
   // Hold to slide: double speed & a horizontal pose, capped at SlideDurationSeconds,
   // then a cooldown before the next slide (see issue #41).
@@ -151,6 +152,8 @@ public partial class Player
     Velocity = Vector3.Zero;
     Position = CalculateRandomSpawnPosition();
     _bread.Restock(); // Fresh bread every life (issue #62).
+    _energyWeapon.ResetCharge(); // Every life starts with a cold weapon (issue #67).
+    ClearStun(); // Death shakes off any punch/banana stun.
     ActivateSpawnArmor();
     SetInputEnabled (isEnabled: false);
     _respawnSound.Play();

--- a/core/players/Player.Shake.cs
+++ b/core/players/Player.Shake.cs
@@ -1,0 +1,38 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Camera shake (issue #70): a decaying random offset when a banana explodes nearby,
+// triggered on every peer via the visual-banana path. Uses the camera's h/v offsets
+// so the replicated camera transform is untouched.
+public partial class Player
+{
+  [Export] public float ExplosionShakeRadius = 20.0f;
+  [Export] public float ExplosionShakeSeconds = 0.4f;
+  [Export] public float ExplosionShakeMagnitude = 0.35f;
+  private float _shakeSecondsLeft;
+  private float _shakeStrength;
+
+  // Called by every exploding banana (live & visual copies alike); only the local
+  // player's camera shakes, with magnitude falling off by distance.
+  public static void NotifyExplosionAt (Vector3 origin) => _localPlayer?.StartShakeFrom (origin);
+
+  private void StartShakeFrom (Vector3 origin)
+  {
+    var distance = GlobalPosition.DistanceTo (origin);
+    if (distance > ExplosionShakeRadius) return;
+    _shakeStrength = Mathf.Max (_shakeStrength, ExplosionShakeMagnitude * (1.0f - distance / ExplosionShakeRadius));
+    _shakeSecondsLeft = ExplosionShakeSeconds;
+  }
+
+  private void UpdateCameraShake (double delta)
+  {
+    if (_shakeSecondsLeft <= 0.0f) return;
+    _shakeSecondsLeft = Mathf.Max (0.0f, _shakeSecondsLeft - (float)delta);
+    var falloff = _shakeSecondsLeft / ExplosionShakeSeconds;
+    _camera.HOffset = _rng.RandfRange (-1.0f, 1.0f) * _shakeStrength * falloff;
+    _camera.VOffset = _rng.RandfRange (-1.0f, 1.0f) * _shakeStrength * falloff;
+    if (_shakeSecondsLeft > 0.0f) return;
+    _shakeStrength = 0.0f;
+  }
+}

--- a/core/players/Player.Shake.cs.uid
+++ b/core/players/Player.Shake.cs.uid
@@ -1,0 +1,1 @@
+uid://c0j7i0bi0q57r

--- a/core/players/Player.Stun.cs
+++ b/core/players/Player.Stun.cs
@@ -1,0 +1,47 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Shared stun system (issues #70 & #71): while stunned, walking slows & jumping &
+// sliding are blocked. Punch stuns stack (heavier stack = slower); banana blasts
+// fully stun for a flat window synced with the splatter overlay.
+public partial class Player
+{
+  // Replicated so every peer can see how stunned this player is; only the victim writes it.
+  [Export] public float StunFactor { get; set; }
+  [Export] public float StunMaxSlow = 0.6f;
+  [Export] public float PunchStunFactorStep = 0.34f;
+  [Export] public float PunchStunSeconds = 3.0f;
+  [Export] public float BananaStunSeconds = 5.0f;
+  private float _stunSecondsLeft;
+  private bool IsStunned => _stunSecondsLeft > 0.0f;
+  private float StunSpeedMultiplier() => 1.0f - StunFactor * StunMaxSlow;
+
+  // Punch stuns stack: every connect adds slow, so a flurry grinds the victim down (issue #71).
+  private void ApplyPunchStun()
+  {
+    StunFactor = Mathf.Min (1.0f, StunFactor + PunchStunFactorStep);
+    _stunSecondsLeft = Mathf.Max (_stunSecondsLeft, PunchStunSeconds);
+  }
+
+  // Banana blasts fully stun for a flat window, synced with the splatter overlay (issue #70).
+  private void ApplyBananaStun()
+  {
+    StunFactor = 1.0f;
+    _stunSecondsLeft = Mathf.Max (_stunSecondsLeft, BananaStunSeconds);
+  }
+
+  private void UpdateStun (double delta)
+  {
+    if (!IsStunned) return;
+    _stunSecondsLeft -= (float)delta;
+    if (IsStunned) return;
+    ClearStun();
+  }
+
+  private void ClearStun()
+  {
+    _stunSecondsLeft = 0.0f;
+    StunFactor = 0.0f;
+  }
+}

--- a/core/players/Player.Stun.cs.uid
+++ b/core/players/Player.Stun.cs.uid
@@ -1,0 +1,1 @@
+uid://c2p4jyflhl25u

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -132,8 +132,10 @@ public partial class Player : CharacterBody3D
   // Brief - the spawn room & spawn armor already prevent instant re-engagement (#48).
   [Export] public float RespawnInputLockSeconds = 0.3f;
   [Export] public float PunchCooldownSeconds = 0.6f;
-  [Export] public float PunchRange = 2.5f;
+  // Longer than physically normal - close-range fights were too hard to land (issue #71).
+  [Export] public float PunchRange = 4.0f;
   [Export] public float PunchEnergy = 0.2f;
+  [Export] public float PunchDropChance = 0.2f;
   [Export] public float BananaBlastRadius = 6.0f;
   [Export] public float BananaDirectRadius = 1.5f;
   [Export] public float BananaBlastEnergy = 0.9f;
@@ -222,6 +224,7 @@ public partial class Player : CharacterBody3D
     _energyWeapon = GetNode <EnergyWeapon> ("Camera3D/EnergyWeapon");
     _bananaLauncher = GetNode <BananaLauncher> ("Camera3D/BananaLauncher");
     UpdateWeaponVisibility();
+    CreateHands();
     _crossHairs = GetNode <Sprite3D> ("Camera3D/Crosshairs");
     _jumpTimer = GetNode <Timer> ("JumpTimer");
     _hitRedTimer = GetNode <Timer> ("HitRedTimer");
@@ -288,6 +291,8 @@ public partial class Player : CharacterBody3D
     UpdateFullAuto (delta);
     UpdatePunch (delta);
     UpdateCameraKick (delta);
+    UpdateCameraShake (delta);
+    UpdateStun (delta);
     UpdateSlide (delta);
     UpdateCrouch();
     var velocity = Velocity;

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -90,6 +90,9 @@ properties/12/replication_mode = 2
 properties/13/path = NodePath(".:ZapStreakCount")
 properties/13/spawn = true
 properties/13/replication_mode = 2
+properties/14/path = NodePath(".:StunFactor")
+properties/14/spawn = true
+properties/14/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/core/weapons/BananaLauncher.cs
+++ b/core/weapons/BananaLauncher.cs
@@ -3,14 +3,16 @@ using Godot;
 namespace com.forerunnergames.energyshot.weapons;
 
 // Single-use banana launcher (issue #61): selected with the weapon_2 action, it
-// replaces the energy weapon visually & fires one arcing banana, then goes on a
-// long cooldown (the player auto-switches back to the laser meanwhile).
+// replaces the energy weapon visually & fires one lobbed banana, then reloads
+// quickly (issue #70) while the player auto-switches back to the laser.
 public partial class BananaLauncher : Node3D
 {
-  [Export] public float CooldownSeconds = 10.0f;
+  [Export] public float CooldownSeconds = 1.5f;
   private static readonly Color BananaYellow = new(0.92f, 0.78f, 0.12f);
   private float _cooldownLeft;
   public bool CanFire => _cooldownLeft <= 0.0f;
+  // 0..1 readiness (1 = ready) for the HUD cooldown bar (issue #70).
+  public float CooldownFraction => 1.0f - _cooldownLeft / CooldownSeconds;
   public void StartCooldown() => _cooldownLeft = CooldownSeconds;
   public override void _Ready() => ApplyRifleVisuals();
   public override void _PhysicsProcess (double delta) => _cooldownLeft = Mathf.Max (0.0f, _cooldownLeft - (float)delta);

--- a/core/weapons/BananaProjectile.cs
+++ b/core/weapons/BananaProjectile.cs
@@ -1,16 +1,21 @@
+using com.forerunnergames.energyshot.players;
 using Godot;
 
 namespace com.forerunnergames.energyshot.weapons;
 
-// A lobbed banana that arcs under gravity & explodes on impact with a big yellow
-// flash (issue #61). Only the shooter's own banana is "live" (reports the blast);
-// other peers spawn visual-only copies. Impacts are detected by sweeping a ray
-// along the path traveled each physics frame, same as LaserBolt.
+// A lobbed banana grenade (issues #61 & #70): launched fast on a proper gravity arc,
+// it bounces & slides off surfaces (dampened) with a short fuse lit by first contact,
+// explodes instantly on a direct player hit, & shakes every nearby camera. Only the
+// shooter's own banana is "live" (reports the blast); other peers spawn visual-only
+// copies. Impacts are detected by sweeping a ray along the path traveled each physics
+// frame, same as LaserBolt.
 public partial class BananaProjectile : Node3D
 {
-  [Export] public float Speed = 22.0f;
-  [Export] public float GravityAcceleration = 30.0f;
-  [Export] public float MaxLifetimeSeconds = 6.0f;
+  [Export] public float Speed = 40.0f;
+  [Export] public float GravityAcceleration = 24.0f;
+  [Export] public float MaxLifetimeSeconds = 8.0f;
+  [Export] public float FuseSeconds = 1.2f;
+  [Export] public float Restitution = 0.55f;
   [Export] public float SpinRadiansPerSecond = 10.0f;
   [Export] public float FlashRadius = 6.0f;
   [Export] public float FlashSeconds = 0.4f;
@@ -20,6 +25,8 @@ public partial class BananaProjectile : Node3D
   private Vector3 _velocity;
   private float _age;
   private bool _isLive;
+  private bool _fuseLit;
+  private float _fuseSecondsLeft;
   private Rid _shooterRid;
   private MeshInstance3D _mesh = null!;
 
@@ -42,8 +49,9 @@ public partial class BananaProjectile : Node3D
   {
     var dt = (float)delta;
     _age += dt;
+    if (_fuseLit) _fuseSecondsLeft -= dt;
 
-    if (_age > MaxLifetimeSeconds)
+    if (_age > MaxLifetimeSeconds || (_fuseLit && _fuseSecondsLeft <= 0.0f))
     {
       Explode (GlobalPosition);
       return;
@@ -57,19 +65,44 @@ public partial class BananaProjectile : Node3D
     query.HitFromInside = true;
     var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
 
-    if (hit.Count > 0)
+    if (hit.Count == 0)
+    {
+      GlobalPosition = to;
+      return;
+    }
+
+    // A direct player hit skips the bounce: instant boom (issue #70).
+    if (hit["collider"].AsGodotObject() is CharacterBody3D)
     {
       Explode ((Vector3)hit["position"]);
       return;
     }
 
-    GlobalPosition = to;
+    Bounce (hit);
+  }
+
+  // Surfaces don't stop the banana outright: it bounces & slides, dampened each
+  // contact, & the first contact lights the fuse (issue #70).
+  private void Bounce (Godot.Collections.Dictionary hit)
+  {
+    LightFuse();
+    var normal = (Vector3)hit["normal"];
+    _velocity = _velocity.Bounce (normal) * Restitution;
+    GlobalPosition = (Vector3)hit["position"] + normal * 0.05f;
+  }
+
+  private void LightFuse()
+  {
+    if (_fuseLit) return;
+    _fuseLit = true;
+    _fuseSecondsLeft = FuseSeconds;
   }
 
   private void Explode (Vector3 origin)
   {
     if (_isLive) EmitSignal (SignalName.Exploded, origin);
     SpawnFlash (origin);
+    Player.NotifyExplosionAt (origin); // Every peer's own camera shakes if nearby (issue #70).
     QueueFree();
   }
 

--- a/core/weapons/EnergyWeapon.cs
+++ b/core/weapons/EnergyWeapon.cs
@@ -64,6 +64,18 @@ public partial class EnergyWeapon : Node3D
     if (_cooldownLeft > 0.0f || _isFullAutoMode) return;
     SpinUp();
   }
+
+  // Cold-starts the weapon on respawn (issue #67): cancels the charge state, spin
+  // tween, charging sound, & charged color instantly, so dying mid-charge can't
+  // carry a max-energy shot into the next life.
+  public void ResetCharge()
+  {
+    IsSpinningUp = false;
+    _chargingSound.Stop();
+    _tween?.Kill();
+    _currentRotationSpeed = MinRotationSpeed;
+    WeaponColor = _isFullAutoMode ? FullAutoColor : _normalColor;
+  }
   private void Rotate (double delta) => _pivot.Rotate (Vector3.Right, _currentRotationSpeed * (float)delta);
   private bool IsRecoilRecovered() => _recoilOffset.Length() <= 0.01f;
   private float CalculateEnergy() => _currentRotationSpeed / MaxRotationSpeed;

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -16,6 +16,7 @@ public partial class World : Node3D
   [Signal] public delegate void PlayerRespawnedFellEventHandler (string playerName);
   [Signal] public delegate void SelfPlayerHealthChangedEventHandler (string playerName, int health);
   [Signal] public delegate void SelfPlayerPunchedEventHandler();
+  [Signal] public delegate void SelfPlayerSplatteredEventHandler();
   [Signal] public delegate void RemoteMessageReceivedEventHandler (string message);
   [Signal] public delegate void KickedFromServerEventHandler (string reason);
   [Signal] public delegate void ServerShutDownEventHandler();
@@ -210,6 +211,7 @@ public partial class World : Node3D
     _selfPlayer = selfPlayer;
     selfPlayer.HealthChanged += value => EmitSignal (SignalName.SelfPlayerHealthChanged, selfPlayer.DisplayName, value);
     selfPlayer.Punched += () => EmitSignal (SignalName.SelfPlayerPunched);
+    selfPlayer.Splattered += () => EmitSignal (SignalName.SelfPlayerSplattered);
     selfPlayer.Scored += (playerName, shotPlayerName) => EmitSignal (SignalName.PlayerScored, ++_score, playerName, shotPlayerName);
     GD.Print ($"{_selfPlayer.NetworkId}: Registered my player {_selfPlayer.DisplayName}");
     EmitSignal (SignalName.NewGameStarted, _selfPlayer.DisplayName, _selfPlayer.MaxHealth);

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -21,10 +21,16 @@ public partial class Hud : Control
   private RichTextLabel _leaderboardEntries = null!;
   private ShaderMaterial _vignette = null!;
   private ShaderMaterial _blur = null!;
+  private ShaderMaterial _splatter = null!;
   private ProgressBar _shotBar = null!;
   private ProgressBar _punchBar = null!;
   private ProgressBar _fullAutoBar = null!;
+  private ProgressBar _bananaBar = null!;
   private float _blurIntensity;
+  private float _splatterSecondsLeft;
+  private float _splatterSlide;
+  private const float SplatterSeconds = 5.0f; // Matches the banana stun window (issue #70).
+  private const float SplatterSlidePerSecond = 0.06f;
   private int _zapStreak;
   private int _zappedStreak;
   private int _fallStreak;
@@ -74,10 +80,13 @@ public partial class Hud : Control
     _leaderboardEntries = GetNode <RichTextLabel> ("Leaderboard/MarginContainer/VBoxContainer/Entries");
     _vignette = (ShaderMaterial)GetNode <ColorRect> ("Vignette").Material;
     _blur = (ShaderMaterial)GetNode <ColorRect> ("Blur").Material;
+    _splatter = (ShaderMaterial)GetNode <ColorRect> ("Splatter").Material;
     _shotBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Shot/Bar");
     _punchBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Punch/Bar");
     _fullAutoBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/FullAuto/Bar");
+    _bananaBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Banana/Bar");
     _world.SelfPlayerPunched += OnSelfPlayerPunched;
+    _world.SelfPlayerSplattered += OnSelfPlayerSplattered;
     GetNode <Timer> ("LeaderboardTimer").Timeout += UpdateLeaderboard;
     _quitDialog = GetNode <ConfirmationDialog2> ("QuitDialog");
     _quitDialog.Confirmed += () => EmitSignal (SignalName.GameQuit);
@@ -104,15 +113,28 @@ public partial class Hud : Control
   public override void _Process (double delta)
   {
     UpdateBlur (delta);
+    UpdateSplatter (delta);
     UpdateCooldownBars();
   }
 
-  // Punch blur stacks per hit & fades back to sharp.
+  // Punch blur stacks per hit & fades back to sharp; a heavy stack fades slower, so
+  // being near-blind lingers (issue #68).
   private void UpdateBlur (double delta)
   {
     if (_blurIntensity <= 0.0f) return;
-    _blurIntensity = Mathf.Max (0.0f, _blurIntensity - 0.25f * (float)delta);
+    var fadePerSecond = Mathf.Lerp (0.25f, 0.1f, _blurIntensity);
+    _blurIntensity = Mathf.Max (0.0f, _blurIntensity - fadePerSecond * (float)delta);
     _blur.SetShaderParameter ("intensity", _blurIntensity);
+  }
+
+  // The splat slides slowly down the screen & fades out with the banana stun (issue #70).
+  private void UpdateSplatter (double delta)
+  {
+    if (_splatterSecondsLeft <= 0.0f) return;
+    _splatterSecondsLeft = Mathf.Max (0.0f, _splatterSecondsLeft - (float)delta);
+    _splatterSlide += SplatterSlidePerSecond * (float)delta;
+    _splatter.SetShaderParameter ("slide", _splatterSlide);
+    _splatter.SetShaderParameter ("intensity", _splatterSecondsLeft / SplatterSeconds);
   }
 
   private void UpdateCooldownBars()
@@ -122,12 +144,22 @@ public partial class Hud : Control
     _shotBar.Value = self.ShotReadyFraction;
     _punchBar.Value = self.PunchReadyFraction;
     _fullAutoBar.Value = self.FullAutoReadyFraction;
+    _bananaBar.Value = self.BananaReadyFraction;
   }
 
+  // ~3 hits reach max blur (issue #68): the shader's top LOD is a near-whiteout.
   private void OnSelfPlayerPunched()
   {
-    _blurIntensity = Mathf.Min (1.0f, _blurIntensity + 0.34f);
+    _blurIntensity = Mathf.Min (1.0f, _blurIntensity + 0.4f);
     _blur.SetShaderParameter ("intensity", _blurIntensity);
+  }
+
+  private void OnSelfPlayerSplattered()
+  {
+    _splatterSecondsLeft = SplatterSeconds;
+    _splatterSlide = 0.0f;
+    _splatter.SetShaderParameter ("slide", 0.0f);
+    _splatter.SetShaderParameter ("intensity", 1.0f);
   }
 
   private void OnNewGameStarted (string selfPlayerName, int selfMaxHealth)

--- a/ui/hud/Hud.tscn
+++ b/ui/hud/Hud.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=12 format=3 uid="uid://cobme7o27cxru"]
+[gd_scene load_steps=14 format=3 uid="uid://cobme7o27cxru"]
 
 [ext_resource type="Script" path="res://ui/hud/Hud.cs" id="1_5s36p"]
 [ext_resource type="PackedScene" uid="uid://huun2vjv0k1v" path="res://ui/hud/messages/MessageScroller.tscn" id="1_6ovnf"]
 [ext_resource type="PackedScene" uid="uid://bmpjrf8pqokyu" path="res://ui/dialogs/confirm/ConfirmationDialog2.tscn" id="3_v7kl8"]
 [ext_resource type="Shader" path="res://ui/hud/vignette.gdshader" id="4_vgntt"]
 [ext_resource type="Shader" path="res://ui/hud/blur.gdshader" id="5_blur"]
+[ext_resource type="Shader" path="res://ui/hud/splatter.gdshader" id="6_spltr"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_vgntt"]
 shader = ExtResource("4_vgntt")
@@ -13,6 +14,11 @@ shader_parameter/intensity = 0.0
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_blur"]
 shader = ExtResource("5_blur")
 shader_parameter/intensity = 0.0
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_spltr"]
+shader = ExtResource("6_spltr")
+shader_parameter/intensity = 0.0
+shader_parameter/slide = 0.0
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ldrbd"]
 bg_color = Color(0, 0, 0, 0.392157)
@@ -69,6 +75,16 @@ mouse_filter = 2
 
 [node name="Vignette" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_vgntt")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="Splatter" type="ColorRect" parent="."]
+material = SubResource("ShaderMaterial_spltr")
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -152,6 +168,25 @@ theme_override_font_sizes/font_size = 28
 text = "Full-Auto"
 
 [node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/FullAuto"]
+custom_minimum_size = Vector2(0, 22)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 1.0
+show_percentage = false
+
+[node name="Banana" type="HBoxContainer" parent="VBoxContainer/Cooldowns"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer/Cooldowns/Banana"]
+custom_minimum_size = Vector2(220, 0)
+layout_mode = 2
+theme_override_font_sizes/font_size = 28
+text = "Banana"
+
+[node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/Banana"]
 custom_minimum_size = Vector2(0, 22)
 layout_mode = 2
 size_flags_horizontal = 3

--- a/ui/hud/blur.gdshader
+++ b/ui/hud/blur.gdshader
@@ -1,10 +1,11 @@
 shader_type canvas_item;
 
-// Screen blur that stacks with punches received & fades back to sharp.
+// Screen blur that stacks with punches received & fades back to sharp. Max LOD is a
+// near-whiteout of detail so a full stack leaves the victim barely able to see (#68).
 uniform sampler2D screen_tex : hint_screen_texture, filter_linear_mipmap;
 uniform float intensity : hint_range(0.0, 1.0) = 0.0;
 
 void fragment() {
-	vec4 blurred = textureLod(screen_tex, SCREEN_UV, intensity * 4.5);
+	vec4 blurred = textureLod(screen_tex, SCREEN_UV, intensity * 7.0);
 	COLOR = vec4(blurred.rgb, clamp(intensity * 20.0, 0.0, 1.0));
 }

--- a/ui/hud/splatter.gdshader
+++ b/ui/hud/splatter.gdshader
@@ -1,0 +1,24 @@
+shader_type canvas_item;
+
+// Banana splatter (issue #70): procedural semi-transparent yellow blobs that slide
+// slowly down the screen & fade out, synced with the banana stun. No external assets.
+uniform float intensity : hint_range(0.0, 1.0) = 0.0;
+uniform float slide = 0.0;
+
+float blob(vec2 uv, vec2 center, float radius) {
+	return 1.0 - smoothstep(radius * 0.55, radius, distance(uv, center));
+}
+
+void fragment() {
+	vec2 uv = vec2(UV.x, UV.y - slide);
+	float a = 0.0;
+	a = max(a, blob(uv, vec2(0.18, 0.22), 0.16));
+	a = max(a, blob(uv, vec2(0.52, 0.10), 0.22));
+	a = max(a, blob(uv, vec2(0.82, 0.28), 0.14));
+	a = max(a, blob(uv, vec2(0.30, 0.52), 0.19));
+	a = max(a, blob(uv, vec2(0.68, 0.60), 0.17));
+	a = max(a, blob(uv, vec2(0.10, 0.75), 0.13));
+	a = max(a, blob(uv, vec2(0.90, 0.80), 0.18));
+	a = max(a, blob(uv, vec2(0.45, 0.85), 0.15));
+	COLOR = vec4(0.95, 0.82, 0.15, a * intensity * 0.85);
+}

--- a/ui/hud/splatter.gdshader.uid
+++ b/ui/hud/splatter.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bpql0uxgw6ah3


### PR DESCRIPTION
Feature batch from playtest feedback: banana gun rework (#70), fists & punch rework (#71, absorbing the blur tuning of #68), and the respawn weapon-spin bug (#67).

## Banana rework (#70)
- **Lobbing ballistics**: launch speed 40 m/s under 24 m/s² projectile gravity (both exported), so aiming ~45° up from the spawn room lobs bananas most of the map.
- **Bounce & slide**: surfaces no longer stop the banana — it bounces (dampened, restitution 0.55) & slides; first contact lights a 1.2 s fuse (exported). A direct player hit still explodes instantly.
- **Reload 10 s → 1.5 s** (exported), with a visible **Banana** row added to the HUD cooldown bars (`BananaReadyFraction`, same pattern as Shot/Punch/Full-Auto).
- **Screen shake**: every peer within 20 m shakes when a banana explodes (decaying random offset ~0.4 s, magnitude falls off with distance). Runs via the existing visual-banana RPC path & uses the camera's h/v offsets so the replicated camera transform is untouched.
- **Splatter overlay**: victims get a procedural full-screen yellow splat (canvas shader, no external assets) that slides slowly down & fades over 5 s, synced with a flat **5 s banana stun**.

## Fists & punch rework (#71, absorbs #68)
- **Floating sphere hands**: two translucent player-colored spheres ride the camera & grip the visible weapon (fixed exported offsets per weapon); they replicate to every peer.
- **Boxer punches**: a randomly chosen hand visibly shoots forward & back (~0.25 s tween) each swing, replayed on peers via an RPC (SpawnVisualLaser pattern).
- **Connect-only punch sound**: no whoosh on a miss; the sound plays on the shooter when the ray hits & on the victim in `ReceivePunch`.
- **Reach**: `PunchRange` 2.5 → 4.0 (exported).
- **Stronger stacking blur** (#68): +0.4 intensity per hit (~3 hits ≈ near-blind), blur shader max LOD 4.5 → 7.0, & the fade slows at high stack so the whiteout lingers.
- **Shared stun system** (`Player.Stun.cs`): punch stuns stack (each connect slows the victim more), banana blasts fully stun for 5 s; stun blocks jumping & sliding, & `StunFactor` is replicated.
- **20% weapon-drop chance on connect**: guarded via `HasMethod ("DropHeldWeapon")` so the in-flight weapon-pickup branch merges trivially — until it lands, the victim just logs the near-drop. Equip/firing logic is untouched here.

## Weapon reset on respawn (#67)
- New `EnergyWeapon.ResetCharge()` cancels the charge state, spin tween, charging sound, & charged color; `Respawn()` calls it (& clears any active stun), so dying mid-charge can't carry a max-energy shot into the next life.

## Validation
- `dotnet build`: 0 warnings, 0 errors
- Godot 4.7.1 headless import: clean
- gdUnit4 suite: 18/18 passed
- Full 3-instance playtest (host + shooter + victim): **PASSED** with no driver changes — punch damage, kills, respawn armor, fire-rate cap, & full-auto all assert as before (the new stun only slows the stationary victim; the connect-only sound has no assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
