### PR TITLE
Make crouch a toggle: press C to crouch, press again to stand

### DIFF
--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -12,7 +12,7 @@ public partial class Player
   private void Fall (ref Vector3 velocity, double delta) => velocity += Gravity * (float)delta;
   private bool WantsSlide() => _isInputEnabled && !IsStunned && Input.IsActionPressed ("slide");
   // Slide wins: crouch is ignored while sliding (see issue #51).
-  private bool WantsCrouch() => _isInputEnabled && !Sliding && Input.IsActionPressed ("crouch");
+  private bool ToggledCrouch() => _isInputEnabled && Input.IsActionJustPressed ("crouch");
   private float MoveSpeed() => (Sliding ? Speed * SlideSpeedMultiplier : _crouching ? Speed * CrouchSpeedMultiplier : Speed) * StunSpeedMultiplier();
 
   // Hold to slide: double speed & a horizontal pose, capped at SlideDurationSeconds,
@@ -49,12 +49,14 @@ public partial class Player
 
   // Hold C to crouch: shorter profile & half speed (see issue #51). Standing back up
   // requires overhead clearance so the head can't clip into geometry above.
+  // Press C to crouch, press again to stand (issue #85). Sliding cancels a crouch;
+  // standing needs overhead clearance.
   private void UpdateCrouch()
   {
-    var crouching = WantsCrouch();
-    if (crouching == _crouching) return;
-    if (!crouching && IsOverheadBlocked()) return;
-    Crouching = crouching;
+    if (Sliding && _crouching) { Crouching = false; ApplyCameraHeight(); return; }
+    if (!ToggledCrouch() || Sliding) return;
+    if (_crouching && IsOverheadBlocked()) return;
+    Crouching = !_crouching;
     ApplyCameraHeight();
   }
 

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -44,6 +44,7 @@ public partial class Player
   {
     _slideCooldownLeft = SlideCooldownSeconds;
     Sliding = false;
+    if (IsOverheadBlocked()) Crouching = true; // Slid under something low: come up into a crouch, not the ceiling.
     ApplyCameraHeight();
   }
 
@@ -159,7 +160,11 @@ public partial class Player
     _energyWeapon.ResetCharge(); // Every life starts with a cold weapon (issue #67).
     ClearStun(); // Death shakes off any punch/banana stun.
     ActivateSpawnArmor();
-    Crouching = false; // Fresh lives start standing (crouch is a toggle now).
+    // Fresh lives start standing & slide-ready: no lingering pose, no cooldown carryover (#104).
+    Sliding = false;
+    _slideSecondsLeft = 0.0f;
+    _slideCooldownLeft = 0.0f;
+    Crouching = false;
     ApplyCameraHeight();
     SetInputEnabled (isEnabled: false);
     _respawnSound.Play();

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -159,6 +159,8 @@ public partial class Player
     _energyWeapon.ResetCharge(); // Every life starts with a cold weapon (issue #67).
     ClearStun(); // Death shakes off any punch/banana stun.
     ActivateSpawnArmor();
+    Crouching = false; // Fresh lives start standing (crouch is a toggle now).
+    ApplyCameraHeight();
     SetInputEnabled (isEnabled: false);
     _respawnSound.Play();
     GD.Print ($"{DisplayName}: I respawned!");


### PR DESCRIPTION
## Summary
Crouch only engaged while C was physically held, so tap-to-crouch/tap-to-stand didn't work. Now a toggle: C crouches, C again stands (overhead-clearance check retained; starting a slide cancels a crouch).

Fixes #85

## Testing
- `dotnet build` clean; full 3-instance playtest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crouching now toggles with distinct button presses instead of requiring the input to remain held.
  * Sliding and crouching interactions are handled more consistently.
  * Players can no longer stand when overhead clearance is insufficient.
  * Respawning now reliably resets crouching and restores the correct camera height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->