### PR TITLE
Fix passwords, crown, negative scores, & pickups; add pings, red death messages, & server logging

### DIFF
--- a/core/players/Player.Banana.cs
+++ b/core/players/Player.Banana.cs
@@ -102,6 +102,7 @@ public partial class Player
 
     GD.Print ($"{DisplayName}: My banana blasted {victim.DisplayName}!");
     _hitmarkerSound.Play();
+    ReportToServer ($"blast: {DisplayName} banana-blasted {victim.DisplayName} (energy {energy:0.00})");
     victim.RpcId (victim.NetworkId, MethodName.ReceiveBlast, blastOrigin, energy, DisplayName);
   }
 

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -1,3 +1,4 @@
+using com.forerunnergames.energyshot.utilities;
 using com.forerunnergames.energyshot.weapons;
 using Godot;
 
@@ -10,6 +11,28 @@ public partial class Player
   // Bolts spawn this far ahead of the camera; the first sweep still starts at the
   // camera so nearer geometry isn't skipped (issue #112).
   private const float MuzzleOffsetMeters = 0.9f;
+
+  // Combat reports for the server log (issue #111): the attacker->victim damage RPCs
+  // never execute on the server, so the attacker also files a tiny report the server
+  // just prints - one small reliable RPC per landed hit, cheap & always on.
+  private void ReportToServer (string message)
+  {
+    if (Multiplayer.IsServer())
+    {
+      ServerLog.Event (NetworkId, message);
+      return;
+    }
+
+    RpcId (1, MethodName.LogOnServer, message);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void LogOnServer (string message)
+  {
+    if (!Multiplayer.IsServer()) return;
+    ServerLog.Event (Multiplayer.GetRemoteSenderId(), message);
+  }
+
   private bool IsFullAutoActive() => _fullAutoSecondsLeft > 0.0f;
   // 0..1 readiness fractions for the HUD cooldown bars (1 = ready).
   public float ShotReadyFraction => _energyWeapon.CooldownFraction;
@@ -113,6 +136,7 @@ public partial class Player
     Rpc (MethodName.PlayRemotePunch, hand); // ...but peers only ever see real connects (issue #82).
     _punchSound.Play(); // Puncher-only, connect-only (issue #82): the victim hears the damage sound instead.
     GD.Print ($"{DisplayName}: I punched {victim.DisplayName}!");
+    ReportToServer ($"punch: {DisplayName} punched {victim.DisplayName}");
     victim.RpcId (victim.NetworkId, MethodName.ReceivePunch, DisplayName);
   }
 
@@ -194,6 +218,7 @@ public partial class Player
   {
     GD.Print ($"{DisplayName}: I hit {playerPuppet.DisplayName}!");
     _hitmarkerSound.Play();
+    ReportToServer ($"hit: {DisplayName} zapped {playerPuppet.DisplayName} (energy {energy:0.00})");
     playerPuppet.RpcId (playerPuppet.NetworkId, MethodName.ReceiveHit, energy, DisplayName, throughBarrier, isFullAuto);
   }
 

--- a/core/players/Player.Cosmetics.cs
+++ b/core/players/Player.Cosmetics.cs
@@ -100,9 +100,11 @@ public partial class Player
 
   // Golden crown for the current score leader (issue #89): each peer computes the
   // leader locally in World from the replicated Scores & toggles this; the crown
-  // floats above the name tag & slowly spins while worn.
+  // floats clearly above the name tag & slowly spins while worn (issue #107).
+  private const float CrownNameTagSpacing = 0.6f;
   private Node3D? _crown;
   private Tween? _crownSpin;
+  public bool IsCrowned => _crown is { Visible: true };
 
   public void SetCrowned (bool isCrowned)
   {
@@ -143,6 +145,16 @@ public partial class Player
     _nameTag.Position = new Vector3 (_nameTag.Position.X, NameTagBaseHeight + verticalOffset, _nameTag.Position.Z);
     _healthTag.Scale = originalHealthTagScale * healthTagScaleFactor;
     _healthTag.Position = new Vector3 (_healthTag.Position.X, NameTagBaseHeight + verticalOffset - tagSpacing, _healthTag.Position.Z);
+    UpdateCrownPlacement (scaleFactor, verticalOffset);
+  }
+
+  // The crown rides clearly above the name tag & scales with it, so the leader is
+  // obvious at any distance instead of hiding behind/inside the tag (issue #107).
+  private void UpdateCrownPlacement (float scaleFactor, float verticalOffset)
+  {
+    if (_crown == null) return;
+    _crown.Scale = Vector3.One * scaleFactor;
+    _crown.Position = new Vector3 (_crown.Position.X, NameTagBaseHeight + verticalOffset + CrownNameTagSpacing * scaleFactor, _crown.Position.Z);
   }
 
   private float CalculateTagScaleFactor (float distance)

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -45,8 +45,41 @@ public partial class Player : CharacterBody3D
   [Signal] public delegate void ScoredEventHandler (string playerName, string shotPlayerName);
   [Signal] public delegate void RespawnedShotEventHandler (string playerName, string shotByPlayerName);
   [Signal] public delegate void RespawnedFellEventHandler (string playerName);
-  // Replicated like Health so every peer can render the leaderboard.
-  [Export] public int Score { get; set; }
+  // Replicated like Health so every peer can render the leaderboard. Never clamped:
+  // fall penalties can take it negative (issue #108).
+  [Export]
+  public int Score
+  {
+    get => _score;
+    set
+    {
+      if (_score != value) LogReplicatedChangeOnServer ($"score: {DisplayName} {_score} -> {value}");
+      _score = value;
+    }
+  }
+
+  // Round-trip time to the server in ms, measured server-side once a second &
+  // replicated like Score so every peer can render it on the leaderboard (issue
+  // #100); -1 = not measured yet.
+  [Export] public int PingMs { get; set; } = -1;
+
+  // Only the server measures pings; it tells the owning client, which writes the
+  // replicated property (issue #100).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ReceivePingMeasurement (int pingMs)
+  {
+    if (Multiplayer.GetRemoteSenderId() != 1) return;
+    if (!IsMultiplayerAuthority()) return;
+    PingMs = pingMs;
+  }
+
+  // Server-side score & streak logging (issue #111): the replicated property setters
+  // run on the server whenever a peer's value syncs there, covering every code path.
+  private void LogReplicatedChangeOnServer (string message)
+  {
+    if (!IsInsideTree() || Multiplayer.MultiplayerPeer is not ENetMultiplayerPeer || !Multiplayer.IsServer()) return;
+    ServerLog.Event (NetworkId, message);
+  }
 
   // Difficulty handicap: beginners get a bigger health pool. Replicated so every
   // peer scales this player's health bar correctly.
@@ -119,6 +152,7 @@ public partial class Player : CharacterBody3D
     get => _zapStreakCount;
     set
     {
+      if (_zapStreakCount != value) LogReplicatedChangeOnServer ($"streak: {DisplayName} {_zapStreakCount} -> {value}");
       _zapStreakCount = value;
       ApplyStreakGlow();
     }
@@ -231,9 +265,12 @@ public partial class Player : CharacterBody3D
   private ProgressBar _healthBar = null!;
   private string _displayName = string.Empty;
   private int _health;
+  private int _score;
   private int _maxHealth = 200;
   private bool _isInputEnabled;
   private static Player? _localPlayer;
+  // The pickup claim fallback needs the local player without a scene search (issue #110).
+  public static Player? Local => _localPlayer;
   public override void _EnterTree() => SetMultiplayerAuthority (NetworkId);
   public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
   // Guards against "The multiplayer instance isn't currently active" error spam from
@@ -256,6 +293,7 @@ public partial class Player : CharacterBody3D
     _jumpTimer = GetNode <Timer> ("JumpTimer");
     _hitRedTimer = GetNode <Timer> ("HitRedTimer");
     _nameTag = GetNode <Label3D> ("NameTag");
+    _crown = GetNodeOrNull <Node3D> ("Crown");
     _healthTag = GetNode <Sprite3D> ("HealthTag");
     _streakLight = GetNode <OmniLight3D> ("StreakLight");
     _healthBar = GetNode <ProgressBar> ("SubViewport/HealthBar");

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -98,6 +98,9 @@ properties/14/replication_mode = 2
 properties/15/path = NodePath(".:HeldWeapon")
 properties/15/spawn = true
 properties/15/replication_mode = 2
+properties/16/path = NodePath(".:PingMs")
+properties/16/spawn = true
+properties/16/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2
@@ -113,11 +116,11 @@ text = "PlayerName"
 outline_size = 20
 
 [node name="Crown" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.6, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.1, 0)
 visible = false
 
 [node name="CrownMesh" type="MeshInstance3D" parent="Crown"]
-transform = Transform3D(0.03, 0, 0, 0, 0, 0.03, 0, -0.03, 0, 0, 0, 0)
+transform = Transform3D(0.05, 0, 0, 0, 0, 0.05, 0, -0.05, 0, 0, 0, 0)
 mesh = ExtResource("11_crown")
 
 [node name="StreakLight" type="OmniLight3D" parent="."]

--- a/core/weapons/WeaponPickup.cs
+++ b/core/weapons/WeaponPickup.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.utilities;
 using Godot;
 
 namespace com.forerunnergames.energyshot.weapons;
@@ -78,7 +79,7 @@ public partial class WeaponPickup : Area3D
     if (!Multiplayer.IsServer() || !Expires) return;
     _expiryLeft -= (float)delta;
     if (_expiryLeft > 0.0f) return;
-    GD.Print ($"Server: Unclaimed dropped {Weapon} pickup expired");
+    ServerLog.Event ($"weapon despawn: unclaimed dropped {Weapon} pickup [{Name}] expired");
     QueueFree(); // The MultiplayerSpawner despawns it on every peer; the WeaponSpawner respawns the weapon at a free spawn point.
   }
 
@@ -93,8 +94,22 @@ public partial class WeaponPickup : Area3D
     _spawner.SendPickupRequest (Name, collector.NetworkId);
   }
 
-  // Can't pick up a weapon type you already hold.
-  private Player? FindLocalCollector() => GetOverlappingBodies().OfType <Player>().FirstOrDefault (player => player.IsMultiplayerAuthority() && !player.Holds (Weapon));
+  // Sphere radius (1.2) + the player capsule's reach, against the player's center.
+  private const float ClaimRangeMeters = 1.7f;
+
+  // Can't pick up a weapon type you already hold. Area3D overlap alone can miss a
+  // player who's inside the area but hasn't generated fresh contacts (issue #110), so
+  // a plain distance check on the local player backs it up.
+  private Player? FindLocalCollector()
+  {
+    var collector = GetOverlappingBodies().OfType <Player>().FirstOrDefault (IsEligibleCollector);
+    if (collector != null) return collector;
+    var local = Player.Local;
+    if (local == null || !IsEligibleCollector (local)) return null;
+    return (local.GlobalPosition + Vector3.Up).DistanceTo (GlobalPosition) <= ClaimRangeMeters ? local : null;
+  }
+
+  private bool IsEligibleCollector (Player player) => player.IsMultiplayerAuthority() && !player.Holds (Weapon);
 
   private void UpdateVisuals()
   {

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using com.forerunnergames.energyshot.core.world;
 using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.utilities;
 using Godot;
 
 namespace com.forerunnergames.energyshot.weapons;
@@ -139,20 +140,28 @@ public partial class WeaponSpawner : Node3D
     pickup.Expires = expires;
     pickup.PreviousOwner = previousOwner; // For theft-revenge messages (issue #84).
     GetParent().AddChild (pickup); // The MultiplayerSpawner replicates the spawn to every peer.
-    GD.Print ($"Server: Spawned {type} pickup at {position}");
+    ServerLog.Event ($"weapon spawn: {type} pickup [{pickup.Name}] at {position}{(expires ? " (expiring drop)" : "")}");
   }
 
   // First request wins: a pickup that's already claimed or expired is simply gone.
+  // Every claim/award/deny decision is logged server-side (issues #110 & #111).
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
   private void RequestPickup (string pickupName, int collectorId)
   {
     if (!Multiplayer.IsServer()) return;
     var pickup = GetParent().GetNodeOrNull <WeaponPickup> (pickupName);
-    if (pickup == null || pickup.IsQueuedForDeletion()) return;
+    ServerLog.Event (collectorId, $"weapon claim: pickup [{pickupName}]");
+
+    if (pickup == null || pickup.IsQueuedForDeletion())
+    {
+      ServerLog.Event (collectorId, $"weapon deny: pickup [{pickupName}] {(pickup == null ? "no longer exists" : "is already claimed")}");
+      return;
+    }
+
     var type = pickup.Weapon;
     var previousOwner = pickup.PreviousOwner;
     pickup.QueueFree(); // Despawns on every peer via the MultiplayerSpawner.
-    GD.Print ($"Server: Player [{collectorId}] picked up the {type}");
+    ServerLog.Event (collectorId, $"weapon award: {type} from pickup [{pickupName}]");
 
     if (collectorId == Multiplayer.GetUniqueId())
     {
@@ -170,10 +179,12 @@ public partial class WeaponSpawner : Node3D
   private void RequestDrop (Vector3 position, int droppedMask)
   {
     if (!Multiplayer.IsServer()) return;
+    // A direct (non-RPC) call means the host itself dropped, so there's no remote sender.
     var senderId = Multiplayer.GetRemoteSenderId();
-    if (senderId == 0) senderId = Multiplayer.GetUniqueId(); // Direct local call: the host player itself.
+    if (senderId == 0) senderId = Multiplayer.GetUniqueId();
     var dropperName = Players().FirstOrDefault (player => player.NetworkId == senderId)?.DisplayName ?? string.Empty;
     var dropped = (HeldWeapon)droppedMask;
+    ServerLog.Event (senderId, $"weapon drop: {dropped} at {position}");
     var spot = position + Vector3.Up * PickupHoverHeight;
     if (dropped.HasFlag (HeldWeapon.Laser)) Spawn (HeldWeapon.Laser, spot, expires: true, dropperName);
     if (dropped.HasFlag (HeldWeapon.Banana)) Spawn (HeldWeapon.Banana, spot + Vector3.Right * 0.8f, expires: true, dropperName);

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -34,7 +34,6 @@ public partial class World : Node3D
   private string _selfPlayerName = string.Empty;
   private int _selfDifficulty = 2;
   private int _score;
-  [Rpc] private void OnKickedFromServer (string reason) => EmitSignal (SignalName.KickedFromServer, reason);
   private int FindPlayerId (string displayName) => FindPlayer (displayName)?.NetworkId ?? 0;
   private Player? FindPlayer (string displayName) => GetChildren().OfType <Player>().FirstOrDefault (player => player.DisplayName == displayName);
   private Player? FindPlayer (int peerId) => GetChildren().OfType <Player>().FirstOrDefault (player => player.NetworkId == peerId);
@@ -43,7 +42,20 @@ public partial class World : Node3D
   private void OnGamePaused() => _selfPlayer?.SetInputEnabled (isEnabled: false);
   private void OnGameResumed() => _selfPlayer?.SetInputEnabled (isEnabled: true);
   private void OnGameQuit() => GetTree().Quit();
-  private static void OnClientConnectedToServer (long peerId) => GD.Print ($"Server: Client ID [{peerId}] connected");
+  private static void OnClientConnectedToServer (long peerId) => ServerLog.Event (peerId, "connected");
+  // Only a live ENet server session logs (issue #111): the engine's default
+  // OfflineMultiplayerPeer also reports IsServer, which would spam clients in menus.
+  private bool IsActiveServer() => Multiplayer.MultiplayerPeer is ENetMultiplayerPeer && Multiplayer.IsServer();
+
+  // Being kicked already explains the follow-up disconnect: unhooking first keeps the
+  // kick reason (e.g. "Wrong password.") from being overwritten by a bogus
+  // "server was shut down" moments later (issue #109).
+  [Rpc]
+  private void OnKickedFromServer (string reason)
+  {
+    OnJoinCanceled();
+    EmitSignal (SignalName.KickedFromServer, reason);
+  }
 
   public override void _Ready()
   {
@@ -60,6 +72,9 @@ public partial class World : Node3D
     _ui.GameQuit += OnGameQuit;
     _networkManager.PlayerRespawnedShot += (playerName, shotByPlayerName) => OnPlayerRespawned (playerName, SignalName.PlayerRespawnedShot, shotByPlayerName);
     _networkManager.PlayerRespawnedFell += playerName => OnPlayerRespawned (playerName, SignalName.PlayerRespawnedFell);
+    // Deaths reach the server through these notifications on every path (issue #111).
+    _networkManager.PlayerRespawnedShot += (playerName, shotByPlayerName) => { if (IsActiveServer()) ServerLog.Event (FindPlayerId (playerName), $"death: {playerName} zapped out by {shotByPlayerName}"); };
+    _networkManager.PlayerRespawnedFell += playerName => { if (IsActiveServer()) ServerLog.Event (FindPlayerId (playerName), $"death: {playerName} fell off the world"); };
     _networkManager.RemoteMessageReceived += message => EmitSignal (SignalName.RemoteMessageReceived, message);
     _networkManager.PlayerJoinGame += playerName => EmitSignal (SignalName.PlayerJoinedGame, playerName);
     _networkManager.PlayerLeftGame += playerName => EmitSignal (SignalName.PlayerLeftGame, playerName);
@@ -97,7 +112,9 @@ public partial class World : Node3D
     var error = peer.CreateClient (address, port);
     if (error != Error.Ok) GD.PrintErr ($"Playtest join failed: {error}");
     Multiplayer.MultiplayerPeer = peer;
-    Multiplayer.ConnectedToServer += () => OnJoinGameSuccess (playerName, difficulty, password);
+    // One-shot: a retried session (e.g. the playtest's wrong-password probe, issue
+    // #109) must not replay stale credentials from an earlier attempt's handler.
+    Multiplayer.Connect (MultiplayerApi.SignalName.ConnectedToServer, Callable.From (() => OnJoinGameSuccess (playerName, difficulty, password)), (uint)ConnectFlags.OneShot);
   }
 
   // Dedicated-server exports carry the feature tag, so the server binary needs no flag;
@@ -150,38 +167,39 @@ public partial class World : Node3D
   {
     if (!Multiplayer.IsServer()) return;
     var senderId = Multiplayer.GetRemoteSenderId();
-    GD.Print ($"Server: {senderId} {playerName} is requesting to join the game (difficulty {difficulty})");
+    ServerLog.Event (senderId, $"join request: [{playerName}] (difficulty {difficulty})");
 
     // Server-enforced game password (issue #90); empty server password = open server.
     if (_serverPassword.Length > 0 && password != _serverPassword)
     {
+      ServerLog.Event (senderId, $"join denied: [{playerName}] wrong password");
       Kick (senderId, "Wrong password.");
-      GD.PrintErr ($"Server: Disconnected client ID [{senderId}], wrong password");
       return;
     }
 
+    ServerLog.Event (senderId, $"password {(_serverPassword.Length > 0 ? "accepted" : "not required")} for [{playerName}]");
     var duplicateId = FindPlayer (senderId);
     var duplicateName = FindPlayer (playerName);
 
     if (duplicateId != null)
     {
+      ServerLog.Event (senderId, $"join denied: duplicate ID, [{duplicateId.DisplayName} (ID: {duplicateId.NetworkId})] is already in game");
       Kick (senderId, "You're already in the game.");
-      GD.PrintErr ($"Server: Disconnected client ID [{senderId}], duplicate ID, [{duplicateId.DisplayName} (ID: {duplicateId.NetworkId})] is already in game");
       return;
     }
 
     if (duplicateName != null)
     {
+      ServerLog.Event (senderId, $"join denied: duplicate display name, [{duplicateName.DisplayName} (ID: {duplicateName.NetworkId})] is already in game");
       Kick (senderId, "Your name is already in use by another player.");
-      GD.PrintErr ($"Server: Disconnected client ID [{senderId}], duplicate display name, [{duplicateName.DisplayName} (ID: {duplicateName.NetworkId})] is already in game");
       return;
     }
 
     // Host-chosen player cap (issue #73).
     if (GetPlayers().Count() >= _maxPlayers)
     {
+      ServerLog.Event (senderId, $"join denied: game is full ({_maxPlayers} players)");
       Kick (senderId, "Game is full.");
-      GD.PrintErr ($"Server: Disconnected client ID [{senderId}], game is full ({_maxPlayers} players)");
       return;
     }
 
@@ -191,6 +209,7 @@ public partial class World : Node3D
   // Delay the disconnect so the kick-reason RPC isn't dropped by an immediate peer disconnect (see issue #23).
   private async void Kick (int peerId, string reason)
   {
+    ServerLog.Event (peerId, $"kicked: {reason}");
     RpcId (peerId, MethodName.OnKickedFromServer, reason);
     await ToSignal (GetTree().CreateTimer (0.5), SceneTreeTimer.SignalName.Timeout);
     if (!Multiplayer.GetPeers().Contains (peerId)) return;
@@ -227,7 +246,7 @@ public partial class World : Node3D
   private void OnClientDisconnectedFromServer (long id)
   {
     RemovePlayer (id);
-    GD.Print ($"Server: Player [{id}] disconnected");
+    ServerLog.Event (id, "disconnected");
   }
 
   private void _OnMultiplayerSpawnerSpawned (Node node)
@@ -258,7 +277,7 @@ public partial class World : Node3D
     player.RespawnedFell += respawnedPlayerName => _networkManager.NotifyPlayerRespawnedFell (respawnedPlayerName);
     AddChild (player);
     player.DisplayName = playerName;
-    GD.Print ($"Server: [{player.DisplayName} {player.NetworkId}] joined the game");
+    ServerLog.Event (player.NetworkId, $"spawn: [{player.DisplayName}] joined the game (max health {maxHealth})");
     _networkManager.NotifyPlayerJoinGame (player.DisplayName);
     if (!player.IsMultiplayerAuthority()) return;
     RegisterSelf (player);
@@ -286,11 +305,13 @@ public partial class World : Node3D
 
   // Golden crown (issue #89): every peer computes the score leader locally from the
   // replicated Scores each second - no new networking; ties break by the
-  // leaderboard's sort order (highest score, then name).
+  // leaderboard's sort order (highest score, then name). The same tick samples pings
+  // server-side (issue #100).
   private void StartCrownTicker()
   {
     var timer = new Timer { WaitTime = 1.0, Autostart = true };
     timer.Timeout += UpdateCrownHolder;
+    timer.Timeout += UpdatePings;
     AddChild (timer);
   }
 
@@ -299,5 +320,27 @@ public partial class World : Node3D
     var players = GetPlayers().ToList();
     var leader = players.OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName).FirstOrDefault();
     players.ForEach (player => player.SetCrowned (player == leader));
+  }
+
+  // Per-player ping (issue #100): the server samples each peer's ENet round-trip time
+  // once a second & tells the owning client, which writes the replicated PingMs that
+  // every peer renders on the leaderboard.
+  private void UpdatePings()
+  {
+    if (Multiplayer.MultiplayerPeer is not ENetMultiplayerPeer peer || !Multiplayer.IsServer()) return;
+    foreach (var player in GetPlayers()) UpdatePing (peer, player);
+  }
+
+  private void UpdatePing (ENetMultiplayerPeer peer, Player player)
+  {
+    if (player.NetworkId == Multiplayer.GetUniqueId())
+    {
+      player.PingMs = 0; // The host is the server: its own ping is always 0.
+      return;
+    }
+
+    if (!Multiplayer.GetPeers().Contains (player.NetworkId)) return; // Mid-disconnect.
+    var pingMs = (int)peer.GetPeer (player.NetworkId).GetStatistic (ENetPacketPeer.PeerStatistic.RoundTripTime);
+    player.RpcId (player.NetworkId, Player.MethodName.ReceivePingMeasurement, pingMs);
   }
 }

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -92,11 +92,17 @@ public partial class PlaytestDriver : Node
   {
     _world.StartHostSession (HostName, difficulty: 2, Port, Password);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players joined");
+    // Exactly one player wears the crown even at 0-0 (issue #107).
+    await WaitUntil (() => _world.GetPlayers().Count (player => player.IsCrowned) == 1, 10, "exactly one player crowned at 0-0");
+    // Server-measured pings replicate back to every peer (issue #100).
+    await WaitUntil (() => FindPlayer (ShooterName)?.PingMs >= 0, 15, "shooter's ping measured & replicated to host");
     // Shooter kills victim once (plus possibly the host itself in the line of
     // fire); wait to observe the replicated score.
     await WaitUntil (() => FindPlayer (ShooterName)?.Score >= 1, 120, "shooter's kill replicated to host");
     // Victim respawns with armor visible to the host too.
     await WaitUntil (() => FindPlayer (VictimName)?.SpawnArmor == true, 30, "victim respawn armor replicated to host");
+    // The victim's fall at score 0 goes negative & replicates (issue #108).
+    await WaitUntil (() => FindPlayer (VictimName)?.Score == -1, 60, "victim's fall penalty (-1) replicated to host");
     // Stay up until both clients have finished & disconnected.
     await WaitUntil (() => _world.GetPlayers().Count() == 1, 120, "clients disconnected");
   }
@@ -111,6 +117,8 @@ public partial class PlaytestDriver : Node
     Assert (host.MaxHealth == 200, $"host MaxHealth replicated as Expert 200, got {host.MaxHealth}");
     Assert (Self.MaxHealth == 300, $"own MaxHealth is Intermediate 300, got {Self.MaxHealth}");
     Assert (Self.HeldWeapon == HeldWeapon.None, "spawned unarmed (#72)");
+    // The server measures our ping & tells us within a tick or two (issue #100).
+    await WaitUntil (() => Self.PingMs >= 0, 15, "own ping measured by the server");
 
     // Movement: hold forward briefly & verify we actually moved.
     var startPosition = Self.GlobalPosition;
@@ -230,6 +238,9 @@ public partial class PlaytestDriver : Node
 
   private async Task RunVictim()
   {
+    // Password enforcement (issue #109): a wrong password must get kicked with
+    // "Wrong password." before the real join succeeds.
+    await AssertWrongPasswordIsKicked();
     _world.StartClientSession (VictimName, difficulty: 0, _address, Port, Password);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
     Assert (Self.MaxHealth == 400, $"own MaxHealth is Beginner 400, got {Self.MaxHealth}");
@@ -254,8 +265,26 @@ public partial class PlaytestDriver : Node
     // Streak glow (#77/#88): the shooter's kill streak must replicate to the victim's
     // copy of the shooter node, since that drives the glow & leaderboard pulsing here.
     await WaitUntil (() => FindPlayer (ShooterName)?.ZapStreakCount >= 1, 15, "shooter's streak replicated to victim");
+    // Fall penalty goes negative (issue #108): step off the world at score 0 & verify -1.
+    Assert (Self.Score == 0, $"own score is 0 before the fall, got {Self.Score}");
+    Self.Position = new Vector3 (120.0f, 5.0f, 120.0f); // Beyond the arena: nothing below but the kill boundary.
+    await WaitUntil (() => Self.Score == -1, 60, "fall at score 0 dropped own score to -1");
     // Give the shooter time to finish its solo phases (fire-rate & full-auto) before we vanish.
     await Task.Delay (8000);
+  }
+
+  // Negative password check (issue #109): join with a bogus password, expect the
+  // server to kick us with exactly "Wrong password.", then wait out the disconnect
+  // so the real join starts clean.
+  private async Task AssertWrongPasswordIsKicked()
+  {
+    var kickReason = string.Empty;
+    _world.KickedFromServer += reason => kickReason = reason;
+    _world.StartClientSession (VictimName, difficulty: 0, _address, Port, "wrong-" + Password);
+    await WaitUntil (() => kickReason.Length > 0, 30, "wrong-password join was kicked");
+    Assert (kickReason == "Wrong password.", $"kick reason is \"Wrong password.\", got \"{kickReason}\"");
+    await WaitUntil (() => Multiplayer.MultiplayerPeer.GetConnectionStatus() != MultiplayerPeer.ConnectionStatus.Connected, 15, "kicked connection fully closed");
+    await Task.Delay (500); // Let the peer teardown settle before reconnecting.
   }
 
   // ---------------------------------------------------------------- helpers

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -55,22 +55,25 @@ public partial class Hud : Control
   private void UpdateLeaderboard()
   {
     var players = _world.GetPlayers().OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName);
-    _leaderboardEntries.Text = string.Join ("\n", players.Select (LeaderboardEntry));
+    _leaderboardEntries.Text = string.Join ("\n", players.Select ((player, index) => LeaderboardEntry (player, isLeader: index == 0)));
     UpdateScoreLabel();
   }
 
-  // 3+ streak entries glow & pulse so the hot player stands out (see issue #77).
-  private static string LeaderboardEntry (players.Player player) =>
-    player.IsOnStreak
-      ? $"[pulse freq=1.5 color=#ffd24d ease=-2.0][wave amp=18.0 freq=4.0][b]{player.DisplayName}  {player.Score}[/b][/wave][/pulse]"
-      : $"{player.DisplayName}  {player.Score}";
+  // 3+ streak entries glow & pulse so the hot player stands out (see issue #77); the
+  // current leader wears the crown (issue #107) & every entry shows its ping (issue #100).
+  private static string LeaderboardEntry (players.Player player, bool isLeader)
+  {
+    var entry = $"{player.DisplayName}  {player.Score}  ({Mathf.Max (0, player.PingMs)}ms)";
+    if (player.IsOnStreak) entry = $"[pulse freq=1.5 color=#ffd24d ease=-2.0][wave amp=18.0 freq=4.0][b]{entry}[/b][/wave][/pulse]";
+    return isLeader ? $"\U0001F451 {entry}" : entry;
+  }
 
   // Score can also drop (fall penalty), so the label reads the replicated value.
   private void UpdateScoreLabel() => _scoreLabel.Text = $"Score: {_world.SelfPlayer?.Score ?? 0}";
   private bool IsSelf (string playerName) => _selfPlayerName == playerName;
   private void OnKickedFromServer (string reason) => Hide();
   private void OnServerShutDown() => Hide();
-  private void PrintMessage (string message) => _messageScroller.AddMessage (message);
+  private void PrintMessage (string message, MessageScroller.MessageImportance importance = MessageScroller.MessageImportance.Medium) => _messageScroller.AddMessage (message, importance);
   // @formatter:on
 
   public override void _Ready()
@@ -201,7 +204,8 @@ public partial class Hud : Control
     }
 
     if (!IsSelf (playerName)) return;
-    Announce (MessageGenerator.OnZapped (playerName, shotByPlayerName, BuildDeathContext (shotByPlayerName)));
+    // Your own death renders red locally (issue #101); everyone else gets the same text in white.
+    Announce (MessageGenerator.OnZapped (playerName, shotByPlayerName, BuildDeathContext (shotByPlayerName)), MessageScroller.MessageImportance.Critical);
     ++_zappedStreak;
     _zapStreak = 0;
     if (_zappedStreak >= 3) Announce (MessageGenerator.OnZappedStreak (playerName));
@@ -228,13 +232,14 @@ public partial class Hud : Control
       self?.LastZapThroughBarrier ?? false);
   }
 
-  private void Announce (string message) => NotifyMessage (message, message);
+  private void Announce (string message, MessageScroller.MessageImportance importance = MessageScroller.MessageImportance.Medium) => NotifyMessage (message, message, importance);
 
   private void OnPlayerRespawnedFell (string playerName)
   {
     if (!IsSelf (playerName)) return;
     UpdateScoreLabel(); // Falling costs a point; show it immediately.
-    Announce (MessageGenerator.OnPlayerRespawnedFell (isSelf: false, playerName, out _)); // Same text for every peer (#53).
+    // Same text for every peer (#53); red locally because it's your own death (issue #101).
+    Announce (MessageGenerator.OnPlayerRespawnedFell (isSelf: false, playerName, out _), MessageScroller.MessageImportance.Critical);
     ++_fallStreak;
     if (_fallStreak >= 3) Announce (MessageGenerator.OnFallStreak (playerName));
   }
@@ -266,9 +271,9 @@ public partial class Hud : Control
     EmitSignal (SignalName.GameResumed);
   }
 
-  private void NotifyMessage (string localMessage, string remoteMessage, string excludedPlayerName = "")
+  private void NotifyMessage (string localMessage, string remoteMessage, MessageScroller.MessageImportance importance = MessageScroller.MessageImportance.Medium, string excludedPlayerName = "")
   {
-    PrintMessage (localMessage);
+    PrintMessage (localMessage, importance);
     EmitSignal (SignalName.Message, remoteMessage, excludedPlayerName);
   }
 }

--- a/ui/hud/messages/MessageScroller.cs
+++ b/ui/hud/messages/MessageScroller.cs
@@ -150,7 +150,7 @@ public partial class MessageScroller : Control
     ShiftMessagesUp();
     UpdateBottomMessage (_messageImportanceToColors[importance], singleLineMessage);
     ModulateMessages();
-    AddMessageToHistory (singleLineMessage);
+    AddMessageToHistory (_messageImportanceToColors[importance], singleLineMessage);
     StartMessageTimer (importance, isInstant);
     return true;
   }
@@ -181,10 +181,12 @@ public partial class MessageScroller : Control
     tween.TweenProperty (_messageLabel3, "modulate:a", 0.8f, 0.5f).From (1.0f);
   }
 
-  private void AddMessageToHistory (string singleLineMessage)
+  // The history keeps each message's scroller color (issue #101), e.g. your own
+  // deaths stay red there too.
+  private void AddMessageToHistory (Color color, string singleLineMessage)
   {
     if (_messageHistory.Count >= MaxMessageHistoryLines) _messageHistory.RemoveRange (0, _messageHistoryLineRemovalAmount);
-    _messageHistory.Add (singleLineMessage);
+    _messageHistory.Add ($"[color=#{color.ToHtml (false)}]{singleLineMessage}[/color]");
     if (!IsMessageHistoryVisible()) return;
     UpdateMessageHistory();
   }

--- a/utilities/ServerLog.cs
+++ b/utilities/ServerLog.cs
@@ -1,0 +1,13 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.utilities;
+
+// Always-on server-side event log (issue #111): journald captures the official
+// server's stdout, so consistently prefixed GD.Print lines with a timestamp & the
+// relevant peer id are enough for live debugging. Client-side logging is unchanged.
+public static class ServerLog
+{
+  public static void Event (long peerId, string message) => GD.Print ($"{Prefix()} [peer {peerId}] {message}");
+  public static void Event (string message) => GD.Print ($"{Prefix()} {message}");
+  private static string Prefix() => $"[{Time.GetDatetimeStringFromSystem (utc: true)}] Server:";
+}

--- a/utilities/ServerLog.cs.uid
+++ b/utilities/ServerLog.cs.uid
@@ -1,0 +1,1 @@
+uid://cf7co6vakgh56


### PR DESCRIPTION
Seven fixes/features in one validated batch.

## Password enforcement (#109)
- Audited the #95 flow end to end (Join dialog → `JoinGameSuccess` → `World.OnJoinGameSuccess` → `RequestPlayerSlot` → server compare → kick) & **verified server-side enforcement works on every hosting path** — the "any password joins" symptom matches the official server deliberately running open (empty `--password`), which stays as designed.
- Fixed the bug that masked kicks: the kick reason (e.g. `Wrong password.`) was overwritten a moment later by a bogus "The server was shut down." because the kicked client's `ServerDisconnected` hook survived the kick. Being kicked now unhooks it first, so the real reason stays on screen.
- `StartClientSession`'s `ConnectedToServer` handler is now one-shot, so a retried join can't replay stale credentials.
- **New negative playtest assertion**: the victim role first joins with a wrong password, asserts it's kicked with exactly `Wrong password.`, waits out the disconnect, then rejoins correctly.

## Crown fixes (#107)
- The crown now rides clearly **above** the name tag & scales with the same distance factor the tags use, so the leader is obvious at any range instead of hiding behind/inside the tag; the base model is bigger & sits higher.
- The leaderboard marks the top entry with a crown glyph to the left of the name.
- Playtest asserts **exactly one player is crowned at a 0-0 game start** (score desc, then name).

## Negative fall scores (#108)
- Verified no clamp exists anywhere (Score property, HUD, leaderboard) & documented that `Score` must never be clamped.
- Playtest now teleports the victim off the world at score 0 & asserts `-1` replicates to every peer (own HUD value + host's copy).

## Laser pickup reliability (#110)
- Area3D overlap alone can miss a player who's inside the pickup's area without generating fresh contacts; a plain distance check on the local player now backs it up, so standing on a pickup while unarmed always claims it.
- Every claim/award/deny decision is now logged server-side with the reason (ties into #111), making any remaining misses diagnosable from journald.

## Per-player ping on the leaderboard (#100)
- The server samples each peer's ENet round-trip time once a second (`GetPeer(id).GetStatistic(RoundTripTime)`) & tells the owning client, which writes a replicated `PingMs` (same pattern as `Score`) that every peer renders.
- Leaderboard format: `name  score  (NNms)`. Playtest-asserted end to end (server measures → owner writes → replicates to other peers).

## Red self-death messages (#101)
- Messages announcing your own zap-out or fall render red in the message scroller, & the history now keeps each message's color, so they stay red there too.
- Every other peer still sees the identical shared text (#53) in white.

## Server-side logging (#111)
New tiny `utilities/ServerLog.cs` prints timestamped, peer-tagged lines, always on & cheap (journald captures stdout); client logging unchanged. Covered events:
- joins & kicks with password results, connects/disconnects, spawns
- deaths (zapped & fell), score changes, streak changes
- weapon spawn/claim/award/deny/drop/despawn
- punch/hit/blast reports (attackers file a small report RPC, since the attacker→victim damage RPCs never execute on the server)

Sample from the playtest run:
```
[2026-08-11T19:13:24] Server: [peer 260942523] join request: [Victim] (difficulty 0)
[2026-08-11T19:13:24] Server: [peer 260942523] join denied: [Victim] wrong password
[2026-08-11T19:13:24] Server: [peer 260942523] kicked: Wrong password.
[2026-08-11T19:13:28] Server: [peer 1114542486] weapon award: Laser from pickup [WeaponPickup5]
[2026-08-11T19:13:59] Server: [peer 1903954338] death: Victim zapped out by Shooter
[2026-08-11T19:13:59] Server: [peer 1114542486] score: Shooter 0 -> 1
[2026-08-11T19:14:01] Server: [peer 1903954338] death: Victim fell off the world
[2026-08-11T19:14:01] Server: [peer 1903954338] score: Victim 0 -> -1
```

## Validation
- `dotnet build`: 0 warnings, 0 errors
- Headless import: clean
- gdUnit4: 20/20 test cases pass
- Full playtest (host + shooter + victim): **PASS**, including the new wrong-password kick, one-crown-at-0-0, ping replication, & negative-score assertions

Fixes #100
Fixes #101
Fixes #107
Fixes #108
Fixes #109
Fixes #110
Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
