### PR TITLE
HUD: non-blocking messages, one-line ranked leaderboard with ping, & slide cooldown bar

### DIFF
--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -16,6 +16,8 @@ public partial class Player
   public bool DiedArmed { get; private set; }
   public bool DiedHoldingBananaGun { get; private set; }
   public int LostStreakCount { get; private set; }
+  // 0..1 for the HUD's slide cooldown bar, like PunchReadyFraction (issue #127).
+  public float SlideReadyFraction => 1.0f - _slideCooldownLeft / SlideCooldownSeconds;
   private bool IsFalling() => !IsOnFloor();
   // Stun blocks jumping & sliding (issues #70 & #71).
   private bool IsJumping() => _isInputEnabled && !IsStunned && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -17,7 +17,8 @@ public partial class Player
   public bool DiedHoldingBananaGun { get; private set; }
   public int LostStreakCount { get; private set; }
   // 0..1 for the HUD's slide cooldown bar, like PunchReadyFraction (issue #127).
-  public float SlideReadyFraction => 1.0f - _slideCooldownLeft / SlideCooldownSeconds;
+  // Non-positive cooldown = always ready; clamped so the HUD bar never sees NaN or overshoot.
+  public float SlideReadyFraction => SlideCooldownSeconds <= 0.0f ? 1.0f : Mathf.Clamp (1.0f - _slideCooldownLeft / SlideCooldownSeconds, 0.0f, 1.0f);
   private bool IsFalling() => !IsOnFloor();
   // Stun blocks jumping & sliding (issues #70 & #71).
   private bool IsJumping() => _isInputEnabled && !IsStunned && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -25,7 +25,7 @@ public partial class Hud : Control
   private ShaderMaterial _blur = null!;
   private ShaderMaterial _splatter = null!;
   private ProgressBar _shotBar = null!;
-  private ProgressBar _punchBar = null!;
+  private ProgressBar _slideBar = null!;
   private ProgressBar _fullAutoBar = null!;
   private ProgressBar _bananaBar = null!;
   private float _blurIntensity;
@@ -55,17 +55,18 @@ public partial class Hud : Control
   private void UpdateLeaderboard()
   {
     var players = _world.GetPlayers().OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName);
-    _leaderboardEntries.Text = string.Join ("\n", players.Select ((player, index) => LeaderboardEntry (player, isLeader: index == 0)));
+    _leaderboardEntries.Text = string.Join ("\n", players.Select ((player, index) => LeaderboardEntry (player, rank: index + 1)));
     UpdateScoreLabel();
   }
 
   // 3+ streak entries glow & pulse so the hot player stands out (see issue #77); the
   // current leader wears the crown (issue #107) & every entry shows its ping (issue #100).
-  private static string LeaderboardEntry (players.Player player, bool isLeader)
+  // Entries are ranked by sorted position, ties keep list order (issue #126).
+  private static string LeaderboardEntry (players.Player player, int rank)
   {
-    var entry = $"{player.DisplayName}  {player.Score}  ({Mathf.Max (0, player.PingMs)}ms)";
+    var entry = $"{rank}. {player.DisplayName}  {player.Score}  ({Mathf.Max (0, player.PingMs)}ms)";
     if (player.IsOnStreak) entry = $"[pulse freq=1.5 color=#ffd24d ease=-2.0][wave amp=18.0 freq=4.0][b]{entry}[/b][/wave][/pulse]";
-    return isLeader ? $"\U0001F451 {entry}" : entry;
+    return rank == 1 ? $"\U0001F451 {entry}" : entry;
   }
 
   // Score can also drop (fall penalty), so the label reads the replicated value.
@@ -87,7 +88,7 @@ public partial class Hud : Control
     _blur = (ShaderMaterial)GetNode <ColorRect> ("Blur").Material;
     _splatter = (ShaderMaterial)GetNode <ColorRect> ("Splatter").Material;
     _shotBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Shot/Bar");
-    _punchBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Punch/Bar");
+    _slideBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Slide/Bar");
     _fullAutoBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/FullAuto/Bar");
     _bananaBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Banana/Bar");
     _world.SelfPlayerPunched += OnSelfPlayerPunched;
@@ -147,7 +148,7 @@ public partial class Hud : Control
     var self = _world.SelfPlayer;
     if (self == null || !Visible) return;
     _shotBar.Value = self.ShotReadyFraction;
-    _punchBar.Value = self.PunchReadyFraction;
+    _slideBar.Value = self.SlideReadyFraction; // The slide bar replaced the punch bar (issue #127).
     _fullAutoBar.Value = self.FullAutoReadyFraction;
     _bananaBar.Value = self.BananaReadyFraction;
   }

--- a/ui/hud/Hud.tscn
+++ b/ui/hud/Hud.tscn
@@ -139,16 +139,16 @@ step = 0.01
 value = 1.0
 show_percentage = false
 
-[node name="Punch" type="HBoxContainer" parent="VBoxContainer/Cooldowns"]
+[node name="Slide" type="HBoxContainer" parent="VBoxContainer/Cooldowns"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/Cooldowns/Punch"]
+[node name="Label" type="Label" parent="VBoxContainer/Cooldowns/Slide"]
 custom_minimum_size = Vector2(220, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 28
-text = "Punch"
+text = "Slide"
 
-[node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/Punch"]
+[node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/Slide"]
 custom_minimum_size = Vector2(0, 22)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -211,7 +211,7 @@ layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -520.0
+offset_left = -720.0
 offset_top = 20.0
 offset_right = -20.0
 grow_horizontal = 0
@@ -241,6 +241,7 @@ theme_override_font_sizes/bold_font_size = 40
 bbcode_enabled = true
 fit_content = true
 scroll_active = false
+autowrap_mode = 0
 text = ""
 
 [node name="LeaderboardTimer" type="Timer" parent="."]

--- a/ui/hud/messages/MessageScroller.cs
+++ b/ui/hud/messages/MessageScroller.cs
@@ -7,8 +7,6 @@ namespace com.forerunnergames.energyshot.ui.hud.messages;
 
 public partial class MessageScroller : Control
 {
-  [Signal] public delegate void OnMessageScrollerExpandedEventHandler();
-  [Signal] public delegate void OnMessageScrollerCollapsedEventHandler();
   [Export] public float LowMessageImportanceDisplayTimeSeconds = 0.1f;
   [Export] public float MediumMessageImportanceDisplayTimeSeconds = 1.0f;
   [Export] public float HighMessageImportanceDisplayTimeSeconds = 2.0f;
@@ -110,7 +108,8 @@ public partial class MessageScroller : Control
   }
 
   // Tab toggles the full message history - a clickable button can't work while the
-  // mouse is captured for aiming (see issue #74).
+  // mouse is captured for aiming (see issue #74). The history is a passive overlay
+  // that never captures input: movement, shooting, & camera keep working (issue #118).
   public override void _UnhandledInput (InputEvent @event)
   {
     if (!Input.IsActionJustPressed ("messages")) return;
@@ -122,12 +121,10 @@ public partial class MessageScroller : Control
     if (IsMessageHistoryVisible())
     {
       HideMessageHistory();
-      EmitSignal (SignalName.OnMessageScrollerCollapsed);
       return;
     }
 
     ShowMessageHistory();
-    EmitSignal (SignalName.OnMessageScrollerExpanded);
   }
 
   private void DisplayNextMessage()

--- a/ui/hud/messages/MessageScroller.cs
+++ b/ui/hud/messages/MessageScroller.cs
@@ -112,8 +112,22 @@ public partial class MessageScroller : Control
   // that never captures input: movement, shooting, & camera keep working (issue #118).
   public override void _UnhandledInput (InputEvent @event)
   {
-    if (!Input.IsActionJustPressed ("messages")) return;
-    ToggleMessageHistory();
+    if (Input.IsActionJustPressed ("messages")) ToggleMessageHistory();
+    if (!IsMessageHistoryVisible()) return;
+    // PageUp/PageDown scroll the open history (built-in ui actions, nothing captured):
+    // with the scrollbar hidden, this is the only path to entries beyond the visible
+    // range (issue #118).
+    if (Input.IsActionJustPressed ("ui_page_up")) ScrollMessageHistoryBy (-HistoryScrollStepLines);
+    if (Input.IsActionJustPressed ("ui_page_down")) ScrollMessageHistoryBy (HistoryScrollStepLines);
+  }
+
+  private const int HistoryScrollStepLines = 10;
+  private int _historyScrollLine;
+
+  private void ScrollMessageHistoryBy (int lines)
+  {
+    _historyScrollLine = Mathf.Clamp (_historyScrollLine + lines, 0, Mathf.Max (0, _messageHistoryLabel.GetLineCount() - 1));
+    _messageHistoryLabel.ScrollToLine (_historyScrollLine);
   }
 
   private void ToggleMessageHistory()
@@ -211,6 +225,9 @@ public partial class MessageScroller : Control
     UpdateMessageHistory();
     _messageContainer.Hide();
     _messageHistoryContainer.Show();
+    // Open at the newest entry; PageUp walks back from there (issue #118).
+    _historyScrollLine = Mathf.Max (0, _messageHistoryLabel.GetLineCount() - 1);
+    _messageHistoryLabel.ScrollToLine (_historyScrollLine);
   }
 
   private void HideMessageHistory()

--- a/ui/hud/messages/MessageScroller.tscn
+++ b/ui/hud/messages/MessageScroller.tscn
@@ -75,22 +75,6 @@ horizontal_alignment = 1
 vertical_alignment = 1
 clip_text = true
 
-[node name="Expand" type="MarginContainer" parent="MarginContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-size_flags_stretch_ratio = 1.2
-mouse_filter = 2
-
-[node name="Hint" type="Label" parent="MarginContainer/VBoxContainer/Expand"]
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 3
-modulate = Color(1, 1, 1, 0.45)
-theme_override_font_sizes/font_size = 22
-text = "Tab — messages"
-horizontal_alignment = 1
-
 [node name="History" type="MarginContainer" parent="."]
 visible = false
 layout_mode = 1
@@ -119,7 +103,7 @@ mouse_filter = 2
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 9
-focus_mode = 2
+mouse_filter = 2
 bbcode_enabled = true
 text = "Test First
 TestTestTestTestTestTestTestTestTestTestTest
@@ -171,20 +155,5 @@ Test
 Test
 TestTestTestTestTestTestTestTestTestTestTestTest
 Test Last TestTestTestTestTestTestTestTestTestTestTest"
+scroll_active = false
 scroll_following = true
-selection_enabled = true
-
-[node name="Collapse" type="MarginContainer" parent="History/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 9
-mouse_filter = 2
-
-[node name="Hint" type="Label" parent="History/VBoxContainer/Collapse"]
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 3
-modulate = Color(1, 1, 1, 0.45)
-theme_override_font_sizes/font_size = 22
-text = "Tab — close"
-horizontal_alignment = 1


### PR DESCRIPTION
Three HUD/UI fixes in one batch:

**#118 — Non-blocking message history**
- The Tab message history is now a passive overlay that never captures input: the history `RichTextLabel` no longer takes focus (Tab was also `ui_focus_next`, so it grabbed keyboard events) or mouse events (its default `MOUSE_FILTER_STOP` was consuming the mouse motion & clicks that `Player._UnhandledInput` needs for camera & weapon charging). Movement, shooting, & camera all keep working while it's open.
- The on-screen "Tab — messages" & "Tab — close" hints are removed; Tab still toggles the history.
- The now-unused expand/collapse signals are removed; the quit dialog's pause behavior is unchanged.

**#126 — One-line ranked leaderboard entries**
- Entries render as `1. Name  score  (NNms)` — rank numbers in front (sorted position, ties keep list order), ping on the same line.
- Wrapping fixed by turning autowrap off on the entries label & widening the leaderboard panel from 500px to 700px.
- Crown for the leader & streak glow/pulse formatting keep working.

**#127 — Slide cooldown bar replaces punch bar**
- The punch bar (0.3s cooldown, pointless to display) is replaced in place by a slide bar surfacing the real 5s cooldown.
- New `Player.SlideReadyFraction` (0..1, like `PunchReadyFraction`) wired into `Hud.UpdateCooldownBars`.

Validation: `dotnet build` clean (0 warnings/errors) & the full playtest passes (host + shooter + victim).

Fixes #118
Fixes #126
Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a slide cooldown indicator to the HUD, showing slide readiness.
  * Leaderboard entries now display explicit ranks, preserve tie ordering, and show a crown for first place.
  * Expanded the leaderboard layout for improved readability.

* **Bug Fixes**
  * Updated message history to behave as a passive overlay, preventing it from capturing mouse input or unintended scrolling.
  * Simplified message history visibility controls for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->