### PR TITLE
Add a third-person chase view on V

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 | Right mouse | Punch |
 | F | Full-auto ability (3 s, 15 s cooldown) |
 | Space | Jump |
+| V | Toggle first-/third-person view |
 | Esc | Quit dialog |
 
 ## Multiplayer

--- a/core/players/Player.View.cs
+++ b/core/players/Player.View.cs
@@ -1,0 +1,60 @@
+using com.forerunnergames.energyshot.utilities;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Third-person chase view (issue #119): V toggles between the first-person view & a
+// camera behind/above the head. The "Camera3D" head node stays the aim source & its
+// replicated transform is untouched - the chase camera is a separate local-only rig
+// hung off it - so shots, punches, rocket boosts, & the crosshair ray behave
+// identically in both views, & remote players see nothing change.
+public partial class Player
+{
+  [Export] public float ThirdPersonBackMeters = 2.8f;
+  [Export] public float ThirdPersonUpMeters = 1.2f;
+  // The crosshair sprite sits 10m down the aim ray (Player.tscn); the chase camera
+  // pitches down just enough to keep it centered on screen.
+  private const float CrosshairDistanceMeters = 10.0f;
+  private bool _thirdPerson;
+  private SpringArm3D? _thirdPersonArm;
+  private Camera3D? _thirdPersonCamera;
+  // The playtest toggles mid-run & asserts bolts still spawn (issue #119).
+  public bool IsThirdPerson => _thirdPerson;
+
+  private void ApplySavedViewPreference()
+  {
+    if (Settings.ThirdPersonView) SetThirdPerson (enabled: true);
+  }
+
+  private void UpdateViewToggle()
+  {
+    if (!_isInputEnabled || !Input.IsActionJustPressed ("toggle_view")) return;
+    SetThirdPerson (!_thirdPerson);
+    Settings.ThirdPersonView = _thirdPerson; // The chosen view survives restarts (issue #119).
+  }
+
+  private void SetThirdPerson (bool enabled)
+  {
+    _thirdPerson = enabled;
+    if (enabled && _thirdPersonCamera == null) CreateThirdPersonRig();
+    // The #124 draw-over-walls weapon overlay is a first-person trick only: in third
+    // person the own weapons & hands render normally, like every other peer sees them.
+    SetFirstPersonOverlayEnabled (!enabled);
+    (enabled ? _thirdPersonCamera! : _camera).Current = true;
+  }
+
+  // The SpringArm3D pulls the chase camera in whenever world geometry (layer 1) sits
+  // behind the head, so walls never end up between the camera & the player or clip
+  // it inside them. Created in code, local-only: the replicated Camera3D transform &
+  // the synchronizer's property indices stay untouched, & the rig inherits crouch/
+  // slide camera heights, camera kick, & aim pitch for free.
+  private void CreateThirdPersonRig()
+  {
+    _thirdPersonArm = new SpringArm3D { Position = new Vector3 (0.0f, ThirdPersonUpMeters, 0.0f), SpringLength = ThirdPersonBackMeters, CollisionMask = 1, Margin = 0.3f };
+    _thirdPersonArm.AddExcludedObject (GetRid());
+    _camera.AddChild (_thirdPersonArm);
+    var pitch = -Mathf.Atan (ThirdPersonUpMeters / (ThirdPersonBackMeters + CrosshairDistanceMeters));
+    _thirdPersonCamera = new Camera3D { Rotation = new Vector3 (pitch, 0.0f, 0.0f) };
+    _thirdPersonArm.AddChild (_thirdPersonCamera);
+  }
+}

--- a/core/players/Player.View.cs.uid
+++ b/core/players/Player.View.cs.uid
@@ -1,0 +1,1 @@
+uid://g2nv8onf18mr

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using com.forerunnergames.energyshot.weapons;
 using Godot;
 
@@ -154,7 +155,7 @@ public partial class Player
     ApplyOverlayMaterials (_bananaLauncher);
   }
 
-  private static void ApplyOverlayMaterials (Node node)
+  private void ApplyOverlayMaterials (Node node)
   {
     if (node is MeshInstance3D mesh) ApplyOverlayMaterial (mesh);
     foreach (var child in node.GetChildren()) ApplyOverlayMaterials (child);
@@ -162,13 +163,13 @@ public partial class Player
 
   // Per-instance override materials (muzzle, banana launcher) are mutated in place;
   // shared imported materials (glb handle) are duplicated first so puppets keep theirs.
-  private static void ApplyOverlayMaterial (MeshInstance3D mesh)
+  private void ApplyOverlayMaterial (MeshInstance3D mesh)
   {
     if (mesh.MaterialOverride is BaseMaterial3D overrideMaterial) { MakeOverlay (overrideMaterial); return; }
     for (var surface = 0; surface < mesh.GetSurfaceOverrideMaterialCount(); ++surface) ApplyOverlaySurface (mesh, surface);
   }
 
-  private static void ApplyOverlaySurface (MeshInstance3D mesh, int surface)
+  private void ApplyOverlaySurface (MeshInstance3D mesh, int surface)
   {
     if (mesh.GetActiveMaterial (surface) is not BaseMaterial3D material) return;
     var copy = (BaseMaterial3D)material.Duplicate();
@@ -176,12 +177,35 @@ public partial class Player
     mesh.SetSurfaceOverrideMaterial (surface, copy);
   }
 
+  // Each overlaid material's original settings, so the third-person view (issue #119)
+  // can restore the normal on-the-body look & the toggle can re-overlay it.
+  private readonly List <(BaseMaterial3D Material, BaseMaterial3D.TransparencyEnum Transparency, bool NoDepthTest, int RenderPriority)> _overlayMaterials = [];
+
+  private void MakeOverlay (BaseMaterial3D material)
+  {
+    _overlayMaterials.Add ((material, material.Transparency, material.NoDepthTest, material.RenderPriority));
+    ApplyOverlay (material);
+  }
+
   // Alpha transparency is required for render_priority to order the draw (priority
   // only applies in the transparent pass); 99 keeps the crosshairs (100) on top.
-  private static void MakeOverlay (BaseMaterial3D material)
+  private static void ApplyOverlay (BaseMaterial3D material)
   {
     material.Transparency = BaseMaterial3D.TransparencyEnum.Alpha;
     material.NoDepthTest = true;
     material.RenderPriority = 99;
+  }
+
+  // The overlay is a first-person trick only (issue #119): the third-person view
+  // restores every material's originals so the weapons render normally on the body.
+  private void SetFirstPersonOverlayEnabled (bool enabled)
+  {
+    foreach (var original in _overlayMaterials)
+    {
+      if (enabled) { ApplyOverlay (original.Material); continue; }
+      original.Material.Transparency = original.Transparency;
+      original.Material.NoDepthTest = original.NoDepthTest;
+      original.Material.RenderPriority = original.RenderPriority;
+    }
   }
 }

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -345,6 +345,7 @@ public partial class Player : CharacterBody3D
     Input.MouseMode = Input.MouseModeEnum.Captured;
     Position = CalculateRandomSpawnPosition();
     ActivateSpawnArmor();
+    ApplySavedViewPreference(); // Third-person view survives restarts (issue #119).
   }
 
   public override void _ExitTree()
@@ -368,6 +369,7 @@ public partial class Player : CharacterBody3D
     if (!IsMultiplayerAuthority()) return;
     UpdateSpawnArmor();
     UpdateXrayReveal();
+    UpdateViewToggle(); // Third-person toggle on V (issue #119).
     UpdateWeaponSelection();
     UpdateBananaLauncher();
     UpdateBread();

--- a/project.godot
+++ b/project.godot
@@ -113,6 +113,11 @@ crouch={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":67,"key_label":0,"unicode":99,"location":0,"echo":false,"script":null)
 ]
 }
+toggle_view={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":86,"key_label":0,"unicode":118,"location":0,"echo":false,"script":null)
+]
+}
 messages={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -222,6 +222,15 @@ public partial class PlaytestDriver : Node
     // replicate here so the glow & pulsing leaderboard entry clear.
     await WaitUntil (() => victim.ZapStreakCount == 0, 15, "victim's streak reset replicated to shooter");
 
+    // Third-person view (#119): toggle mid-run so the fire-rate & full-auto phases
+    // below prove bolts still spawn from the aim ray with the chase camera live.
+    // Toggle-until-third-person (instead of a single press) absorbs a persisted
+    // third-person preference (the view survives restarts by design): whatever the
+    // starting view, the phases below must run in third person.
+    var startedThirdPerson = Self.IsThirdPerson;
+    await ToggleViewUntil (thirdPerson: true);
+    Assert (Self.IsThirdPerson, "third-person view toggled on (#119)");
+
     // Fire-rate cap: spamming can spawn at most 1 bolt (cooldown blocks recharging).
     AimAt (Self.GlobalPosition + new Vector3 (0, 1, 10)); // Aim away from everyone.
     var boltsBefore = _boltsSpawned;
@@ -275,6 +284,23 @@ public partial class PlaytestDriver : Node
     await Task.Delay (100);
     ReleaseAction ("crouch");
     await WaitUntil (() => !Self.Crouching, 5, "stood back up after the canceled slide (#131)");
+
+    // The toggle persists to the shared user settings (#119); restore the starting
+    // view so a playtest run never flips the developer's real preference.
+    await ToggleViewUntil (startedThirdPerson);
+  }
+
+  // Presses V until the view matches; the toggle only persists on a real key press,
+  // so this exercises the exact input path a player uses (#119).
+  private async Task ToggleViewUntil (bool thirdPerson)
+  {
+    for (var attempt = 0; attempt < 2 && Self.IsThirdPerson != thirdPerson; ++attempt)
+    {
+      PressAction ("toggle_view");
+      await Task.Delay (100);
+      ReleaseAction ("toggle_view");
+      await Task.Delay (200);
+    }
   }
 
   private async Task RunVictim()

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -54,6 +54,13 @@ public static class Settings
     set => Set ("last_join_password", value);
   }
 
+  // Third-person chase view (issue #119), remembered so the chosen view survives restarts.
+  public static bool ThirdPersonView
+  {
+    get => GetBool ("third_person_view", false);
+    set => Set ("third_person_view", value);
+  }
+
   // Mini music player visibility (issue #137): hiding it never stops the music.
   public static bool ShowMusicPlayer
   {


### PR DESCRIPTION
Implements #119: press **V** to toggle between the first-person view & a third-person chase camera; press again to switch back. The chosen view persists across restarts.

## How it works

- **Aim is untouched.** The existing `Camera3D` head node remains the single aim source (`FindAimedCollider`, `OnWeaponShotFired`, rocket boosts, punches all still read its transform). The chase camera is a separate, local-only `SpringArm3D` + `Camera3D` rig created in code & hung off the head node, so it inherits yaw, pitch, crouch/slide camera heights, & camera kick for free — shots & punches land exactly where the crosshair points in both views.
- **Nothing replicates.** `Camera3D:position`/`rotation` are replicated properties (indices 4–5) that also place the weapon models on remote copies — moving the real camera back would have floated every puppet's weapon 2.8m behind its body. The code-built rig sidesteps that entirely: the Player.tscn scene & the synchronizer's contiguous 0–16 property indices are unchanged.
- **Wall clipping.** The `SpringArm3D` (world geometry layer only, own body excluded, 0.3 margin) pulls the camera in whenever level geometry sits behind the head, so walls never end up between the camera & the player or clip the camera inside them.
- **Crosshair.** The crosshair sprite sits 10m down the aim ray, so it stays on the correct aim line from the pulled-back camera by construction; the chase camera pitches down slightly (atan(1.2 / 12.8)) to keep it centered on screen. Bolt spawns (camera + direction × muzzle offset, with the camera-swept first frame from #112) are unchanged since they originate from the untouched head camera.
- **#124 overlay interaction.** The local draw-over-walls weapon/hand overlay is now first-person-only: each overlaid material's original transparency/depth-test/render-priority is recorded, & the toggle restores them in third person so your own weapons & hands render normally on the body — exactly like every other peer sees them — then re-applies the overlay when you switch back.
- **Persistence.** `Settings.ThirdPersonView` follows the existing `user://settings.cfg` pattern.

## Non-goals (per issue)

No over-the-shoulder offset switching, no zoom levels, no third-person-specific animations.

## Validation

- `dotnet build`: 0 errors, 0 warnings.
- Full headless playtest **PASS** (host + shooter + victim all exit 0): the shooter now toggles third-person mid-run & the fire-rate & full-auto phases assert bolts still spawn from the pulled-back view; the run restores the starting view afterward so playtests never flip a developer's real preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)