### PR TITLE
Add selectable player colors replicated to every peer

### DIFF
--- a/core/players/Player.Cosmetics.cs
+++ b/core/players/Player.Cosmetics.cs
@@ -9,14 +9,24 @@ namespace com.forerunnergames.energyshot.players;
 // tint, x-ray ghost) uses non-white colors or separate nodes.
 public partial class Player
 {
-  private static readonly Color NormalColor = new("0027ff");
   private static readonly Color HitColor = Colors.DarkRed;
-  // White glow blended over the player's color, so armored players stay identifiable.
-  private static readonly Color SpawnArmorColor = NormalColor.Lerp (Colors.White, 0.65f);
   private static readonly Color XrayColor = new(1.0f, 0.1f, 0.1f, 0.55f);
+  // The player's chosen palette color (issue #43): the "base color" every effect
+  // (hit flash, spawn-armor glow) returns to.
+  private Color BaseColor => PlayerColors.At (_colorIndex);
+  // White glow blended over the player's chosen color, so armored players stay identifiable.
+  private Color SpawnArmorColor => BaseColor.Lerp (Colors.White, 0.65f);
   private void SetColor (Color color) => (_mesh.GetSurfaceOverrideMaterial (0) as StandardMaterial3D)!.AlbedoColor = color;
-  // Restores the player's resting color: white glow while spawn armor holds, normal blue otherwise.
-  private void RestoreBaseColor() => SetColor (SpawnArmor ? SpawnArmorColor : NormalColor);
+  // Restores the player's resting color: white glow while spawn armor holds, the chosen color otherwise.
+  private void RestoreBaseColor() => SetColor (SpawnArmor ? SpawnArmorColor : BaseColor);
+
+  // Re-tints everything derived from the chosen color (issue #43); safe pre-_Ready,
+  // when spawn-state sync runs & the node refs are still null.
+  private void ApplyChosenColor()
+  {
+    if (_mesh != null) RestoreBaseColor();
+    UpdateHandColor();
+  }
 
   // A firing/punching player provably has no spawn armor, & those broadcasts are
   // reliable RPCs - so even if the SpawnArmor=false delta was missed, the white

--- a/core/players/Player.Hands.cs
+++ b/core/players/Player.Hands.cs
@@ -15,19 +15,23 @@ public partial class Player
   [Export] public Vector3 RightHandRestOffset = new(0.55f, -0.45f, -0.85f);
   [Export] public float HandBobFrequency = 2.2f;
   [Export] public float HandBobMeters = 0.05f;
+  private const float HandAlpha = 0.85f;
   private readonly MeshInstance3D?[] _hands = new MeshInstance3D?[2];
   private readonly Tween?[] _handTweens = new Tween?[2];
+  private StandardMaterial3D? _handsMaterial;
   private float _handBobPhase;
   private int ChooseRandomPunchHand() => _rng.Randf() < 0.5f ? 0 : 1;
   private Vector3 HandRestOffset (int hand) => hand == 0 ? LeftHandRestOffset : RightHandRestOffset;
+  // The fists follow the chosen body color too (issue #43).
+  private void UpdateHandColor() { if (_handsMaterial != null) _handsMaterial.AlbedoColor = new Color (BaseColor, HandAlpha); }
 
   // Runs on every peer so everyone sees everyone's fists.
   private void CreateHands()
   {
     var camera = GetNode <Node3D> ("Camera3D");
-    var material = new StandardMaterial3D { AlbedoColor = new Color (NormalColor, 0.85f), Transparency = BaseMaterial3D.TransparencyEnum.Alpha, Roughness = 0.4f };
-    if (IsMultiplayerAuthority()) MakeOverlay (material); // Own first-person hands draw over walls (issue #124).
-    for (var i = 0; i < _hands.Length; ++i) _hands[i] = CreateHand (i, camera, material);
+    _handsMaterial = new StandardMaterial3D { AlbedoColor = new Color (BaseColor, HandAlpha), Transparency = BaseMaterial3D.TransparencyEnum.Alpha, Roughness = 0.4f };
+    if (IsMultiplayerAuthority()) MakeOverlay (_handsMaterial); // Own first-person hands draw over walls (issue #124).
+    for (var i = 0; i < _hands.Length; ++i) _hands[i] = CreateHand (i, camera, _handsMaterial);
     UpdateHandsVisibility();
   }
 

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -58,6 +58,21 @@ public partial class Player : CharacterBody3D
     }
   }
 
+  // Selected body color (issue #43): an index into PlayerColors, chosen in the
+  // host/join dialog & replicated like DisplayName so every peer tints this player's
+  // body, fists, & leaderboard entry. Duplicates are allowed - name tags & the crown
+  // disambiguate; the flash/glow effects always return to this chosen color.
+  [Export]
+  public int ColorIndex
+  {
+    get => _colorIndex;
+    set
+    {
+      _colorIndex = value;
+      ApplyChosenColor();
+    }
+  }
+
   // Round-trip time to the server in ms, measured server-side once a second &
   // replicated like Score so every peer can render it on the leaderboard (issue
   // #100); -1 = not measured yet.
@@ -270,6 +285,7 @@ public partial class Player : CharacterBody3D
   private Sprite3D _healthTag = null!;
   private ProgressBar _healthBar = null!;
   private string _displayName = string.Empty;
+  private int _colorIndex;
   private int _health;
   private int _score;
   private int _maxHealth = 200;

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -47,6 +47,7 @@ shadow_size = 10
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_kwhax"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_tcox5"]
+resource_local_to_scene = true
 albedo_color = Color(0, 0.152941, 1, 1)
 
 [sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_di3dt"]
@@ -104,6 +105,9 @@ properties/15/replication_mode = 2
 properties/16/path = NodePath(".:PingMs")
 properties/16/spawn = true
 properties/16/replication_mode = 2
+properties/17/path = NodePath(".:ColorIndex")
+properties/17/spawn = true
+properties/17/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/core/players/PlayerColors.cs
+++ b/core/players/PlayerColors.cs
@@ -24,11 +24,12 @@ public static class PlayerColors
 
   public static int Count => Palette.Length;
   // Out-of-range (e.g. a stale saved setting after a palette change, or a spoofed
-  // value) falls back to the default blue instead of crashing every peer.
-  public static Color At (int index) => index >= 0 && index < Palette.Length ? Palette[index] : Palette[0];
+  // replicated value) always lands on the default blue - never some other entry -
+  // so every consumer (body tint, dialogs, leaderboard) agrees on the fallback.
+  public static int NormalizeIndex (int index) => index >= 0 && index < Palette.Length ? index : 0;
+  public static Color At (int index) => Palette[NormalizeIndex (index)];
   // Leaderboard name tint (issue #43): lightened so dark palette entries stay readable on the HUD.
   public static string TextHex (int index) => At (index).Lerp (Colors.White, 0.35f).ToHtml (includeAlpha: false);
-  public static int Clamp (int index) => Mathf.Clamp (index, 0, Palette.Length - 1);
   // Fills a host/join dialog dropdown with one swatch + name entry per palette color.
   public static void Populate (OptionButton button)
   {

--- a/core/players/PlayerColors.cs
+++ b/core/players/PlayerColors.cs
@@ -1,0 +1,44 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Selectable body colors (issue #43): a small, distinct, colorblind-friendly palette
+// (Okabe-Ito based) that every peer resolves by replicated index. White is excluded
+// on purpose - it's exclusively the spawn-armor indicator (issue #114).
+public static class PlayerColors
+{
+  private static readonly string[] Names = { "Blue", "Orange", "Sky Blue", "Green", "Yellow", "Vermilion", "Pink", "Purple", "Teal" };
+
+  private static readonly Color[] Palette =
+  {
+    new("0027ff"), // Blue: the original default body color.
+    new("e69f00"),
+    new("56b4e9"),
+    new("009e73"),
+    new("f0e442"),
+    new("d55e00"),
+    new("cc79a7"),
+    new("8f45c9"),
+    new("00bfc4")
+  };
+
+  public static int Count => Palette.Length;
+  // Out-of-range (e.g. a stale saved setting after a palette change, or a spoofed
+  // value) falls back to the default blue instead of crashing every peer.
+  public static Color At (int index) => index >= 0 && index < Palette.Length ? Palette[index] : Palette[0];
+  // Leaderboard name tint (issue #43): lightened so dark palette entries stay readable on the HUD.
+  public static string TextHex (int index) => At (index).Lerp (Colors.White, 0.35f).ToHtml (includeAlpha: false);
+  public static int Clamp (int index) => Mathf.Clamp (index, 0, Palette.Length - 1);
+  // Fills a host/join dialog dropdown with one swatch + name entry per palette color.
+  public static void Populate (OptionButton button)
+  {
+    for (var i = 0; i < Palette.Length; ++i) button.AddIconItem (Swatch (i), Names[i], i);
+  }
+
+  private static Texture2D Swatch (int index)
+  {
+    var image = Image.CreateEmpty (64, 64, false, Image.Format.Rgb8);
+    image.Fill (At (index));
+    return ImageTexture.CreateFromImage (image);
+  }
+}

--- a/core/players/PlayerColors.cs.uid
+++ b/core/players/PlayerColors.cs.uid
@@ -1,0 +1,1 @@
+uid://df3cmkfopo83y

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -33,6 +33,7 @@ public partial class World : Node3D
   private Player? _selfPlayer;
   private string _selfPlayerName = string.Empty;
   private int _selfDifficulty = 2;
+  private int _selfColorIndex; // Chosen body color (issue #43), applied on our own spawned node.
   private int _score;
   private int FindPlayerId (string displayName) => FindPlayer (displayName)?.NetworkId ?? 0;
   private Player? FindPlayer (string displayName) => GetChildren().OfType <Player>().FirstOrDefault (player => player.DisplayName == displayName);
@@ -99,16 +100,16 @@ public partial class World : Node3D
 
   // Session entry points for the automated playtest harness: same code paths the
   // host/join dialogs use, minus the UI & UPnP.
-  public void StartHostSession (string playerName, int difficulty, int port, string password)
+  public void StartHostSession (string playerName, int difficulty, int port, string password, int colorIndex = 0)
   {
     var peer = new ENetMultiplayerPeer();
     var error = peer.CreateServer (port);
     if (error != Error.Ok) GD.PrintErr ($"Playtest host failed: {error}");
     Multiplayer.MultiplayerPeer = peer;
-    OnHostGameSuccess (playerName, difficulty, MaxPlayers, password);
+    OnHostGameSuccess (playerName, difficulty, MaxPlayers, password, colorIndex);
   }
 
-  public void StartClientSession (string playerName, int difficulty, string address, int port, string password)
+  public void StartClientSession (string playerName, int difficulty, string address, int port, string password, int colorIndex = 0)
   {
     var peer = new ENetMultiplayerPeer();
     var error = peer.CreateClient (address, port);
@@ -116,7 +117,7 @@ public partial class World : Node3D
     Multiplayer.MultiplayerPeer = peer;
     // One-shot: a retried session (e.g. the playtest's wrong-password probe, issue
     // #109) must not replay stale credentials from an earlier attempt's handler.
-    Multiplayer.Connect (MultiplayerApi.SignalName.ConnectedToServer, Callable.From (() => OnJoinGameSuccess (playerName, difficulty, password)), (uint)ConnectFlags.OneShot);
+    Multiplayer.Connect (MultiplayerApi.SignalName.ConnectedToServer, Callable.From (() => OnJoinGameSuccess (playerName, difficulty, password, colorIndex)), (uint)ConnectFlags.OneShot);
   }
 
   // Dedicated-server exports carry the feature tag, so the server binary needs no flag;
@@ -165,7 +166,7 @@ public partial class World : Node3D
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void RequestPlayerSlot (string playerName, int difficulty, string password)
+  private void RequestPlayerSlot (string playerName, int difficulty, string password, int colorIndex)
   {
     if (!Multiplayer.IsServer()) return;
     var senderId = Multiplayer.GetRemoteSenderId();
@@ -205,7 +206,7 @@ public partial class World : Node3D
       return;
     }
 
-    AddPlayer (senderId, playerName, Player.MaxHealthFor (difficulty));
+    AddPlayer (senderId, playerName, Player.MaxHealthFor (difficulty), colorIndex);
   }
 
   // Delay the disconnect so the kick-reason RPC isn't dropped by an immediate peer disconnect (see issue #23).
@@ -218,21 +219,22 @@ public partial class World : Node3D
     Multiplayer.MultiplayerPeer.DisconnectPeer (peerId);
   }
 
-  private void OnHostGameSuccess (string playerName, int difficulty, int maxPlayers, string password)
+  private void OnHostGameSuccess (string playerName, int difficulty, int maxPlayers, string password, int colorIndex)
   {
     _maxPlayers = Mathf.Clamp (maxPlayers, 2, MaxPlayers);
     _serverPassword = password;
     Multiplayer.PeerConnected += OnClientConnectedToServer;
     Multiplayer.PeerDisconnected += OnClientDisconnectedFromServer;
-    AddPlayer (Multiplayer.GetUniqueId(), playerName, Player.MaxHealthFor (difficulty));
+    AddPlayer (Multiplayer.GetUniqueId(), playerName, Player.MaxHealthFor (difficulty), colorIndex);
   }
 
-  private void OnJoinGameSuccess (string playerName, int difficulty, string password)
+  private void OnJoinGameSuccess (string playerName, int difficulty, string password, int colorIndex)
   {
     _selfPlayerName = playerName;
     _selfDifficulty = difficulty;
+    _selfColorIndex = colorIndex;
     if (!Multiplayer.IsConnected (MultiplayerApi.SignalName.ServerDisconnected, _onServerDisconnectedCallable)) Multiplayer.Connect (MultiplayerApi.SignalName.ServerDisconnected, _onServerDisconnectedCallable);
-    RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty, password);
+    RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty, password, colorIndex);
   }
 
   private void OnServerDisconnected() => EmitSignal (SignalName.ServerShutDown);
@@ -264,17 +266,19 @@ public partial class World : Node3D
     // This node is the replication authority, so the difficulty health pool must be
     // set here (client-side) - values set on the server copy get overwritten by sync.
     spawnedPlayer.MaxHealth = Player.MaxHealthFor (_selfDifficulty);
+    spawnedPlayer.ColorIndex = _selfColorIndex; // Chosen body color (issue #43), same authority rule.
     spawnedPlayer.Health = spawnedPlayer.MaxHealth;
     spawnedPlayer.RespawnedShot += (playerName, shotByPlayerName) => _networkManager.NotifyPlayerRespawnedShot (playerName, shotByPlayerName);
     spawnedPlayer.RespawnedFell += playerName => _networkManager.NotifyPlayerRespawnedFell (playerName);
     RegisterSelf (spawnedPlayer);
   }
 
-  private void AddPlayer (int peerId, string playerName, int maxHealth)
+  private void AddPlayer (int peerId, string playerName, int maxHealth, int colorIndex)
   {
     var player = _playerScene.Instantiate <Player>();
     player.Name = $"{peerId}";
     player.MaxHealth = maxHealth;
+    player.ColorIndex = colorIndex; // Chosen body color (issue #43), carried into spawn state for every peer.
     player.RespawnedShot += (respawnedPlayerName, shotByPlayerName) => _networkManager.NotifyPlayerRespawnedShot (respawnedPlayerName, shotByPlayerName);
     player.RespawnedFell += respawnedPlayerName => _networkManager.NotifyPlayerRespawnedFell (respawnedPlayerName);
     AddChild (player);

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -21,6 +21,10 @@ public partial class PlaytestDriver : Node
   private const string HostName = "Host";
   private const string ShooterName = "Shooter";
   private const string VictimName = "Victim";
+  // Distinct chosen body colors per role (issue #43), asserted to replicate everywhere.
+  private const int HostColor = 1;
+  private const int ShooterColor = 3;
+  private const int VictimColor = 5;
   private World _world = null!;
   private string _role = string.Empty;
   private string _address = "127.0.0.1";
@@ -92,8 +96,10 @@ public partial class PlaytestDriver : Node
 
   private async Task RunHost()
   {
-    _world.StartHostSession (HostName, difficulty: 2, Port, Password);
+    _world.StartHostSession (HostName, difficulty: 2, Port, Password, HostColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players joined");
+    // Chosen body colors (issue #43) replicate to the host like every other peer.
+    await WaitUntil (() => FindPlayer (ShooterName)?.ColorIndex == ShooterColor && FindPlayer (VictimName)?.ColorIndex == VictimColor, 15, "clients' chosen colors replicated to host (#43)");
     // Exactly one player wears the crown even at 0-0 (issue #107).
     await WaitUntil (() => _world.GetPlayers().Count (player => player.IsCrowned) == 1, 10, "exactly one player crowned at 0-0");
     // Server-measured pings replicate back to every peer (issue #100).
@@ -115,13 +121,16 @@ public partial class PlaytestDriver : Node
 
   private async Task RunShooter()
   {
-    _world.StartClientSession (ShooterName, difficulty: 1, _address, Port, Password);
+    _world.StartClientSession (ShooterName, difficulty: 1, _address, Port, Password, ShooterColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
     var victim = FindPlayer (VictimName)!;
     var host = FindPlayer (HostName)!;
     Assert (victim.MaxHealth == 400, $"victim MaxHealth replicated as Beginner 400, got {victim.MaxHealth}");
     Assert (host.MaxHealth == 200, $"host MaxHealth replicated as Expert 200, got {host.MaxHealth}");
     Assert (Self.MaxHealth == 300, $"own MaxHealth is Intermediate 300, got {Self.MaxHealth}");
+    // Chosen body colors (issue #43): everyone's pick replicates to this peer.
+    Assert (Self.ColorIndex == ShooterColor, $"own chosen color is {ShooterColor}, got {Self.ColorIndex}");
+    await WaitUntil (() => victim.ColorIndex == VictimColor && host.ColorIndex == HostColor, 15, "victim's & host's chosen colors replicated to shooter (#43)");
     Assert (Self.HeldWeapon == HeldWeapon.None, "spawned unarmed (#72)");
     // The server measures our ping & tells us within a tick or two (issue #100).
     await WaitUntil (() => Self.PingMs >= 0, 15, "own ping measured by the server");
@@ -140,6 +149,11 @@ public partial class PlaytestDriver : Node
 
     // Wait out everyone's initial spawn armor before the damage phase.
     await WaitUntil (() => !victim.SpawnArmor, 15, "victim's initial spawn armor expired");
+
+    // Chosen color on the body (issue #43): with armor's white glow gone, the victim's
+    // per-instance body material must show exactly its picked palette color.
+    var victimBody = (StandardMaterial3D)victim.GetNode <MeshInstance3D> ("MeshInstance3D").GetSurfaceOverrideMaterial (0);
+    Assert (victimBody.AlbedoColor.IsEqualApprox (PlayerColors.At (VictimColor)), "victim's body tinted with its chosen color (#43)");
 
     // Streak replication (#88): the victim simulates an active 3-streak; it must
     // replicate here so the on-fire glow & pulsing leaderboard entry appear.
@@ -282,9 +296,11 @@ public partial class PlaytestDriver : Node
     // Password enforcement (issue #109): a wrong password must get kicked with
     // "Wrong password." before the real join succeeds.
     await AssertWrongPasswordIsKicked();
-    _world.StartClientSession (VictimName, difficulty: 0, _address, Port, Password);
+    _world.StartClientSession (VictimName, difficulty: 0, _address, Port, Password, VictimColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
     Assert (Self.MaxHealth == 400, $"own MaxHealth is Beginner 400, got {Self.MaxHealth}");
+    // Chosen body color (issue #43): the shooter's pick replicates to the victim too.
+    await WaitUntil (() => FindPlayer (ShooterName)?.ColorIndex == ShooterColor, 15, "shooter's chosen color replicated to victim (#43)");
     Assert (Self.SpawnArmor, "spawned with spawn armor");
     // Synced music (issue #137): same track as everyone & the shooter's vote
     // propagated here through the server broadcast.

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -123,6 +123,10 @@ public partial class PlaytestDriver : Node
   {
     _world.StartClientSession (ShooterName, difficulty: 1, _address, Port, Password, ShooterColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
+    // DisplayName is an on-change sync that can land a beat after the spawn itself
+    // under CI load (issue #78): wait for both names before dereferencing the
+    // lookups, or FindPlayer returns null right here.
+    await WaitUntil (() => FindPlayer (VictimName) != null && FindPlayer (HostName) != null, 30, "victim's & host's names replicated to shooter");
     var victim = FindPlayer (VictimName)!;
     var host = FindPlayer (HostName)!;
     Assert (victim.MaxHealth == 400, $"victim MaxHealth replicated as Beginner 400, got {victim.MaxHealth}");

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -98,7 +98,8 @@ public partial class PlaytestDriver : Node
   {
     _world.StartHostSession (HostName, difficulty: 2, Port, Password, HostColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players joined");
-    // Chosen body colors (issue #43) replicate to the host like every other peer.
+    // Chosen body colors (issue #43): own pick stuck & both clients' picks replicate to the host.
+    Assert (Self.ColorIndex == HostColor, $"own chosen color is {HostColor}, got {Self.ColorIndex}");
     await WaitUntil (() => FindPlayer (ShooterName)?.ColorIndex == ShooterColor && FindPlayer (VictimName)?.ColorIndex == VictimColor, 15, "clients' chosen colors replicated to host (#43)");
     // Exactly one player wears the crown even at 0-0 (issue #107).
     await WaitUntil (() => _world.GetPlayers().Count (player => player.IsCrowned) == 1, 10, "exactly one player crowned at 0-0");
@@ -184,6 +185,11 @@ public partial class PlaytestDriver : Node
     Assert (victim.Health < healthBeforePunch, $"punch damaged the victim ({healthBeforePunch} -> {victim.Health})");
     // Sync property index 14 (#88): the punch stun must replicate to the shooter's copy.
     await WaitUntil (() => victim.StunFactor > 0.0f, 2, "victim's punch stun replicated to shooter");
+
+    // Hit-flash restoration (#43): the punch just flashed this puppet's body dark
+    // red; the flash must settle back onto the exact chosen palette color - the
+    // riskiest base-color path, since it used to restore a hardcoded default.
+    await WaitUntil (() => victimBody.AlbedoColor.IsEqualApprox (PlayerColors.At (VictimColor)), 15, "victim's body returned to its chosen color after the hit flash (#43)");
 
     // Weapon lifecycle (#72): everyone spawns unarmed, so collect the deterministic
     // laser pickup the WeaponSpawner keeps in the spawn room in --playtest mode.
@@ -329,8 +335,9 @@ public partial class PlaytestDriver : Node
     _world.StartClientSession (VictimName, difficulty: 0, _address, Port, Password, VictimColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
     Assert (Self.MaxHealth == 400, $"own MaxHealth is Beginner 400, got {Self.MaxHealth}");
-    // Chosen body color (issue #43): the shooter's pick replicates to the victim too.
-    await WaitUntil (() => FindPlayer (ShooterName)?.ColorIndex == ShooterColor, 15, "shooter's chosen color replicated to victim (#43)");
+    // Chosen body colors (issue #43): own pick stuck & both peers' picks replicate to the victim.
+    Assert (Self.ColorIndex == VictimColor, $"own chosen color is {VictimColor}, got {Self.ColorIndex}");
+    await WaitUntil (() => FindPlayer (ShooterName)?.ColorIndex == ShooterColor && FindPlayer (HostName)?.ColorIndex == HostColor, 15, "shooter's & host's chosen colors replicated to victim (#43)");
     Assert (Self.SpawnArmor, "spawned with spawn armor");
     // Synced music (issue #137): same track as everyone & the shooter's vote
     // propagated here through the server broadcast.

--- a/ui/UI.cs
+++ b/ui/UI.cs
@@ -9,8 +9,8 @@ namespace com.forerunnergames.energyshot.ui;
 public partial class UI : CanvasLayer
 {
   [Signal] public delegate void MessageEventHandler (string message, string excludedPlayerName);
-  [Signal] public delegate void HostGameSuccessEventHandler (string playerName, int difficulty, int maxPlayers, string password);
-  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName, int difficulty, string password);
+  [Signal] public delegate void HostGameSuccessEventHandler (string playerName, int difficulty, int maxPlayers, string password, int colorIndex);
+  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName, int difficulty, string password, int colorIndex);
   [Signal] public delegate void JoinCanceledEventHandler();
   [Signal] public delegate void GamePausedEventHandler();
   [Signal] public delegate void GameResumedEventHandler();
@@ -38,8 +38,8 @@ public partial class UI : CanvasLayer
     _hud.GamePaused += () => EmitSignal (SignalName.GamePaused);
     _hud.GameResumed += () => EmitSignal (SignalName.GameResumed);
     _hud.GameQuit += () => EmitSignal (SignalName.GameQuit);
-    _hostGameDialog.HostGameSuccess += (playerName, difficulty, maxPlayers, password) => EmitSignal (SignalName.HostGameSuccess, playerName, difficulty, maxPlayers, password);
-    _joinGameDialog.JoinGameSuccess += (playerName, difficulty, password) => EmitSignal (SignalName.JoinGameSuccess, playerName, difficulty, password);
+    _hostGameDialog.HostGameSuccess += (playerName, difficulty, maxPlayers, password, colorIndex) => EmitSignal (SignalName.HostGameSuccess, playerName, difficulty, maxPlayers, password, colorIndex);
+    _joinGameDialog.JoinGameSuccess += (playerName, difficulty, password, colorIndex) => EmitSignal (SignalName.JoinGameSuccess, playerName, difficulty, password, colorIndex);
     // Animated joining screen (issue #91): covers connect through spawn; failures reopen the join dialog.
     _joinGameDialog.ConnectStarted += _joiningScreen.Open;
     _joinGameDialog.ConnectFailed += _joiningScreen.Close;

--- a/ui/dialogs/host/HostGameDialog.cs
+++ b/ui/dialogs/host/HostGameDialog.cs
@@ -1,3 +1,4 @@
+using com.forerunnergames.energyshot.players;
 using com.forerunnergames.energyshot.utilities;
 using Godot;
 
@@ -5,12 +6,13 @@ namespace com.forerunnergames.energyshot.ui.dialogs;
 
 public partial class HostGameDialog : Control
 {
-  [Signal] public delegate void HostGameSuccessEventHandler (string playerName, int difficulty, int maxPlayers, string password);
+  [Signal] public delegate void HostGameSuccessEventHandler (string playerName, int difficulty, int maxPlayers, string password, int colorIndex);
   [Signal] public delegate void ClosedEventHandler();
   private Button _closeButton = null!;
   private Button _hostGameButton = null!;
   private LineEdit _playerName = null!;
   private OptionButton _difficulty = null!;
+  private OptionButton _playerColor = null!;
   private SpinBox _maxPlayers = null!;
   private LineEdit _password = null!;
   private LineEdit _serverAddress = null!;
@@ -33,6 +35,9 @@ public partial class HostGameDialog : Control
     _difficulty = GetNode <OptionButton> ("PanelContainer/MarginContainer/VBoxContainer/Difficulty");
     // The dropdown's popup items don't inherit the button's font size override.
     _difficulty.GetPopup().AddThemeFontSizeOverride ("font_size", 90);
+    _playerColor = GetNode <OptionButton> ("PanelContainer/MarginContainer/VBoxContainer/PlayerColor");
+    _playerColor.GetPopup().AddThemeFontSizeOverride ("font_size", 90);
+    PlayerColors.Populate (_playerColor); // Selectable body color (issue #43).
     _maxPlayers = GetNode <SpinBox> ("PanelContainer/MarginContainer/VBoxContainer/MaxPlayers");
     _password = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/Password");
     _serverAddress = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/ServerAddress");
@@ -56,6 +61,7 @@ public partial class HostGameDialog : Control
     if (string.IsNullOrEmpty (_playerName.Text)) _playerName.Text = Settings.PlayerName;
     if (string.IsNullOrEmpty (_password.Text)) _password.Text = Settings.HostPassword;
     _difficulty.Selected = Settings.Difficulty;
+    _playerColor.Selected = PlayerColors.Clamp (Settings.PlayerColor);
     _maxPlayers.Value = Settings.MaxPlayers;
     UpdateHostGameButtonState();
     Show();
@@ -103,10 +109,11 @@ public partial class HostGameDialog : Control
     GD.Print ($"Successfully hosted server at [{_serverAddress.Text}:{_serverPort}]!");
     Settings.PlayerName = _playerName.Text;
     Settings.Difficulty = _difficulty.Selected;
+    Settings.PlayerColor = _playerColor.Selected;
     Settings.MaxPlayers = (int)_maxPlayers.Value;
     Settings.HostPassword = _password.Text;
     Hide();
-    EmitSignal (SignalName.HostGameSuccess, _playerName.Text, _difficulty.Selected, (int)_maxPlayers.Value, _password.Text);
+    EmitSignal (SignalName.HostGameSuccess, _playerName.Text, _difficulty.Selected, (int)_maxPlayers.Value, _password.Text, _playerColor.Selected);
   }
 
   private void OnError (string error)

--- a/ui/dialogs/host/HostGameDialog.cs
+++ b/ui/dialogs/host/HostGameDialog.cs
@@ -61,7 +61,7 @@ public partial class HostGameDialog : Control
     if (string.IsNullOrEmpty (_playerName.Text)) _playerName.Text = Settings.PlayerName;
     if (string.IsNullOrEmpty (_password.Text)) _password.Text = Settings.HostPassword;
     _difficulty.Selected = Settings.Difficulty;
-    _playerColor.Selected = PlayerColors.Clamp (Settings.PlayerColor);
+    _playerColor.Selected = PlayerColors.NormalizeIndex (Settings.PlayerColor);
     _maxPlayers.Value = Settings.MaxPlayers;
     UpdateHostGameButtonState();
     Show();

--- a/ui/dialogs/host/HostGameDialog.tscn
+++ b/ui/dialogs/host/HostGameDialog.tscn
@@ -97,6 +97,11 @@ popup/item_1/id = 1
 popup/item_2/text = "Expert (1x health)"
 popup/item_2/id = 2
 
+[node name="PlayerColor" type="OptionButton" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 90
+alignment = 1
+
 [node name="MaxPlayersLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 50

--- a/ui/dialogs/join/JoinGameDialog.cs
+++ b/ui/dialogs/join/JoinGameDialog.cs
@@ -71,7 +71,7 @@ public partial class JoinGameDialog : Control
     if (string.IsNullOrEmpty (_password.Text)) _password.Text = Settings.LastJoinPassword;
     if (string.IsNullOrEmpty (_serverAddress.Text)) _serverAddress.Text = Settings.LastJoinAddress;
     _difficulty.Selected = Settings.Difficulty;
-    _playerColor.Selected = PlayerColors.Clamp (Settings.PlayerColor);
+    _playerColor.Selected = PlayerColors.NormalizeIndex (Settings.PlayerColor);
     UpdateJoinGameButtonState();
     Show();
   }

--- a/ui/dialogs/join/JoinGameDialog.cs
+++ b/ui/dialogs/join/JoinGameDialog.cs
@@ -1,3 +1,4 @@
+using com.forerunnergames.energyshot.players;
 using com.forerunnergames.energyshot.utilities;
 using Godot;
 
@@ -5,7 +6,7 @@ namespace com.forerunnergames.energyshot.ui.dialogs;
 
 public partial class JoinGameDialog : Control
 {
-  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName, int difficulty, string password);
+  [Signal] public delegate void JoinGameSuccessEventHandler (string playerName, int difficulty, string password, int colorIndex);
   [Signal] public delegate void ClosedEventHandler();
   // Hands the join attempt off to the animated joining screen (issue #91).
   [Signal] public delegate void ConnectStartedEventHandler (string address);
@@ -14,6 +15,7 @@ public partial class JoinGameDialog : Control
   private Button _joinGameButton = null!;
   private LineEdit _playerName = null!;
   private OptionButton _difficulty = null!;
+  private OptionButton _playerColor = null!;
   private LineEdit _password = null!;
   private LineEdit _serverAddress = null!;
   private Label _middleText = null!;
@@ -43,6 +45,9 @@ public partial class JoinGameDialog : Control
     _difficulty = GetNode <OptionButton> ("PanelContainer/MarginContainer/VBoxContainer/Difficulty");
     // The dropdown's popup items don't inherit the button's font size override.
     _difficulty.GetPopup().AddThemeFontSizeOverride ("font_size", 90);
+    _playerColor = GetNode <OptionButton> ("PanelContainer/MarginContainer/VBoxContainer/PlayerColor");
+    _playerColor.GetPopup().AddThemeFontSizeOverride ("font_size", 90);
+    PlayerColors.Populate (_playerColor); // Selectable body color (issue #43).
     _password = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/Password");
     _serverAddress = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/ServerAddress");
     _middleText = GetNode <Label> ("PanelContainer/MarginContainer/VBoxContainer/MiddleText");
@@ -66,6 +71,7 @@ public partial class JoinGameDialog : Control
     if (string.IsNullOrEmpty (_password.Text)) _password.Text = Settings.LastJoinPassword;
     if (string.IsNullOrEmpty (_serverAddress.Text)) _serverAddress.Text = Settings.LastJoinAddress;
     _difficulty.Selected = Settings.Difficulty;
+    _playerColor.Selected = PlayerColors.Clamp (Settings.PlayerColor);
     UpdateJoinGameButtonState();
     Show();
   }
@@ -124,9 +130,10 @@ public partial class JoinGameDialog : Control
     Settings.PlayerName = _playerName.Text;
     Settings.LastJoinAddress = _serverAddress.Text;
     Settings.Difficulty = _difficulty.Selected;
+    Settings.PlayerColor = _playerColor.Selected;
     Settings.LastJoinPassword = _password.Text;
     GD.Print ($"Successfully connected to server at [{_serverAddress.Text}:{_serverPort}]");
-    EmitSignal (SignalName.JoinGameSuccess, _playerName.Text, _difficulty.Selected, _password.Text);
+    EmitSignal (SignalName.JoinGameSuccess, _playerName.Text, _difficulty.Selected, _password.Text, _playerColor.Selected);
   }
 
   // Failures return here from the joining screen, showing the error in this dialog as before (issue #91).

--- a/ui/dialogs/join/JoinGameDialog.tscn
+++ b/ui/dialogs/join/JoinGameDialog.tscn
@@ -101,6 +101,11 @@ popup/item_1/id = 1
 popup/item_2/text = "Expert (1x health)"
 popup/item_2/id = 2
 
+[node name="PlayerColor" type="OptionButton" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 90
+alignment = 1
+
 [node name="HSeparator2" type="HSeparator" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -62,9 +62,11 @@ public partial class Hud : Control
   // 3+ streak entries glow & pulse so the hot player stands out (see issue #77); the
   // current leader wears the crown (issue #107) & every entry shows its ping (issue #100).
   // Entries are ranked by sorted position, ties keep list order (issue #126).
+  // Names are tinted with each player's chosen body color (issue #43).
   private static string LeaderboardEntry (players.Player player, int rank)
   {
-    var entry = $"{rank}. {player.DisplayName}  {player.Score}  ({Mathf.Max (0, player.PingMs)}ms)";
+    var name = $"[color=#{players.PlayerColors.TextHex (player.ColorIndex)}]{player.DisplayName}[/color]";
+    var entry = $"{rank}. {name}  {player.Score}  ({Mathf.Max (0, player.PingMs)}ms)";
     if (player.IsOnStreak) entry = $"[pulse freq=1.5 color=#ffd24d ease=-2.0][wave amp=18.0 freq=4.0][b]{entry}[/b][/wave][/pulse]";
     return rank == 1 ? $"\U0001F451 {entry}" : entry;
   }

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -34,6 +34,13 @@ public static class Settings
     set => Set ("difficulty", value);
   }
 
+  // Selected body color (issue #43): an index into PlayerColors, remembered like the name.
+  public static int PlayerColor
+  {
+    get => GetInt ("player_color");
+    set => Set ("player_color", value);
+  }
+
   // Host-chosen player cap (issue #73), remembered like difficulty.
   public static int MaxPlayers
   {


### PR DESCRIPTION
## Summary

Implements #43: each player picks a body color in the host/join dialog from a small palette; the pick persists in settings, replicates to every peer, & tints the body, fists, & leaderboard name.

## What changed

- **Color picker**: a swatch + name dropdown in both the host & join dialogs, backed by a new `PlayerColors` palette (9 distinct, colorblind-friendly colors, Okabe-Ito based; the original blue remains the default). The choice is saved via `Settings.PlayerColor` like the player name.
- **White stays the spawn-armor indicator (#114)**: white is excluded from the palette, & the armor glow is now computed per player as the chosen color lerped 65% toward white — armored players stay identifiable in any color.
- **Base-color interaction**: the chosen color is now the "base color" every effect returns to. `RestoreBaseColor` resolves `SpawnArmor ? chosen.Lerp(White, 0.65) : chosen`, so the hit flash (dark red) & armor glow both settle back onto the chosen color; the streak glow light, full-auto gun tint, & x-ray silhouettes use their own nodes/materials & are untouched.
- **Replication**: new `ColorIndex` replicated property on `Player` (sync property index 17, appended — 0-16 unchanged), set by the owning client like `DisplayName`/`MaxHealth` & also passed through `RequestPlayerSlot` so the server copy carries it in spawn state for late joiners. Duplicate picks are allowed — name tags & the crown disambiguate. Out-of-range/spoofed indices fall back to the default blue.
- **Per-instance body material**: `Player.tscn`'s body material is now `resource_local_to_scene`, so one player's color (or hit flash) can no longer bleed onto every other player's shared material.
- **Fists** follow the chosen color (they previously used the hardcoded blue).
- **Leaderboard**: names are tinted with each player's color via BBCode (lightened for readability on the dark HUD); streak pulse & crown formatting unchanged.

## Validation

- `dotnet build`: 0 errors, 0 warnings.
- Full playtest **PASS**: each role picks a distinct color; asserted cross-replication on all three peers (host sees both clients' colors, shooter sees victim's & host's, victim sees shooter's) plus the puppet body material showing the exact chosen palette color once spawn armor expires.

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a player color selector when hosting or joining games.
  * Player color choices are saved and restored between sessions.
  * Selected colors now apply consistently to player armor, hands, and visual effects.
  * Player colors replicate across multiplayer sessions.
  * Leaderboard names now use each player’s selected color.

* **Bug Fixes**
  * Improved color restoration and synchronization for spawned players.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->