### PR TITLE
Add the boomerang: steals weapons & scoops pickups on its flight

### DIFF
--- a/core/players/DamageKind.cs
+++ b/core/players/DamageKind.cs
@@ -8,5 +8,6 @@ public enum DamageKind
   Laser,
   FullAuto,
   Punch,
-  Banana
+  Banana,
+  Boomerang
 }

--- a/core/players/Player.Boomerang.cs
+++ b/core/players/Player.Boomerang.cs
@@ -1,0 +1,159 @@
+using com.forerunnergames.energyshot.weapons;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Boomerang (issue #98): the slot-4 throwable that curves out, comes back, & is
+// auto-caught on proximity. Hits en route deal moderate victim-authoritative damage
+// (non-lethal from full health, like the banana blast) & steal the victim's held
+// weapon; world pickups on the flight path get scooped. Stolen & scooped cargo rides
+// home on the boomerang: the server holds it in escrow & grants it to the thrower on
+// the catch, with previousOwner set so the theft-revenge messages (issue #84) fire.
+public partial class Player
+{
+  [Export] public float BoomerangEnergy = 0.4f;
+  [Export] public float BoomerangKnockbackScale = 0.5f;
+  private BoomerangProjectile? _liveBoomerang;
+  private BoomerangProjectile? _visualBoomerang;
+  private Node3D _boomerangHeld = null!;
+  // Playtest-observable (issue #98): true from the throw until the catch or loss.
+  public bool IsBoomerangInFlight => _liveBoomerang != null && IsInstanceValid (_liveBoomerang);
+  // Every peer renders this player's empty hand while their boomerang is out flying.
+  private bool IsBoomerangOut => IsBoomerangInFlight || (_visualBoomerang != null && IsInstanceValid (_visualBoomerang));
+
+  // Held model: the same crossed-arms visual as the projectile, resting in the hand.
+  private void CreateBoomerangHeld()
+  {
+    _boomerangHeld = BoomerangProjectile.CreateVisual();
+    _boomerangHeld.Position = new Vector3 (0.5f, -0.4f, -0.9f);
+    _boomerangHeld.RotationDegrees = new Vector3 (0.0f, 15.0f, 75.0f);
+    GetNode <Node3D> ("Camera3D").AddChild (_boomerangHeld);
+  }
+
+  private void UpdateBoomerang()
+  {
+    if (!IsBoomerangSelected || !HasBoomerang || !_isInputEnabled) return;
+    if (IsBoomerangOut || !Input.IsActionJustPressed ("shoot")) return;
+    ThrowBoomerang();
+  }
+
+  private void ThrowBoomerang()
+  {
+    CancelSpawnArmorIfFired();
+    var direction = -_camera.GlobalTransform.Basis.Z;
+    var origin = _camera.GlobalPosition + direction * 0.9f;
+    _liveBoomerang = SpawnBoomerang (origin, direction, isLive: true);
+    Rpc (MethodName.SpawnVisualBoomerang, origin, direction);
+    UpdateWeaponVisibility(); // The hand empties while the boomerang is out.
+    // The same shoot press must not also fire a full-auto laser this frame.
+    _nextAutoShotIn = FullAutoShotIntervalSeconds;
+  }
+
+  // Visual-only copy of the thrower's boomerang on every other peer. Throwing proves
+  // the thrower's spawn armor is gone, so stale armor whitewash clears here (issue #114).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void SpawnVisualBoomerang (Vector3 origin, Vector3 direction)
+  {
+    ClearArmorDisplayOnRemoteAttack();
+    _visualBoomerang = SpawnBoomerang (origin, direction, isLive: false);
+    _visualBoomerang.TreeExited += OnVisualBoomerangGone;
+    UpdateWeaponVisibility();
+  }
+
+  private void OnVisualBoomerangGone()
+  {
+    _visualBoomerang = null;
+    if (IsInsideTree()) UpdateWeaponVisibility(); // The caught boomerang reappears in the hand.
+  }
+
+  private BoomerangProjectile SpawnBoomerang (Vector3 origin, Vector3 direction, bool isLive)
+  {
+    var boomerang = new BoomerangProjectile();
+    GetParent().AddChild (boomerang);
+    boomerang.Launch (origin, direction, isLive, this);
+    if (!isLive) return boomerang;
+    boomerang.HitPlayer += OnBoomerangHitPlayer;
+    boomerang.ScoopedPickup += OnBoomerangScoopedPickup;
+    boomerang.Caught += OnBoomerangCaught;
+    boomerang.Lost += OnBoomerangLost;
+    return boomerang;
+  }
+
+  // The thrower only reports the clip; the victim applies its own damage & theft
+  // (victim-authoritative, same as ReceiveHit & ReceiveBlast).
+  private void OnBoomerangHitPlayer (Player victim)
+  {
+    GD.Print ($"{DisplayName}: My boomerang clipped {victim.DisplayName}!");
+    _hitmarkerSound.Play();
+    ReportToServer ($"boomerang: {DisplayName} clipped {victim.DisplayName}");
+    victim.RpcId (victim.NetworkId, MethodName.ReceiveBoomerangHit, DisplayName);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ReceiveBoomerangHit (string thrownByPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    if (SpawnArmor) return;
+    var throwerId = Multiplayer.GetRemoteSenderId();
+    GD.Print ($"{DisplayName}: I was clipped by {thrownByPlayerName}'s boomerang!");
+    LastDamageKind = DamageKind.Boomerang; // Message context (issue #84).
+    SurrenderWeaponToBoomerang (throwerId);
+    // A boomerang never zaps out a full-health player, like the banana blast (issue #98).
+    ApplyDamage (BoomerangEnergy, thrownByPlayerName, BoomerangKnockbackScale, isSurvivableAtFullHealth: true);
+  }
+
+  // The theft half of the hit (issue #98): the victim owns its HeldWeapon, so it
+  // releases the weapon itself & files it into the server's boomerang escrow, bound
+  // for the thrower. An unarmed victim (or one whose only weapon is a boomerang
+  // that's out flying) loses nothing.
+  private void SurrenderWeaponToBoomerang (int throwerId)
+  {
+    var type = PickDroppableWeapon();
+    if (type == HeldWeapon.None) return;
+    HeldWeapon &= ~type;
+    ForgetTheft (type);
+    DeselectUnheldWeapon();
+    GD.Print ($"{DisplayName}: That boomerang made off with my {type}!");
+    Spawner.SendStolenEscrowRequest (throwerId, type);
+  }
+
+  private void OnBoomerangScoopedPickup (string pickupName) => Spawner.SendScoopRequest (pickupName);
+
+  private void OnBoomerangCaught()
+  {
+    _liveBoomerang = null;
+    Rpc (MethodName.FreeVisualBoomerang); // Visual copies may lag the catch slightly.
+    _weaponPickupSound.Play(); // Satisfying catch chime, owner-local (issue #123).
+    GD.Print ($"{DisplayName}: I caught my boomerang!");
+    UpdateWeaponVisibility();
+    Spawner.SendBoomerangCatchRequest(); // The server grants any escrowed cargo (issue #98).
+  }
+
+  // The boomerang couldn't complete the trip (safety timeout): it drops as a pickup
+  // where it is, along with any cargo it was carrying (issue #98).
+  private void OnBoomerangLost (Vector3 position)
+  {
+    _liveBoomerang = null;
+    Rpc (MethodName.FreeVisualBoomerang);
+    HeldWeapon &= ~HeldWeapon.Boomerang;
+    DeselectUnheldWeapon();
+    Spawner.SendBoomerangReleaseRequest (position);
+  }
+
+  // Zapping out (or falling off the world) mid-flight: the boomerang & its cargo
+  // drop as pickups wherever the boomerang currently is (issue #98).
+  private void ReleaseBoomerangInFlight()
+  {
+    if (!IsBoomerangInFlight) { _liveBoomerang = null; return; }
+    var position = _liveBoomerang!.GlobalPosition;
+    _liveBoomerang.QueueFree();
+    OnBoomerangLost (position);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void FreeVisualBoomerang()
+  {
+    if (_visualBoomerang == null || !IsInstanceValid (_visualBoomerang)) return;
+    _visualBoomerang.QueueFree();
+  }
+}

--- a/core/players/Player.Boomerang.cs.uid
+++ b/core/players/Player.Boomerang.cs.uid
@@ -1,0 +1,1 @@
+uid://c63o4fnjyw3n2

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -45,15 +45,18 @@ public partial class Player
   public bool Holds (HeldWeapon type) => (_heldWeapon & type) != 0;
   private bool HasLaser => Holds (HeldWeapon.Laser);
   private bool HasBanana => Holds (HeldWeapon.Banana);
+  private bool HasBoomerang => Holds (HeldWeapon.Boomerang);
   private bool IsFistsSelected => _selectedWeapon == SelectedWeapon.Fists;
   private bool IsLaserSelected => _selectedWeapon == SelectedWeapon.Laser;
   private bool IsBananaSelected => _selectedWeapon == SelectedWeapon.Banana;
+  private bool IsBoomerangSelected => _selectedWeapon == SelectedWeapon.Boomerang;
   private WeaponSpawner Spawner => _weaponSpawner ??= GetNode <WeaponSpawner> ("/root/World/WeaponSpawner");
 
   // Falling off the world: held weapons return to the spawn pool via the caps instead
   // of dropping as unreachable pickups below the map.
   private void ClearHeldWeapons()
   {
+    ReleaseBoomerangInFlight(); // A boomerang out flying still drops where it is (issue #98).
     ForgetTheft (_heldWeapon);
     HeldWeapon = HeldWeapon.None;
     SelectedWeapon = SelectedWeapon.Fists;
@@ -71,9 +74,10 @@ public partial class Player
   // Runs on every peer via the replicated HeldWeapon & SelectedWeapon properties.
   private void UpdateWeaponVisibility()
   {
-    if (_bananaLauncher == null) return;
+    if (_bananaLauncher == null || _boomerangHeld == null) return;
     _energyWeapon.Visible = IsLaserSelected && HasLaser;
     _bananaLauncher.Visible = IsBananaSelected && HasBanana;
+    _boomerangHeld.Visible = IsBoomerangSelected && HasBoomerang && !IsBoomerangOut; // Empty hand while it's out flying (issue #98).
     UpdateHandsVisibility(); // Hands render only while fists are selected (issue #82).
   }
 
@@ -85,6 +89,7 @@ public partial class Player
     if (Input.IsActionJustPressed ("weapon_1")) SelectedWeapon = SelectedWeapon.Fists;
     if (Input.IsActionJustPressed ("weapon_2") && HasLaser) SelectedWeapon = SelectedWeapon.Laser;
     if (Input.IsActionJustPressed ("weapon_3") && HasBanana) SelectedWeapon = SelectedWeapon.Banana;
+    if (Input.IsActionJustPressed ("weapon_4") && HasBoomerang) SelectedWeapon = SelectedWeapon.Boomerang; // Slot 4 (issue #98).
   }
 
   // A dropped or lost gun can't stay selected: fall back to fists (issue #82).
@@ -92,6 +97,7 @@ public partial class Player
   {
     if (IsLaserSelected && !HasLaser) SelectedWeapon = SelectedWeapon.Fists;
     if (IsBananaSelected && !HasBanana) SelectedWeapon = SelectedWeapon.Fists;
+    if (IsBoomerangSelected && !HasBoomerang) SelectedWeapon = SelectedWeapon.Fists;
   }
 
   // Called back (via the WeaponSpawner's ConfirmPickup RPC) after the server despawns
@@ -99,7 +105,8 @@ public partial class Player
   public void GrantWeapon (HeldWeapon type, string previousOwner = "")
   {
     HeldWeapon |= type;
-    SelectedWeapon = type == HeldWeapon.Banana ? SelectedWeapon.Banana : SelectedWeapon.Laser; // Every pickup auto-equips (issue #128).
+    // Every pickup auto-equips (issue #128), boomerang included (issue #98).
+    SelectedWeapon = type switch { HeldWeapon.Banana => SelectedWeapon.Banana, HeldWeapon.Boomerang => SelectedWeapon.Boomerang, _ => SelectedWeapon.Laser };
     RememberTheft (type, previousOwner);
     _weaponPickupSound.Play(); // Satisfying pickup chime, owner-local only (issue #123).
     GD.Print ($"{DisplayName}: I picked up a {type}!");
@@ -122,13 +129,12 @@ public partial class Player
     return true;
   }
 
-  // Drops the selected gun (or the other one while boxing) as a world pickup; the
-  // punch branch calls this with a drop chance when a player gets punched.
+  // Drops the selected gun (or another carried one while boxing) as a world pickup;
+  // the punch branch calls this with a drop chance when a player gets punched.
   public void DropHeldWeapon()
   {
-    var type = IsBananaSelected ? HeldWeapon.Banana : HeldWeapon.Laser;
-    if (!Holds (type)) type = type == HeldWeapon.Banana ? HeldWeapon.Laser : HeldWeapon.Banana;
-    if (!Holds (type)) return;
+    var type = PickDroppableWeapon();
+    if (type == HeldWeapon.None) return;
     HeldWeapon &= ~type;
     ForgetTheft (type);
     DeselectUnheldWeapon();
@@ -136,9 +142,27 @@ public partial class Player
     GD.Print ($"{DisplayName}: I dropped my {type}!");
   }
 
-  // Death drops everything carried at the death spot (issue #72).
+  // Selected gun first, then any other carried one. A boomerang that's out flying
+  // isn't in the hand, so it can't be knocked loose or stolen from it (issue #98).
+  private HeldWeapon PickDroppableWeapon()
+  {
+    var preferred = _selectedWeapon switch { SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, _ => HeldWeapon.Laser };
+
+    foreach (var type in new[] { preferred, HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang })
+    {
+      if (!Holds (type)) continue;
+      if (type == HeldWeapon.Boomerang && IsBoomerangInFlight) continue;
+      return type;
+    }
+
+    return HeldWeapon.None;
+  }
+
+  // Death drops everything carried at the death spot (issue #72); a boomerang out
+  // flying drops where the boomerang is instead (issue #98).
   private void DropAllHeldWeapons()
   {
+    ReleaseBoomerangInFlight();
     if (_heldWeapon == HeldWeapon.None) return;
     Spawner.SendDropRequest (GlobalPosition, _heldWeapon);
     ClearHeldWeapons();
@@ -152,6 +176,7 @@ public partial class Player
   {
     ApplyOverlayMaterials (_energyWeapon);
     ApplyOverlayMaterials (_bananaLauncher);
+    ApplyOverlayMaterials (_boomerangHeld);
   }
 
   private static void ApplyOverlayMaterials (Node node)

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -293,6 +293,7 @@ public partial class Player : CharacterBody3D
     _energyWeapon = GetNode <EnergyWeapon> ("Camera3D/EnergyWeapon");
     _bananaLauncher = GetNode <BananaLauncher> ("Camera3D/BananaLauncher");
     _launcherRestPosition = _bananaLauncher.Position;
+    CreateBoomerangHeld(); // Code-built held model, no scene asset (issue #98).
     UpdateWeaponVisibility();
     CreateHands();
     _crossHairs = GetNode <Sprite3D> ("Camera3D/Crosshairs");
@@ -370,6 +371,7 @@ public partial class Player : CharacterBody3D
     UpdateXrayReveal();
     UpdateWeaponSelection();
     UpdateBananaLauncher();
+    UpdateBoomerang();
     UpdateBread();
     UpdateFullAuto (delta);
     UpdatePunch (delta);

--- a/core/weapons/BoomerangProjectile.cs
+++ b/core/weapons/BoomerangProjectile.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+using com.forerunnergames.energyshot.players;
+using Godot;
+
+namespace com.forerunnergames.energyshot.weapons;
+
+// Thrown boomerang (issue #98): curves outbound up to ~25m (or until it meets level
+// geometry), then homes straight back to the thrower, who auto-catches it on
+// proximity. Only the thrower's own boomerang is "live" (reports hits, scoops,
+// the catch, & losses); other peers fly visual-only copies, like BananaProjectile.
+// Player hits en route are victim-authoritative; the return leg ignores geometry so
+// the trip home always completes while the thrower lives. Built entirely from
+// primitive boxes & an existing whiff sound - no downloaded assets.
+public partial class BoomerangProjectile : Node3D
+{
+  [Export] public float Speed = 20.0f;
+  [Export] public float OutboundMeters = 25.0f;
+  [Export] public float CurveDegreesPerSecond = 40.0f;
+  [Export] public float CatchRadiusMeters = 1.5f;
+  [Export] public float ScoopRadiusMeters = 1.5f;
+  [Export] public float MaxLifetimeSeconds = 12.0f;
+  [Export] public float SpinRadiansPerSecond = 25.0f;
+  [Signal] public delegate void HitPlayerEventHandler (Player victim);
+  [Signal] public delegate void ScoopedPickupEventHandler (string pickupName);
+  [Signal] public delegate void CaughtEventHandler();
+  [Signal] public delegate void LostEventHandler (Vector3 position);
+  // Players live on collision layer 2 (Player.tscn); the return leg sweeps only them.
+  private const uint PlayersLayer = 2;
+  private const float SurfaceClearance = 0.3f;
+  private static readonly Color BoomerangOrange = new(1.0f, 0.55f, 0.1f);
+  private readonly HashSet <int> _victimsHit = new();
+  private readonly HashSet <string> _scoopedPickups = new();
+  private Node3D _visual = null!;
+  private Vector3 _direction = Vector3.Forward;
+  private float _traveled;
+  private float _age;
+  private bool _isLive;
+  private bool _returning;
+  private Player? _thrower;
+  private Rid _throwerRid;
+  private Vector3 CatchPoint() => _thrower!.GlobalPosition + Vector3.Up * 1.2f;
+
+  // Shared look for the projectile, the world pickup, & the held model (issue #98):
+  // two bright crossed arms built from primitive boxes. Fresh materials per call so
+  // the first-person overlay tweak (issue #124) can't bleed into pickups.
+  public static Node3D CreateVisual()
+  {
+    var material = new StandardMaterial3D { AlbedoColor = BoomerangOrange, EmissionEnabled = true, Emission = BoomerangOrange * 0.6f, Roughness = 0.4f };
+    var visual = new Node3D();
+    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.85f, 0.06f, 0.18f) }, MaterialOverride = material, Position = new Vector3 (0.28f, 0.0f, 0.0f) });
+    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.18f, 0.06f, 0.85f) }, MaterialOverride = material, Position = new Vector3 (0.0f, 0.0f, 0.28f) });
+    return visual;
+  }
+
+  public override void _Ready()
+  {
+    _visual = CreateVisual();
+    AddChild (_visual);
+    AddWhooshLoop();
+  }
+
+  // Looping whoosh while airborne: the punch whiff replayed on a fast pitch reads as
+  // a spinning throw - reusing an existing sound instead of downloading one (issue #98).
+  private void AddWhooshLoop()
+  {
+    var whoosh = new AudioStreamPlayer3D { Stream = ResourceLoader.Load <AudioStream> ("res://assets/sounds/punch-whiff.wav"), PitchScale = 1.5f };
+    AddChild (whoosh);
+    whoosh.Finished += () => whoosh.Play();
+    whoosh.Play();
+  }
+
+  public void Launch (Vector3 origin, Vector3 direction, bool isLive, Player thrower)
+  {
+    GlobalPosition = origin;
+    _direction = direction.Normalized();
+    _isLive = isLive;
+    _thrower = thrower;
+    _throwerRid = thrower.GetRid();
+  }
+
+  public override void _PhysicsProcess (double delta)
+  {
+    var dt = (float)delta;
+    _age += dt;
+    if (_thrower == null || !IsInstanceValid (_thrower)) { QueueFree(); return; } // Thrower gone (disconnect teardown).
+    if (_age > MaxLifetimeSeconds) { EndLost(); return; }
+    _visual.RotateY (SpinRadiansPerSecond * dt);
+    UpdateDirection (dt);
+    FlyStep (dt);
+    if (_isLive) ScoopNearbyPickups();
+    TryCatch();
+  }
+
+  private void UpdateDirection (float dt)
+  {
+    if (_returning) { _direction = (CatchPoint() - GlobalPosition).Normalized(); return; }
+    _traveled += Speed * dt;
+    if (_traveled >= OutboundMeters) { _returning = true; return; }
+    _direction = _direction.Rotated (Vector3.Up, Mathf.DegToRad (CurveDegreesPerSecond) * dt); // The signature banked arc.
+  }
+
+  // Sweep the path traveled this frame, same as LaserBolt & BananaProjectile. A
+  // player contact doesn't stop the flight - the boomerang clips them & carries on;
+  // outbound geometry contact turns the flight around early.
+  private void FlyStep (float dt)
+  {
+    var from = GlobalPosition;
+    var to = from + _direction * Speed * dt;
+    var hit = Sweep (from, to);
+
+    if (hit.Count == 0)
+    {
+      GlobalPosition = to;
+      return;
+    }
+
+    if (hit["collider"].AsGodotObject() is Player victim)
+    {
+      HandlePlayerHit (victim);
+      GlobalPosition = to;
+      return;
+    }
+
+    _returning = true;
+    GlobalPosition = (Vector3)hit["position"] + (Vector3)hit["normal"] * SurfaceClearance;
+  }
+
+  private Godot.Collections.Dictionary Sweep (Vector3 from, Vector3 to)
+  {
+    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { _throwerRid });
+    if (_returning) query.CollisionMask = PlayersLayer; // The return leg passes through geometry so it always gets home.
+    query.HitFromInside = true;
+    return GetWorld3D().DirectSpaceState.IntersectRay (query);
+  }
+
+  // One report per victim per flight; only the live boomerang reports (issue #98).
+  private void HandlePlayerHit (Player victim)
+  {
+    if (!_isLive || !_victimsHit.Add (victim.NetworkId)) return;
+    EmitSignal (SignalName.HitPlayer, victim);
+  }
+
+  // Flying within reach of a world pickup grabs it (issue #98): the server despawns
+  // it into escrow & the thrower collects the cargo on the catch.
+  private void ScoopNearbyPickups()
+  {
+    foreach (var pickup in GetParent().GetChildren().OfType <WeaponPickup>())
+    {
+      if (pickup.GlobalPosition.DistanceTo (GlobalPosition) > ScoopRadiusMeters) continue;
+      if (!_scoopedPickups.Add (pickup.Name)) continue;
+      EmitSignal (SignalName.ScoopedPickup, pickup.Name.ToString());
+    }
+  }
+
+  private void TryCatch()
+  {
+    if (!_returning || GlobalPosition.DistanceTo (CatchPoint()) > CatchRadiusMeters) return;
+    if (_isLive) EmitSignal (SignalName.Caught);
+    QueueFree();
+  }
+
+  // Safety net: a flight that somehow never completes drops the boomerang (& its
+  // cargo) as pickups wherever it is, instead of orbiting forever (issue #98).
+  private void EndLost()
+  {
+    if (_isLive) EmitSignal (SignalName.Lost, GlobalPosition);
+    QueueFree();
+  }
+}

--- a/core/weapons/BoomerangProjectile.cs.uid
+++ b/core/weapons/BoomerangProjectile.cs.uid
@@ -1,0 +1,1 @@
+uid://byfd3njkd7fvs

--- a/core/weapons/HeldWeapon.cs
+++ b/core/weapons/HeldWeapon.cs
@@ -1,11 +1,13 @@
 namespace com.forerunnergames.energyshot.weapons;
 
-// What a player is carrying (issue #72). Flags so a player can hold the laser & the
-// banana launcher at the same time; None = unarmed (fists only).
+// What a player is carrying (issue #72). Flags so a player can hold the laser, the
+// banana launcher, & the boomerang (issue #98) at the same time; None = unarmed
+// (fists only).
 [System.Flags]
 public enum HeldWeapon
 {
   None = 0,
   Laser = 1,
-  Banana = 2
+  Banana = 2,
+  Boomerang = 4
 }

--- a/core/weapons/SelectedWeapon.cs
+++ b/core/weapons/SelectedWeapon.cs
@@ -6,5 +6,6 @@ public enum SelectedWeapon
 {
   Fists = 0,
   Laser = 1,
-  Banana = 2
+  Banana = 2,
+  Boomerang = 3
 }

--- a/core/weapons/WeaponPickup.cs
+++ b/core/weapons/WeaponPickup.cs
@@ -40,6 +40,7 @@ public partial class WeaponPickup : Area3D
   private Node3D _visual = null!;
   private Node3D _laserVisual = null!;
   private MeshInstance3D _bananaVisual = null!;
+  private Node3D _boomerangVisual = null!;
   private WeaponSpawner _spawner = null!;
   private float _ageSeconds;
   private float _retryCooldownLeft;
@@ -54,6 +55,8 @@ public partial class WeaponPickup : Area3D
     _bananaVisual = GetNode <MeshInstance3D> ("Visual/Banana");
     _bananaVisual.Mesh = ResourceLoader.Load <Mesh> ("res://assets/weapons/Banana_Rifle.obj");
     _bananaVisual.MaterialOverride = new StandardMaterial3D { AlbedoColor = BananaYellow, Roughness = 0.6f };
+    _boomerangVisual = BoomerangProjectile.CreateVisual(); // Code-built, shared with the projectile (issue #98).
+    _visual.AddChild (_boomerangVisual);
     _spawner = GetNode <WeaponSpawner> ("/root/World/WeaponSpawner");
     _expiryLeft = ExpirySeconds;
     UpdateVisuals();
@@ -113,8 +116,9 @@ public partial class WeaponPickup : Area3D
 
   private void UpdateVisuals()
   {
-    if (_laserVisual == null) return;
+    if (_laserVisual == null || _boomerangVisual == null) return;
     _laserVisual.Visible = Weapon == HeldWeapon.Laser;
     _bananaVisual.Visible = Weapon == HeldWeapon.Banana;
+    _boomerangVisual.Visible = Weapon == HeldWeapon.Boomerang;
   }
 }

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -7,21 +7,29 @@ using Godot;
 
 namespace com.forerunnergames.energyshot.weapons;
 
-// Server-authoritative weapon lifecycle manager (issue #72): keeps at most 3 lasers &
-// exactly 1 banana existing in the level (held + dropped + pickups), spawning pickups
-// at the building-top & banana-platform spawn points. Spawns replicate to every peer
-// through the World's MultiplayerSpawner, same as players.
+// Server-authoritative weapon lifecycle manager (issue #72): keeps at most 3 lasers,
+// 1 banana, & 1 boomerang (issue #98) existing in the level (held + dropped + pickups
+// + boomerang escrow), spawning pickups at the building-top & banana-platform spawn
+// points. Spawns replicate to every peer through the World's MultiplayerSpawner,
+// same as players.
 public partial class WeaponSpawner : Node3D
 {
   [Export] public int MaxLasers = 3;
   [Export] public int MaxBananas = 1;
+  [Export] public int MaxBoomerangs = 1;
   [Export] public float ReconcileIntervalSeconds = 1.0f;
   [Export] public float PickupHoverHeight = 0.9f;
   // Playtest-only (#72): a laser pickup is kept at this fixed spawn-room spot so the
   // playtest driver can walk to it deterministically; z = 5 keeps it clear of the
   // +/-4 random spawn scatter. Respawned by Reconcile if anyone claims it.
   public static readonly Vector3 PlaytestLaserPosition = new(0.0f, 31.1f, 5.0f);
+  // Playtest-only (#98): same idea for the boomerang throw/catch phase.
+  public static readonly Vector3 PlaytestBoomerangPosition = new(3.0f, 31.1f, 5.0f);
   private const float OccupiedRadius = 1.0f;
+  // Cargo riding a boomerang home (issue #98): stolen & scooped weapons live here
+  // between the grab & the thrower's catch, so the caps still count them.
+  private readonly record struct BoomerangCargo (int OwnerId, HeldWeapon Type, string PreviousOwner);
+  private readonly List <BoomerangCargo> _escrow = new();
   private readonly RandomNumberGenerator _rng = new();
   private readonly List <Vector3> _laserPoints = new();
   private PackedScene _pickupScene = null!;
@@ -37,9 +45,13 @@ public partial class WeaponSpawner : Node3D
   private IEnumerable <WeaponPickup> Pickups() => GetParent().GetChildren().OfType <WeaponPickup>();
   private IEnumerable <Player> Players() => GetParent().GetChildren().OfType <Player>();
   private static bool IsFree (Vector3 point, IEnumerable <WeaponPickup> pickups) => pickups.All (pickup => pickup.Position.DistanceTo (point) > OccupiedRadius);
-  private static int Count (HeldWeapon type, List <WeaponPickup> pickups, List <Player> players) => pickups.Count (pickup => pickup.Weapon == type) + players.Count (player => player.Holds (type));
+  // Escrowed boomerang cargo counts too (issue #98), or a reconcile pass mid-flight
+  // would over-spawn the weapon the boomerang is carrying.
+  private int Count (HeldWeapon type, List <WeaponPickup> pickups, List <Player> players) => pickups.Count (pickup => pickup.Weapon == type) + players.Count (player => player.Holds (type)) + _escrow.Count (cargo => cargo.Type == type);
   private void GrantToSelf (int type, string previousOwner) => (GetParent() as World)?.SelfPlayer?.GrantWeapon ((HeldWeapon)type, previousOwner);
   [Rpc] private void ConfirmPickup (int type, string previousOwner) => GrantToSelf (type, previousOwner);
+  // A direct (non-RPC) call means the host itself sent it, so there's no remote sender.
+  private int SenderOrSelf() => Multiplayer.GetRemoteSenderId() == 0 ? Multiplayer.GetUniqueId() : Multiplayer.GetRemoteSenderId();
 
   public override void _Ready()
   {
@@ -91,6 +103,8 @@ public partial class WeaponSpawner : Node3D
   {
     var pickups = Pickups().ToList();
     var players = Players().ToList();
+    // Cargo whose thrower vanished mid-flight goes back to the spawn pool via the caps (issue #98).
+    _escrow.RemoveAll (cargo => players.All (player => player.NetworkId != cargo.OwnerId));
     var freePoints = _laserPoints.Where (point => IsFree (point, pickups)).ToList();
     var laserCount = Count (HeldWeapon.Laser, pickups, players);
 
@@ -100,27 +114,34 @@ public partial class WeaponSpawner : Node3D
       ++laserCount;
     }
 
-    SpawnBananaIfMissing (pickups, players, freePoints);
-    EnsurePlaytestPickup (pickups);
+    SpawnSpecialsIfMissing (pickups, players, freePoints);
+    EnsurePlaytestPickups (pickups);
   }
 
-  // The banana respawns at a random free point: its own high platform + whatever
-  // laser points the lasers didn't claim (laser precedence when contested).
-  private void SpawnBananaIfMissing (List <WeaponPickup> pickups, List <Player> players, List <Vector3> freePoints)
+  // The banana & boomerang (issue #98) respawn at random free points: the high
+  // platform + whatever laser points the lasers didn't claim (laser precedence when
+  // contested); a shared candidate list keeps the two from stacking on one point.
+  private void SpawnSpecialsIfMissing (List <WeaponPickup> pickups, List <Player> players, List <Vector3> freePoints)
   {
-    if (Count (HeldWeapon.Banana, pickups, players) >= MaxBananas) return;
     var candidates = new List <Vector3> (freePoints);
     if (IsFree (_bananaPoint, pickups)) candidates.Add (_bananaPoint);
-    if (candidates.Count == 0) return;
-    Spawn (HeldWeapon.Banana, TakeRandom (candidates), expires: false);
+    if (candidates.Count > 0 && Count (HeldWeapon.Banana, pickups, players) < MaxBananas) Spawn (HeldWeapon.Banana, TakeRandom (candidates), expires: false);
+    if (candidates.Count > 0 && Count (HeldWeapon.Boomerang, pickups, players) < MaxBoomerangs) Spawn (HeldWeapon.Boomerang, TakeRandom (candidates), expires: false);
   }
 
-  // Playtest-only (#72): keeps a laser pickup available in the spawn room for the driver.
-  private void EnsurePlaytestPickup (List <WeaponPickup> pickups)
+  // Playtest-only (#72 & #98): keeps deterministic pickups available in the spawn
+  // room for the driver's collection, shooting, & throw/catch phases.
+  private void EnsurePlaytestPickups (List <WeaponPickup> pickups)
   {
     if (!_isPlaytest) return;
-    if (pickups.Any (pickup => pickup.Position.DistanceTo (PlaytestLaserPosition) < OccupiedRadius)) return;
-    Spawn (HeldWeapon.Laser, PlaytestLaserPosition, expires: false);
+    EnsurePlaytestPickup (HeldWeapon.Laser, PlaytestLaserPosition, pickups);
+    EnsurePlaytestPickup (HeldWeapon.Boomerang, PlaytestBoomerangPosition, pickups);
+  }
+
+  private void EnsurePlaytestPickup (HeldWeapon type, Vector3 position, List <WeaponPickup> pickups)
+  {
+    if (pickups.Any (pickup => pickup.Position.DistanceTo (position) < OccupiedRadius)) return;
+    Spawn (type, position, expires: false);
   }
 
   private Vector3 TakeRandom (List <Vector3> points)
@@ -188,5 +209,128 @@ public partial class WeaponSpawner : Node3D
     var spot = position + Vector3.Up * PickupHoverHeight;
     if (dropped.HasFlag (HeldWeapon.Laser)) Spawn (HeldWeapon.Laser, spot, expires: true, dropperName);
     if (dropped.HasFlag (HeldWeapon.Banana)) Spawn (HeldWeapon.Banana, spot + Vector3.Right * 0.8f, expires: true, dropperName);
+    if (dropped.HasFlag (HeldWeapon.Boomerang)) Spawn (HeldWeapon.Boomerang, spot + Vector3.Left * 0.8f, expires: true, dropperName); // Issue #98.
+  }
+
+  // ------------------------------------------------ boomerang cargo (issue #98)
+
+  // Client -> server entry points; when this peer already is the server, skip the RPC.
+  public void SendScoopRequest (string pickupName)
+  {
+    if (Multiplayer.IsServer()) { RequestBoomerangScoop (pickupName); return; }
+    RpcId (1, MethodName.RequestBoomerangScoop, pickupName);
+  }
+
+  public void SendStolenEscrowRequest (int throwerId, HeldWeapon type)
+  {
+    if (Multiplayer.IsServer()) { RequestBoomerangEscrow (throwerId, (int)type); return; }
+    RpcId (1, MethodName.RequestBoomerangEscrow, throwerId, (int)type);
+  }
+
+  public void SendBoomerangCatchRequest()
+  {
+    if (Multiplayer.IsServer()) { RequestBoomerangCatch(); return; }
+    RpcId (1, MethodName.RequestBoomerangCatch);
+  }
+
+  public void SendBoomerangReleaseRequest (Vector3 position)
+  {
+    if (Multiplayer.IsServer()) { RequestBoomerangRelease (position); return; }
+    RpcId (1, MethodName.RequestBoomerangRelease, position);
+  }
+
+  // A flying boomerang scooped a world pickup: despawn it for everyone & hold the
+  // weapon in escrow until the thrower's catch. First scoop wins, like RequestPickup.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestBoomerangScoop (string pickupName)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var throwerId = SenderOrSelf();
+    var pickup = GetParent().GetNodeOrNull <WeaponPickup> (pickupName);
+
+    if (pickup == null || pickup.IsQueuedForDeletion())
+    {
+      ServerLog.Event (throwerId, $"boomerang scoop deny: pickup [{pickupName}] is gone");
+      return;
+    }
+
+    _escrow.Add (new BoomerangCargo (throwerId, pickup.Weapon, pickup.PreviousOwner));
+    ServerLog.Event (throwerId, $"boomerang scoop: {pickup.Weapon} from pickup [{pickupName}]");
+    pickup.QueueFree(); // Despawns on every peer via the MultiplayerSpawner.
+  }
+
+  // A boomerang hit stole the victim's held weapon. The victim reports its own loss
+  // (it owns its replicated HeldWeapon), so the theft attribution for the revenge
+  // messages (issue #84) comes from the RPC sender - never client-supplied text.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestBoomerangEscrow (int throwerId, int type)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var victimId = SenderOrSelf();
+    var victimName = Players().FirstOrDefault (player => player.NetworkId == victimId)?.DisplayName ?? string.Empty;
+    _escrow.Add (new BoomerangCargo (throwerId, (HeldWeapon)type, victimName));
+    ServerLog.Event (victimId, $"boomerang steal: {(HeldWeapon)type} taken from [{victimName}] for peer {throwerId}");
+  }
+
+  // The thrower caught the boomerang: deliver all escrowed cargo. Grants reuse the
+  // ConfirmPickup path so auto-equip (#128) & theft-revenge (#84) apply; a type the
+  // thrower already holds drops beside them as an expiring pickup instead.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestBoomerangCatch()
+  {
+    if (!Multiplayer.IsServer()) return;
+    var throwerId = SenderOrSelf();
+    var thrower = Players().FirstOrDefault (player => player.NetworkId == throwerId);
+    foreach (var cargo in TakeEscrowFor (throwerId)) Deliver (throwerId, thrower, cargo);
+  }
+
+  private List <BoomerangCargo> TakeEscrowFor (int ownerId)
+  {
+    var cargo = _escrow.Where (item => item.OwnerId == ownerId).ToList();
+    _escrow.RemoveAll (item => item.OwnerId == ownerId);
+    return cargo;
+  }
+
+  private void Deliver (int throwerId, Player? thrower, BoomerangCargo cargo)
+  {
+    if (thrower == null) return; // Mid-disconnect; the caps respawn the weapon.
+    ServerLog.Event (throwerId, $"boomerang deliver: {cargo.Type}{(cargo.PreviousOwner.Length > 0 ? $" (from [{cargo.PreviousOwner}])" : "")}");
+
+    if (thrower.Holds (cargo.Type))
+    {
+      Spawn (cargo.Type, thrower.GlobalPosition + Vector3.Up * PickupHoverHeight, expires: true, cargo.PreviousOwner);
+      return;
+    }
+
+    if (throwerId == Multiplayer.GetUniqueId())
+    {
+      GrantToSelf ((int)cargo.Type, cargo.PreviousOwner);
+      return;
+    }
+
+    RpcId (throwerId, MethodName.ConfirmPickup, (int)cargo.Type, cargo.PreviousOwner);
+  }
+
+  // The boomerang dropped out of the sky (thrower zapped out mid-flight, or the
+  // safety timeout): it & any cargo become expiring pickups where it was, settled
+  // onto the ground below so nothing floats out of reach.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestBoomerangRelease (Vector3 position)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var throwerId = SenderOrSelf();
+    var spot = GroundedSpot (position);
+    ServerLog.Event (throwerId, $"boomerang release: dropped at {spot}");
+    Spawn (HeldWeapon.Boomerang, spot, expires: true);
+    var offset = 0;
+    foreach (var cargo in TakeEscrowFor (throwerId)) Spawn (cargo.Type, spot + Vector3.Right * (0.8f * ++offset), expires: true, cargo.PreviousOwner);
+  }
+
+  private Vector3 GroundedSpot (Vector3 position)
+  {
+    var query = PhysicsRayQueryParameters3D.Create (position, position + Vector3.Down * 100.0f);
+    var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
+    if (hit.Count == 0) return position;
+    return (Vector3)hit["position"] + Vector3.Up * PickupHoverHeight;
   }
 }

--- a/project.godot
+++ b/project.godot
@@ -93,6 +93,11 @@ weapon_3={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":51,"key_label":0,"unicode":51,"location":0,"echo":false,"script":null)
 ]
 }
+weapon_4={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":52,"key_label":0,"unicode":52,"location":0,"echo":false,"script":null)
+]
+}
 eat_bread={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"location":0,"echo":false,"script":null)

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -25,6 +25,7 @@ public partial class PlaytestDriver : Node
   private string _role = string.Empty;
   private string _address = "127.0.0.1";
   private int _boltsSpawned;
+  private int _boomerangsSpawned;
   private Player? _self;
   private Player Self => _self ??= _world.GetPlayers().First (player => player.IsMultiplayerAuthority());
   private MusicManager Music => _world.GetNode <MusicManager> ("MusicManager");
@@ -37,6 +38,7 @@ public partial class PlaytestDriver : Node
     Engine.MaxFps = 30;
     _world = GetNode <World> ("/root/World");
     _world.ChildEnteredTree += node => _boltsSpawned += node is LaserBolt ? 1 : 0;
+    _world.ChildEnteredTree += node => _boomerangsSpawned += node is BoomerangProjectile ? 1 : 0;
     var args = OS.GetCmdlineUserArgs();
     _role = ArgValue (args, "--playtest") ?? string.Empty;
     _address = ArgValue (args, "--address") ?? "127.0.0.1";
@@ -275,6 +277,32 @@ public partial class PlaytestDriver : Node
     await Task.Delay (100);
     ReleaseAction ("crouch");
     await WaitUntil (() => !Self.Crouching, 5, "stood back up after the canceled slide (#131)");
+
+    // Boomerang (#98): collect the deterministic spawn-room pickup, throw it (aimed
+    // away from everyone so no incidental steals), & watch it fly back into the hand.
+    await WaitUntil (() => WalkedTo (WeaponSpawner.PlaytestBoomerangPosition), 45, "walked to the playtest boomerang pickup");
+    await WaitUntil (() => Self.Holds (HeldWeapon.Boomerang), 15, "collected the boomerang pickup (#98)");
+    PressAction ("weapon_4");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_4");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Boomerang, "boomerang selected in slot 4 (#98)");
+    AimAt (Self.GlobalPosition + new Vector3 (10, 1, 0));
+    // The spawn-room round trip can finish faster than a poll, so count spawned
+    // projectiles (like bolts) instead of sampling the transient in-flight state.
+    var boomerangsBefore = _boomerangsSpawned;
+
+    for (var attempt = 0; attempt < 10 && _boomerangsSpawned == boomerangsBefore; ++attempt)
+    {
+      PressAction ("shoot");
+      await Task.Delay (80);
+      ReleaseAction ("shoot");
+      await Task.Delay (300);
+    }
+
+    Assert (_boomerangsSpawned > boomerangsBefore, "boomerang thrown (#98)");
+    // Still held + no longer in flight = the return trip ended in an auto-catch; a
+    // lost boomerang would have cleared the held flag instead (#98).
+    await WaitUntil (() => Self.Holds (HeldWeapon.Boomerang) && !Self.IsBoomerangInFlight, 30, "boomerang returned & was auto-caught (#98)");
   }
 
   private async Task RunVictim()

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -12,12 +12,13 @@ public class MessageGeneratorTest
   private static DeathContext Laser (float energy = 0.5f) => new() { Kind = DamageKind.Laser, Energy = energy };
 
   [TestCase]
-  public void ExactlyOneHundredThreeUniqueMessageTemplates()
+  public void ExactlyOneHundredSevenUniqueMessageTemplates()
   {
-    // 100 from the content wave (issue #84) + 3 through-wall zaps (issue #94).
+    // 100 from the content wave (issue #84) + 3 through-wall zaps (issue #94)
+    // + 4 boomerang zap-outs (issue #98).
     var templates = MessagePools.All.SelectMany (pool => pool).ToList();
-    AssertInt (templates.Count).IsEqual (103);
-    AssertInt (templates.Distinct().Count()).IsEqual (103);
+    AssertInt (templates.Count).IsEqual (107);
+    AssertInt (templates.Distinct().Count()).IsEqual (107);
   }
 
   [TestCase]
@@ -32,8 +33,8 @@ public class MessageGeneratorTest
   [TestCase]
   public void EveryPoolIsInTheRegistry()
   {
-    // 23 scenario pools registered, none empty.
-    AssertInt (MessagePools.All.Count).IsEqual (23);
+    // 24 scenario pools registered, none empty.
+    AssertInt (MessagePools.All.Count).IsEqual (24);
     foreach (var pool in MessagePools.All) AssertBool (pool.Count > 0).IsTrue();
   }
 
@@ -60,6 +61,13 @@ public class MessageGeneratorTest
     var direct = new DeathContext { Kind = DamageKind.Banana, Energy = 0.9f };
     AssertObject (MessageGenerator.SelectZappedPool (blast)).IsSame (MessagePools.BananaBlast);
     AssertObject (MessageGenerator.SelectZappedPool (direct)).IsSame (MessagePools.BananaDirect);
+  }
+
+  [TestCase]
+  public void BoomerangPoolSelectedByDamageKind()
+  {
+    // Boomerang zap-outs get their own flavor (issue #98).
+    AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.Boomerang, Energy = 0.4f })).IsSame (MessagePools.Boomerang);
   }
 
   [TestCase]

--- a/ui/hud/messages/MessageGenerator.cs
+++ b/ui/hud/messages/MessageGenerator.cs
@@ -51,6 +51,7 @@ public static class MessageGenerator
     if (context.Kind == DamageKind.Punch && context.VictimArmed) return MessagePools.PunchedOutArmed;
     if (context.Kind == DamageKind.Punch && context.KillerUnarmed) return MessagePools.FistsVsFists;
     if (context.Kind == DamageKind.Punch) return MessagePools.Punch;
+    if (context.Kind == DamageKind.Boomerang) return MessagePools.Boomerang; // Issue #98.
     if (context.VictimHeldBananaGun) return MessagePools.HoldingBananaGun;
     if (context.Kind == DamageKind.Laser && context.ThroughBarrier) return MessagePools.ThroughWall; // Pierced a wall/floor first (issue #94).
     if (context.KillerSliding) return MessagePools.SlideShotKiller;

--- a/ui/hud/messages/MessagePools.cs
+++ b/ui/hud/messages/MessagePools.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace com.forerunnergames.energyshot.ui.hud;
 
-// The 100 unique message templates (issue #84), grouped into scenario pools.
+// The unique message templates (issue #84), grouped into scenario pools.
 // {v} = the player who got zapped out, {z} = the player who did the zapping,
 // {youOrThey} = pronoun in fall messages. All short, sarcastic, & non-violent.
 public static class MessagePools
@@ -200,6 +200,15 @@ public static class MessagePools
     "{v} is farming respawns at an industrial scale"
   };
 
+  // Boomerang zap-outs (issue #98).
+  public static readonly List <string> Boomerang = new()
+  {
+    "{z}'s boomerang made a round trip through {v}",
+    "{v} stood on the flight path & {z}'s boomerang kept the schedule",
+    "{z} threw it away & it still came back with {v}'s dignity",
+    "{v} got clipped by {z}'s frisbee with commitment issues"
+  };
+
   // {z} zapped {v} with the weapon {v} dropped earlier.
   public static readonly List <string> TheftRevenge = new()
   {
@@ -215,6 +224,6 @@ public static class MessagePools
     Fall, FallStreak, Zapped, ThroughWall, FullCharge, FullAuto, Punch, PunchedOutArmed, FistsVsFists,
     BananaBlast, BananaDirect, HoldingBananaGun, ComboSplatterPunch, JumpShot, SlideShotKiller,
     SlideShotVictim, ZapStreakTier3, ZapStreakTier5, ZapStreakTier7, StreakEnded, StreakLost,
-    ZappedStreak, TheftRevenge
+    ZappedStreak, Boomerang, TheftRevenge
   };
 }


### PR DESCRIPTION
Fixes #98.

## What it does

- **New slot-4 weapon** (key `4`): the boomerang spawns as a world pickup like the laser & banana, capped at 1 by the `WeaponSpawner`, with a code-built spinning crossed-arms model & a looping whoosh reusing the existing punch-whiff sound - nothing downloaded.
- **Throw & catch**: the shoot button throws it on a banked outbound curve (~25m, or until it meets level geometry), then it homes straight back to the thrower & is auto-caught on proximity. Every peer sees the flight (visual copies, like the banana) & the thrower's empty hand while it's out.
- **Hits en route**: moderate victim-authoritative damage (same pattern as `ReceiveHit`/`ReceiveBlast`), never lethal from full health (like the banana blast), with its own zap-out message pool.
- **Steals**: a hit knocks the victim's held weapon loose - the victim releases it into a server-side escrow bound to the thrower, & it rides the boomerang home. The catch grants it through the existing `ConfirmPickup` path, so auto-equip (#128) & the theft-revenge messages (#84) fire with the previous owner attributed from the RPC sender, never client-supplied text.
- **Scoops**: world pickups within ~1.5m of the flight path are despawned into the same escrow & delivered on the catch; a type the thrower already holds drops beside them as an expiring pickup instead.
- **Loss handling**: zapping out (or falling) mid-flight drops the boomerang & its cargo as expiring pickups where the boomerang is, settled onto the ground below; escrow whose thrower disconnects returns to the spawn pool via the caps.

## Design notes

- **No new replicated properties**: `HeldWeapon` gains `Boomerang = 4` (flags) & `SelectedWeapon` gains `Boomerang = 3` - both already replicate, so `Player.tscn`'s replication config (indices 0-16) is untouched.
- **Escrow counts toward the weapon caps**, so a reconcile pass mid-flight can't over-spawn the weapon the boomerang is carrying.
- **Return leg ignores geometry** so the trip home always completes while the thrower lives; the safety timeout (12s) drops it as a pickup otherwise.
- **No cooldown HUD bar**: the throw/catch cycle is physical, not a cooldown.

## Validation

- `dotnet build`: 0 errors, 0 warnings.
- Full playtest **PASS** (host + shooter + victim), including a new phase: the shooter collects a deterministic spawn-room boomerang pickup, selects slot 4, throws, & the boomerang returns & is auto-caught.
- Message tests updated: 107 unique templates / 24 pools (was 103 / 23), plus a boomerang pool-selection case; pool invariants (count, uniqueness, non-violent wording) verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)