### PR TITLE
Add the slingshot: draw-scaled arcing stones

### DIFF
--- a/core/players/DamageKind.cs
+++ b/core/players/DamageKind.cs
@@ -9,5 +9,6 @@ public enum DamageKind
   FullAuto,
   Punch,
   Banana,
-  Boomerang
+  Boomerang,
+  Slingshot
 }

--- a/core/players/Player.Slingshot.cs
+++ b/core/players/Player.Slingshot.cs
@@ -1,0 +1,133 @@
+using com.forerunnergames.energyshot.weapons;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Slingshot (issue #99): the slot-5 ballistic sidearm. Hold shoot to draw the band
+// (like the laser's charge, but ballistic), release to sling an arcing stone; drawn
+// longer = flatter, faster, & harder (draw scales speed & damage, 15-60). Hits are
+// victim-authoritative with knockback, same as ReceiveHit & ReceiveBoomerangHit.
+public partial class Player
+{
+  [Export] public float SlingshotMaxDrawSeconds = 1.2f;
+  [Export] public float SlingshotMinSpeed = 22.0f;
+  [Export] public float SlingshotMaxSpeed = 60.0f;
+  // 15-60 damage via CalculateHealthDecrease (issue #99): a nuisance at a tap,
+  // a proper wallop at full draw, never a one-hit zap-out.
+  [Export] public float SlingshotMinEnergy = 0.15f;
+  [Export] public float SlingshotMaxEnergy = 0.6f;
+  [Export] public float SlingshotKnockbackScale = 0.6f;
+  // How far the held frame pulls back toward the eye at full draw (issue #99).
+  private const float SlingshotDrawPullMeters = 0.25f;
+  private static readonly Vector3 SlingshotRestPosition = new(0.5f, -0.5f, -0.9f);
+  private Node3D _slingshotHeld = null!;
+  private AudioStreamPlayer _slingshotStretchSound = null!;
+  private float _slingshotDrawSeconds;
+  private float SlingshotDrawFraction => Mathf.Clamp (_slingshotDrawSeconds / SlingshotMaxDrawSeconds, 0.0f, 1.0f);
+
+  // Held model: the same code-built Y-frame as the pickup, resting in the hand
+  // (issue #99). The stretch creak is the punch whiff slowed way down - reusing an
+  // existing sound instead of downloading one.
+  private void CreateSlingshotHeld()
+  {
+    _slingshotHeld = SlingshotStone.CreateSlingshotVisual();
+    _slingshotHeld.Position = SlingshotRestPosition;
+    _slingshotHeld.RotationDegrees = new Vector3 (0.0f, 10.0f, -8.0f);
+    GetNode <Node3D> ("Camera3D").AddChild (_slingshotHeld);
+    _slingshotStretchSound = new AudioStreamPlayer { Stream = ResourceLoader.Load <AudioStream> ("res://assets/sounds/punch-whiff.wav"), PitchScale = 0.55f };
+    AddChild (_slingshotStretchSound);
+  }
+
+  // Draw-&-release (issue #99): holding shoot accumulates draw, releasing fires.
+  // Poll-based (not just-released) so a wedged input state self-heals, & losing the
+  // slingshot (or selection) mid-draw cancels cleanly.
+  private void UpdateSlingshot (double delta)
+  {
+    var active = IsSlingshotSelected && HasSlingshot && _isInputEnabled;
+    if (!active) { CancelSlingshotDraw(); return; }
+    if (Input.IsActionPressed ("shoot")) { AccumulateSlingshotDraw ((float)delta); return; }
+    if (_slingshotDrawSeconds <= 0.0f) return;
+    FireSlingshotStone();
+  }
+
+  private void AccumulateSlingshotDraw (float dt)
+  {
+    if (_slingshotDrawSeconds <= 0.0f) _slingshotStretchSound.Play(); // Once per draw.
+    _slingshotDrawSeconds = Mathf.Min (SlingshotMaxDrawSeconds, _slingshotDrawSeconds + dt);
+    ApplySlingshotDrawPose();
+  }
+
+  private void CancelSlingshotDraw()
+  {
+    if (_slingshotDrawSeconds <= 0.0f) return;
+    _slingshotDrawSeconds = 0.0f;
+    _slingshotStretchSound.Stop();
+    ApplySlingshotDrawPose();
+  }
+
+  // The frame pulls back toward the eye as the band stretches (issue #99).
+  private void ApplySlingshotDrawPose() => _slingshotHeld.Position = SlingshotRestPosition + Vector3.Back * (SlingshotDrawPullMeters * SlingshotDrawFraction);
+
+  private void FireSlingshotStone()
+  {
+    CancelSpawnArmorIfFired();
+    var draw = SlingshotDrawFraction;
+    CancelSlingshotDraw();
+    var speed = Mathf.Lerp (SlingshotMinSpeed, SlingshotMaxSpeed, draw);
+    var energy = Mathf.Lerp (SlingshotMinEnergy, SlingshotMaxEnergy, draw);
+    var direction = -_camera.GlobalTransform.Basis.Z;
+    var origin = _camera.GlobalPosition + direction * MuzzleOffsetMeters;
+    SpawnStone (origin, direction, speed, energy, isLive: true);
+    Rpc (MethodName.SpawnVisualStone, origin, direction, speed);
+  }
+
+  // Visual-only copy of the shooter's stone on every other peer. Firing proves the
+  // shooter's spawn armor is gone, so stale armor whitewash clears here (issue #114).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void SpawnVisualStone (Vector3 origin, Vector3 direction, float speed)
+  {
+    ClearArmorDisplayOnRemoteAttack();
+    SpawnStone (origin, direction, speed, energy: 0.0f, isLive: false);
+  }
+
+  private void SpawnStone (Vector3 origin, Vector3 direction, float speed, float energy, bool isLive)
+  {
+    PlaySlingshotThwack (origin);
+    var stone = new SlingshotStone();
+    GetParent().AddChild (stone);
+    stone.Launch (origin, direction, speed, energy, isLive, this);
+    if (isLive) stone.HitPlayer += OnStoneHitPlayer;
+  }
+
+  // Distinct release thwack (issue #99): the punch thud replayed fast & positional
+  // reads as the band snapping - reusing an existing sound, never downloading one.
+  private void PlaySlingshotThwack (Vector3 origin)
+  {
+    var thwack = new AudioStreamPlayer3D { Stream = ResourceLoader.Load <AudioStream> ("res://assets/sounds/punch-thud.wav"), PitchScale = 1.6f };
+    GetParent().AddChild (thwack);
+    thwack.GlobalPosition = origin;
+    thwack.Finished += thwack.QueueFree;
+    thwack.Play();
+  }
+
+  // The shooter only reports the hit; the victim applies its own damage & knockback
+  // (victim-authoritative, same as ReceiveHit & ReceiveBoomerangHit).
+  private void OnStoneHitPlayer (Player victim, float energy)
+  {
+    if (victim.NetworkId == NetworkId) return;
+    GD.Print ($"{DisplayName}: My stone thwacked {victim.DisplayName}!");
+    _hitmarkerSound.Play();
+    ReportToServer ($"slingshot: {DisplayName} thwacked {victim.DisplayName} (energy {energy:0.00})");
+    victim.RpcId (victim.NetworkId, MethodName.ReceiveSlingshotHit, energy, DisplayName);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ReceiveSlingshotHit (float energy, string slungByPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    if (SpawnArmor) return;
+    GD.Print ($"{DisplayName}: I was thwacked by {slungByPlayerName}'s slingshot!");
+    LastDamageKind = DamageKind.Slingshot; // Message context (issue #84).
+    ApplyDamage (energy, slungByPlayerName, SlingshotKnockbackScale);
+  }
+}

--- a/core/players/Player.Slingshot.cs.uid
+++ b/core/players/Player.Slingshot.cs.uid
@@ -1,0 +1,1 @@
+uid://b304h8s4kmg8u

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -142,10 +142,14 @@ public partial class Player
   {
     var type = PickDroppableWeapon();
     if (type == HeldWeapon.None) return;
+    // Request BEFORE clearing (CodeRabbit on #145): the server validates the drop
+    // mask against this player's replicated HeldWeapon, so the request must leave
+    // while the local flags (& therefore the server's replicated view) still show
+    // the weapon; clearing first would race the request with the clear delta.
+    Spawner.SendDropRequest (GlobalPosition, type);
     HeldWeapon &= ~type;
     ForgetTheft (type);
     DeselectUnheldWeapon();
-    Spawner.SendDropRequest (GlobalPosition, type);
     GD.Print ($"{DisplayName}: I dropped my {type}!");
   }
 
@@ -166,7 +170,9 @@ public partial class Player
   }
 
   // Death drops everything carried at the death spot (issue #72); a boomerang out
-  // flying drops where the boomerang is instead (issue #98).
+  // flying drops where the boomerang is instead (issue #98). Request before clear,
+  // same as DropHeldWeapon: the server validates the mask against the replicated
+  // HeldWeapon (CodeRabbit on #145).
   private void DropAllHeldWeapons()
   {
     ReleaseBoomerangInFlight();

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -6,8 +6,9 @@ namespace com.forerunnergames.energyshot.players;
 
 // Weapon lifecycle & selection (issues #72 & #82): players spawn with fists only &
 // arm up from world pickups; death drops everything held at the death spot. Slot 1 =
-// fists (always available), slot 2 = laser, slot 3 = banana; guns are selectable only
-// while held. The server-side WeaponSpawner owns pickup spawning & the weapon caps.
+// fists (always available), slot 2 = laser, slot 3 = banana, slot 4 = boomerang (#98),
+// slot 5 = slingshot (#99); guns are selectable only while held. The server-side
+// WeaponSpawner owns pickup spawning & the weapon caps.
 public partial class Player
 {
   // Replicated like SpawnArmor so every peer knows what this player carries & renders
@@ -47,10 +48,12 @@ public partial class Player
   private bool HasLaser => Holds (HeldWeapon.Laser);
   private bool HasBanana => Holds (HeldWeapon.Banana);
   private bool HasBoomerang => Holds (HeldWeapon.Boomerang);
+  private bool HasSlingshot => Holds (HeldWeapon.Slingshot);
   private bool IsFistsSelected => _selectedWeapon == SelectedWeapon.Fists;
   private bool IsLaserSelected => _selectedWeapon == SelectedWeapon.Laser;
   private bool IsBananaSelected => _selectedWeapon == SelectedWeapon.Banana;
   private bool IsBoomerangSelected => _selectedWeapon == SelectedWeapon.Boomerang;
+  private bool IsSlingshotSelected => _selectedWeapon == SelectedWeapon.Slingshot;
   private WeaponSpawner Spawner => _weaponSpawner ??= GetNode <WeaponSpawner> ("/root/World/WeaponSpawner");
 
   // Falling off the world: held weapons return to the spawn pool via the caps instead
@@ -75,10 +78,11 @@ public partial class Player
   // Runs on every peer via the replicated HeldWeapon & SelectedWeapon properties.
   private void UpdateWeaponVisibility()
   {
-    if (_bananaLauncher == null || _boomerangHeld == null) return;
+    if (_bananaLauncher == null || _boomerangHeld == null || _slingshotHeld == null) return;
     _energyWeapon.Visible = IsLaserSelected && HasLaser;
     _bananaLauncher.Visible = IsBananaSelected && HasBanana;
     _boomerangHeld.Visible = IsBoomerangSelected && HasBoomerang && !IsBoomerangOut; // Empty hand while it's out flying (issue #98).
+    _slingshotHeld.Visible = IsSlingshotSelected && HasSlingshot; // Slot 5 (issue #99).
     UpdateHandsVisibility(); // Hands render only while fists are selected (issue #82).
   }
 
@@ -91,6 +95,7 @@ public partial class Player
     if (Input.IsActionJustPressed ("weapon_2") && HasLaser) SelectedWeapon = SelectedWeapon.Laser;
     if (Input.IsActionJustPressed ("weapon_3") && HasBanana) SelectedWeapon = SelectedWeapon.Banana;
     if (Input.IsActionJustPressed ("weapon_4") && HasBoomerang) SelectedWeapon = SelectedWeapon.Boomerang; // Slot 4 (issue #98).
+    if (Input.IsActionJustPressed ("weapon_5") && HasSlingshot) SelectedWeapon = SelectedWeapon.Slingshot; // Slot 5 (issue #99).
   }
 
   // A dropped or lost gun can't stay selected: fall back to fists (issue #82).
@@ -99,6 +104,7 @@ public partial class Player
     if (IsLaserSelected && !HasLaser) SelectedWeapon = SelectedWeapon.Fists;
     if (IsBananaSelected && !HasBanana) SelectedWeapon = SelectedWeapon.Fists;
     if (IsBoomerangSelected && !HasBoomerang) SelectedWeapon = SelectedWeapon.Fists;
+    if (IsSlingshotSelected && !HasSlingshot) SelectedWeapon = SelectedWeapon.Fists;
   }
 
   // Called back (via the WeaponSpawner's ConfirmPickup RPC) after the server despawns
@@ -106,8 +112,8 @@ public partial class Player
   public void GrantWeapon (HeldWeapon type, string previousOwner = "")
   {
     HeldWeapon |= type;
-    // Every pickup auto-equips (issue #128), boomerang included (issue #98).
-    SelectedWeapon = type switch { HeldWeapon.Banana => SelectedWeapon.Banana, HeldWeapon.Boomerang => SelectedWeapon.Boomerang, _ => SelectedWeapon.Laser };
+    // Every pickup auto-equips (issue #128), boomerang (#98) & slingshot (#99) included.
+    SelectedWeapon = type switch { HeldWeapon.Banana => SelectedWeapon.Banana, HeldWeapon.Boomerang => SelectedWeapon.Boomerang, HeldWeapon.Slingshot => SelectedWeapon.Slingshot, _ => SelectedWeapon.Laser };
     RememberTheft (type, previousOwner);
     _weaponPickupSound.Play(); // Satisfying pickup chime, owner-local only (issue #123).
     GD.Print ($"{DisplayName}: I picked up a {type}!");
@@ -147,9 +153,9 @@ public partial class Player
   // isn't in the hand, so it can't be knocked loose or stolen from it (issue #98).
   private HeldWeapon PickDroppableWeapon()
   {
-    var preferred = _selectedWeapon switch { SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, _ => HeldWeapon.Laser };
+    var preferred = _selectedWeapon switch { SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, SelectedWeapon.Slingshot => HeldWeapon.Slingshot, _ => HeldWeapon.Laser };
 
-    foreach (var type in new[] { preferred, HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang })
+    foreach (var type in new[] { preferred, HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot })
     {
       if (!Holds (type)) continue;
       if (type == HeldWeapon.Boomerang && IsBoomerangInFlight) continue;
@@ -178,6 +184,7 @@ public partial class Player
     ApplyOverlayMaterials (_energyWeapon);
     ApplyOverlayMaterials (_bananaLauncher);
     ApplyOverlayMaterials (_boomerangHeld);
+    ApplyOverlayMaterials (_slingshotHeld); // Slot 5 (issue #99).
   }
 
   private void ApplyOverlayMaterials (Node node)

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -310,6 +310,7 @@ public partial class Player : CharacterBody3D
     _bananaLauncher = GetNode <BananaLauncher> ("Camera3D/BananaLauncher");
     _launcherRestPosition = _bananaLauncher.Position;
     CreateBoomerangHeld(); // Code-built held model, no scene asset (issue #98).
+    CreateSlingshotHeld(); // Same, for the slot-5 slingshot (issue #99).
     UpdateWeaponVisibility();
     CreateHands();
     _crossHairs = GetNode <Sprite3D> ("Camera3D/Crosshairs");
@@ -390,6 +391,7 @@ public partial class Player : CharacterBody3D
     UpdateWeaponSelection();
     UpdateBananaLauncher();
     UpdateBoomerang();
+    UpdateSlingshot (delta); // Draw-&-release stones (issue #99).
     UpdateBread();
     UpdateFullAuto (delta);
     UpdatePunch (delta);

--- a/core/weapons/HeldWeapon.cs
+++ b/core/weapons/HeldWeapon.cs
@@ -1,13 +1,14 @@
 namespace com.forerunnergames.energyshot.weapons;
 
 // What a player is carrying (issue #72). Flags so a player can hold the laser, the
-// banana launcher, & the boomerang (issue #98) at the same time; None = unarmed
-// (fists only).
+// banana launcher, the boomerang (issue #98), & the slingshot (issue #99) at the
+// same time; None = unarmed (fists only).
 [System.Flags]
 public enum HeldWeapon
 {
   None = 0,
   Laser = 1,
   Banana = 2,
-  Boomerang = 4
+  Boomerang = 4,
+  Slingshot = 8
 }

--- a/core/weapons/SelectedWeapon.cs
+++ b/core/weapons/SelectedWeapon.cs
@@ -7,5 +7,6 @@ public enum SelectedWeapon
   Fists = 0,
   Laser = 1,
   Banana = 2,
-  Boomerang = 3
+  Boomerang = 3,
+  Slingshot = 4
 }

--- a/core/weapons/SlingshotStone.cs
+++ b/core/weapons/SlingshotStone.cs
@@ -1,0 +1,83 @@
+using com.forerunnergames.energyshot.players;
+using Godot;
+
+namespace com.forerunnergames.energyshot.weapons;
+
+// A slung stone (issue #99): flies a gravity arc whose speed & sting scale with how
+// long the shooter drew the band - drawn longer = flatter, faster, & harder. Only the
+// shooter's own stone is "live" (reports the hit); other peers fly visual-only copies,
+// like BananaProjectile. Impacts are detected by sweeping a ray along the path
+// traveled each physics frame, so fast stones can't tunnel. Built entirely from a
+// primitive sphere & existing sounds - no downloaded assets.
+public partial class SlingshotStone : Node3D
+{
+  [Export] public float GravityAcceleration = 24.0f;
+  [Export] public float MaxLifetimeSeconds = 6.0f;
+  [Signal] public delegate void HitPlayerEventHandler (Player victim, float energy);
+  private static readonly Color StoneGray = new(0.55f, 0.55f, 0.58f);
+  private static readonly Color FrameBrown = new(0.45f, 0.28f, 0.12f);
+  private static readonly Color BandTan = new(0.85f, 0.72f, 0.35f);
+  private Vector3 _velocity;
+  private float _energy;
+  private float _age;
+  private bool _isLive;
+  private Rid _shooterRid;
+
+  // Shared look for the world pickup & the held model (issue #99): a simple Y-frame
+  // slingshot built from primitive boxes - a wooden handle, two angled prongs, & a
+  // band across the tips. Fresh materials per call so the first-person overlay tweak
+  // (issue #124) can't bleed into pickups.
+  public static Node3D CreateSlingshotVisual()
+  {
+    var wood = new StandardMaterial3D { AlbedoColor = FrameBrown, Roughness = 0.9f };
+    var band = new StandardMaterial3D { AlbedoColor = BandTan, Roughness = 0.6f };
+    var visual = new Node3D();
+    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.07f, 0.4f, 0.07f) }, MaterialOverride = wood });
+    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.06f, 0.3f, 0.06f) }, MaterialOverride = wood, Position = new Vector3 (-0.1f, 0.3f, 0.0f), RotationDegrees = new Vector3 (0.0f, 0.0f, 35.0f) });
+    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.06f, 0.3f, 0.06f) }, MaterialOverride = wood, Position = new Vector3 (0.1f, 0.3f, 0.0f), RotationDegrees = new Vector3 (0.0f, 0.0f, -35.0f) });
+    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.38f, 0.035f, 0.035f) }, MaterialOverride = band, Position = new Vector3 (0.0f, 0.43f, 0.0f) });
+    return visual;
+  }
+
+  public override void _Ready()
+  {
+    AddChild (new MeshInstance3D
+    {
+      Mesh = new SphereMesh { Radius = 0.09f, Height = 0.18f },
+      MaterialOverride = new StandardMaterial3D { AlbedoColor = StoneGray, Roughness = 0.8f }
+    });
+  }
+
+  public void Launch (Vector3 origin, Vector3 direction, float speed, float energy, bool isLive, CharacterBody3D shooter)
+  {
+    GlobalPosition = origin;
+    _velocity = direction.Normalized() * speed;
+    _energy = energy;
+    _isLive = isLive;
+    _shooterRid = shooter.GetRid();
+  }
+
+  public override void _PhysicsProcess (double delta)
+  {
+    var dt = (float)delta;
+    _age += dt;
+    if (_age > MaxLifetimeSeconds) { QueueFree(); return; }
+    var from = GlobalPosition;
+    _velocity.Y -= GravityAcceleration * dt;
+    var to = from + _velocity * dt;
+    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { _shooterRid });
+    query.HitFromInside = true;
+    var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
+
+    if (hit.Count == 0)
+    {
+      GlobalPosition = to;
+      return;
+    }
+
+    // First contact ends the flight (issue #99): a live stone that met a player
+    // reports the hit; anything else just stops the stone.
+    if (_isLive && hit["collider"].AsGodotObject() is Player victim) EmitSignal (SignalName.HitPlayer, victim, _energy);
+    QueueFree();
+  }
+}

--- a/core/weapons/SlingshotStone.cs.uid
+++ b/core/weapons/SlingshotStone.cs.uid
@@ -1,0 +1,1 @@
+uid://c73odury07xkg

--- a/core/weapons/WeaponPickup.cs
+++ b/core/weapons/WeaponPickup.cs
@@ -41,6 +41,7 @@ public partial class WeaponPickup : Area3D
   private Node3D _laserVisual = null!;
   private MeshInstance3D _bananaVisual = null!;
   private Node3D _boomerangVisual = null!;
+  private Node3D _slingshotVisual = null!;
   private WeaponSpawner _spawner = null!;
   private float _ageSeconds;
   private float _retryCooldownLeft;
@@ -57,6 +58,8 @@ public partial class WeaponPickup : Area3D
     _bananaVisual.MaterialOverride = new StandardMaterial3D { AlbedoColor = BananaYellow, Roughness = 0.6f };
     _boomerangVisual = BoomerangProjectile.CreateVisual(); // Code-built, shared with the projectile (issue #98).
     _visual.AddChild (_boomerangVisual);
+    _slingshotVisual = SlingshotStone.CreateSlingshotVisual(); // Code-built, shared with the held model (issue #99).
+    _visual.AddChild (_slingshotVisual);
     _spawner = GetNode <WeaponSpawner> ("/root/World/WeaponSpawner");
     _expiryLeft = ExpirySeconds;
     UpdateVisuals();
@@ -116,9 +119,10 @@ public partial class WeaponPickup : Area3D
 
   private void UpdateVisuals()
   {
-    if (_laserVisual == null || _boomerangVisual == null) return;
+    if (_laserVisual == null || _boomerangVisual == null || _slingshotVisual == null) return;
     _laserVisual.Visible = Weapon == HeldWeapon.Laser;
     _bananaVisual.Visible = Weapon == HeldWeapon.Banana;
     _boomerangVisual.Visible = Weapon == HeldWeapon.Boomerang;
+    _slingshotVisual.Visible = Weapon == HeldWeapon.Slingshot; // Issue #99.
   }
 }

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -201,17 +201,35 @@ public partial class WeaponSpawner : Node3D
   // Dropped weapons become expiring pickups at the drop spot (side by side when both drop at once).
   // The dropper's identity comes from the RPC sender, never from client-supplied data
   // (CodeRabbit on #96): a forged name could plant false theft-revenge attribution.
+  // The mask & position are validated too (CodeRabbit on #145): only weapons the
+  // sender's replicated HeldWeapon shows can drop - droppers send the request BEFORE
+  // clearing their local flags, so the server's view still holds them on arrival -
+  // & the drop grounds onto the level beneath the spot (issue #151).
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
   private void RequestDrop (Vector3 position, int droppedMask)
   {
     if (!Multiplayer.IsServer()) return;
-    // A direct (non-RPC) call means the host itself dropped, so there's no remote sender.
-    var senderId = Multiplayer.GetRemoteSenderId();
-    if (senderId == 0) senderId = Multiplayer.GetUniqueId();
-    var dropperName = Players().FirstOrDefault (player => player.NetworkId == senderId)?.DisplayName ?? string.Empty;
-    var dropped = (HeldWeapon)droppedMask;
-    ServerLog.Event (senderId, $"weapon drop: {dropped} at {position}");
-    var spot = position + Vector3.Up * PickupHoverHeight;
+    var senderId = SenderOrSelf();
+    var dropper = Players().FirstOrDefault (player => player.NetworkId == senderId);
+    var dropped = (HeldWeapon)droppedMask & (dropper?.HeldWeapon ?? HeldWeapon.None);
+
+    if (dropped == HeldWeapon.None)
+    {
+      ServerLog.Event (senderId, $"weapon drop deny: mask [{(HeldWeapon)droppedMask}] not held by sender");
+      return;
+    }
+
+    // Mid-air drops settle onto the level below (issue #151); over the void there's
+    // nothing to rest on, so the spawn is skipped & the caps respawn the weapons at
+    // spawn points instead of leaving unreachable floating pickups.
+    if (!TryFindGround (position, out var spot))
+    {
+      ServerLog.Event (senderId, $"weapon drop skip: no ground beneath {position}; [{dropped}] returns via the caps");
+      return;
+    }
+
+    ServerLog.Event (senderId, $"weapon drop: {dropped} at {spot}");
+    var dropperName = dropper!.DisplayName; // Non-null: the mask intersection above proved the sender exists.
     if (dropped.HasFlag (HeldWeapon.Laser)) Spawn (HeldWeapon.Laser, spot, expires: true, dropperName);
     if (dropped.HasFlag (HeldWeapon.Banana)) Spawn (HeldWeapon.Banana, spot + Vector3.Right * 0.8f, expires: true, dropperName);
     if (dropped.HasFlag (HeldWeapon.Boomerang)) Spawn (HeldWeapon.Boomerang, spot + Vector3.Left * 0.8f, expires: true, dropperName); // Issue #98.
@@ -334,9 +352,20 @@ public partial class WeaponSpawner : Node3D
 
   private Vector3 GroundedSpot (Vector3 position)
   {
-    var query = PhysicsRayQueryParameters3D.Create (position, position + Vector3.Down * 100.0f);
+    TryFindGround (position, out var spot);
+    return spot; // Over the void this keeps the raw position; the pickup expires & the caps respawn it.
+  }
+
+  // Level geometry only (collision layer 1): another player below isn't a shelf.
+  private const uint WorldLayer = 1;
+
+  // Finds the first level surface beneath the point (hover height above it); false
+  // over the void, where there's nothing for a pickup to rest on (issue #151).
+  private bool TryFindGround (Vector3 position, out Vector3 spot)
+  {
+    var query = PhysicsRayQueryParameters3D.Create (position, position + Vector3.Down * 100.0f, collisionMask: WorldLayer);
     var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
-    if (hit.Count == 0) return position;
-    return (Vector3)hit["position"] + Vector3.Up * PickupHoverHeight;
+    spot = hit.Count == 0 ? position : (Vector3)hit["position"] + Vector3.Up * PickupHoverHeight;
+    return hit.Count > 0;
   }
 }

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -8,15 +8,16 @@ using Godot;
 namespace com.forerunnergames.energyshot.weapons;
 
 // Server-authoritative weapon lifecycle manager (issue #72): keeps at most 3 lasers,
-// 1 banana, & 1 boomerang (issue #98) existing in the level (held + dropped + pickups
-// + boomerang escrow), spawning pickups at the building-top & banana-platform spawn
-// points. Spawns replicate to every peer through the World's MultiplayerSpawner,
+// 1 banana, 1 boomerang (issue #98), & 1 slingshot (issue #99) existing in the level
+// (held + dropped + pickups + boomerang escrow), spawning pickups at the building-top
+// & banana-platform spawn points. Spawns replicate to every peer through the World's MultiplayerSpawner,
 // same as players.
 public partial class WeaponSpawner : Node3D
 {
   [Export] public int MaxLasers = 3;
   [Export] public int MaxBananas = 1;
   [Export] public int MaxBoomerangs = 1;
+  [Export] public int MaxSlingshots = 1;
   [Export] public float ReconcileIntervalSeconds = 1.0f;
   [Export] public float PickupHoverHeight = 0.9f;
   // Playtest-only (#72): a laser pickup is kept at this fixed spawn-room spot so the
@@ -25,6 +26,8 @@ public partial class WeaponSpawner : Node3D
   public static readonly Vector3 PlaytestLaserPosition = new(0.0f, 31.1f, 5.0f);
   // Playtest-only (#98): same idea for the boomerang throw/catch phase.
   public static readonly Vector3 PlaytestBoomerangPosition = new(3.0f, 31.1f, 5.0f);
+  // Playtest-only (#99): same idea for the slingshot draw/release phase.
+  public static readonly Vector3 PlaytestSlingshotPosition = new(-3.0f, 31.1f, 5.0f);
   private const float OccupiedRadius = 1.0f;
   // Cargo riding a boomerang home (issue #98): stolen & scooped weapons live here
   // between the grab & the thrower's catch, so the caps still count them.
@@ -118,15 +121,16 @@ public partial class WeaponSpawner : Node3D
     EnsurePlaytestPickups (pickups);
   }
 
-  // The banana & boomerang (issue #98) respawn at random free points: the high
-  // platform + whatever laser points the lasers didn't claim (laser precedence when
-  // contested); a shared candidate list keeps the two from stacking on one point.
+  // The banana, boomerang (issue #98), & slingshot (issue #99) respawn at random free
+  // points: the high platform + whatever laser points the lasers didn't claim (laser
+  // precedence when contested); a shared candidate list keeps them from stacking.
   private void SpawnSpecialsIfMissing (List <WeaponPickup> pickups, List <Player> players, List <Vector3> freePoints)
   {
     var candidates = new List <Vector3> (freePoints);
     if (IsFree (_bananaPoint, pickups)) candidates.Add (_bananaPoint);
     if (candidates.Count > 0 && Count (HeldWeapon.Banana, pickups, players) < MaxBananas) Spawn (HeldWeapon.Banana, TakeRandom (candidates), expires: false);
     if (candidates.Count > 0 && Count (HeldWeapon.Boomerang, pickups, players) < MaxBoomerangs) Spawn (HeldWeapon.Boomerang, TakeRandom (candidates), expires: false);
+    if (candidates.Count > 0 && Count (HeldWeapon.Slingshot, pickups, players) < MaxSlingshots) Spawn (HeldWeapon.Slingshot, TakeRandom (candidates), expires: false);
   }
 
   // Playtest-only (#72 & #98): keeps deterministic pickups available in the spawn
@@ -136,6 +140,7 @@ public partial class WeaponSpawner : Node3D
     if (!_isPlaytest) return;
     EnsurePlaytestPickup (HeldWeapon.Laser, PlaytestLaserPosition, pickups);
     EnsurePlaytestPickup (HeldWeapon.Boomerang, PlaytestBoomerangPosition, pickups);
+    EnsurePlaytestPickup (HeldWeapon.Slingshot, PlaytestSlingshotPosition, pickups); // Issue #99.
   }
 
   private void EnsurePlaytestPickup (HeldWeapon type, Vector3 position, List <WeaponPickup> pickups)
@@ -210,6 +215,7 @@ public partial class WeaponSpawner : Node3D
     if (dropped.HasFlag (HeldWeapon.Laser)) Spawn (HeldWeapon.Laser, spot, expires: true, dropperName);
     if (dropped.HasFlag (HeldWeapon.Banana)) Spawn (HeldWeapon.Banana, spot + Vector3.Right * 0.8f, expires: true, dropperName);
     if (dropped.HasFlag (HeldWeapon.Boomerang)) Spawn (HeldWeapon.Boomerang, spot + Vector3.Left * 0.8f, expires: true, dropperName); // Issue #98.
+    if (dropped.HasFlag (HeldWeapon.Slingshot)) Spawn (HeldWeapon.Slingshot, spot + Vector3.Back * 0.8f, expires: true, dropperName); // Issue #99.
   }
 
   // ------------------------------------------------ boomerang cargo (issue #98)

--- a/project.godot
+++ b/project.godot
@@ -98,6 +98,11 @@ weapon_4={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":52,"key_label":0,"unicode":52,"location":0,"echo":false,"script":null)
 ]
 }
+weapon_5={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":53,"key_label":0,"unicode":53,"location":0,"echo":false,"script":null)
+]
+}
 eat_bread={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"location":0,"echo":false,"script":null)

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -30,6 +30,7 @@ public partial class PlaytestDriver : Node
   private string _address = "127.0.0.1";
   private int _boltsSpawned;
   private int _boomerangsSpawned;
+  private int _stonesSpawned;
   private Player? _self;
   private Player Self => _self ??= _world.GetPlayers().First (player => player.IsMultiplayerAuthority());
   private MusicManager Music => _world.GetNode <MusicManager> ("MusicManager");
@@ -43,6 +44,7 @@ public partial class PlaytestDriver : Node
     _world = GetNode <World> ("/root/World");
     _world.ChildEnteredTree += node => _boltsSpawned += node is LaserBolt ? 1 : 0;
     _world.ChildEnteredTree += node => _boomerangsSpawned += node is BoomerangProjectile ? 1 : 0;
+    _world.ChildEnteredTree += node => _stonesSpawned += node is SlingshotStone ? 1 : 0;
     var args = OS.GetCmdlineUserArgs();
     _role = ArgValue (args, "--playtest") ?? string.Empty;
     _address = ArgValue (args, "--address") ?? "127.0.0.1";
@@ -336,6 +338,27 @@ public partial class PlaytestDriver : Node
     // Still held + no longer in flight = the return trip ended in an auto-catch; a
     // lost boomerang would have cleared the held flag instead (#98).
     await WaitUntil (() => Self.Holds (HeldWeapon.Boomerang) && !Self.IsBoomerangInFlight, 30, "boomerang returned & was auto-caught (#98)");
+
+    // Slingshot (#99): collect the deterministic spawn-room pickup, then draw the
+    // band (hold shoot) & release - a stone projectile must spawn.
+    await WaitUntil (() => WalkedTo (WeaponSpawner.PlaytestSlingshotPosition), 45, "walked to the playtest slingshot pickup");
+    await WaitUntil (() => Self.Holds (HeldWeapon.Slingshot), 15, "collected the slingshot pickup (#99)");
+    PressAction ("weapon_5");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_5");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Slingshot, "slingshot selected in slot 5 (#99)");
+    AimAt (Self.GlobalPosition + new Vector3 (10, 1, 0)); // Aim away from everyone.
+    var stonesBefore = _stonesSpawned;
+
+    for (var attempt = 0; attempt < 10 && _stonesSpawned == stonesBefore; ++attempt)
+    {
+      PressAction ("shoot");
+      await Task.Delay (600); // Hold to draw (#99); release slings the stone.
+      ReleaseAction ("shoot");
+      await Task.Delay (300);
+    }
+
+    Assert (_stonesSpawned > stonesBefore, "slingshot draw & release fired a stone (#99)");
 
     // The toggle persists to the shared user settings (#119); restore the starting
     // view so a playtest run never flips the developer's real preference.

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -12,13 +12,13 @@ public class MessageGeneratorTest
   private static DeathContext Laser (float energy = 0.5f) => new() { Kind = DamageKind.Laser, Energy = energy };
 
   [TestCase]
-  public void ExactlyOneHundredSevenUniqueMessageTemplates()
+  public void ExactlyOneHundredElevenUniqueMessageTemplates()
   {
     // 100 from the content wave (issue #84) + 3 through-wall zaps (issue #94)
-    // + 4 boomerang zap-outs (issue #98).
+    // + 4 boomerang zap-outs (issue #98) + 4 slingshot zap-outs (issue #99).
     var templates = MessagePools.All.SelectMany (pool => pool).ToList();
-    AssertInt (templates.Count).IsEqual (107);
-    AssertInt (templates.Distinct().Count()).IsEqual (107);
+    AssertInt (templates.Count).IsEqual (111);
+    AssertInt (templates.Distinct().Count()).IsEqual (111);
   }
 
   [TestCase]
@@ -33,8 +33,8 @@ public class MessageGeneratorTest
   [TestCase]
   public void EveryPoolIsInTheRegistry()
   {
-    // 24 scenario pools registered, none empty.
-    AssertInt (MessagePools.All.Count).IsEqual (24);
+    // 25 scenario pools registered, none empty.
+    AssertInt (MessagePools.All.Count).IsEqual (25);
     foreach (var pool in MessagePools.All) AssertBool (pool.Count > 0).IsTrue();
   }
 
@@ -68,6 +68,13 @@ public class MessageGeneratorTest
   {
     // Boomerang zap-outs get their own flavor (issue #98).
     AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.Boomerang, Energy = 0.4f })).IsSame (MessagePools.Boomerang);
+  }
+
+  [TestCase]
+  public void SlingshotPoolSelectedByDamageKind()
+  {
+    // Slingshot zap-outs get their own flavor (issue #99).
+    AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.Slingshot, Energy = 0.6f })).IsSame (MessagePools.Slingshot);
   }
 
   [TestCase]

--- a/ui/hud/messages/MessageGenerator.cs
+++ b/ui/hud/messages/MessageGenerator.cs
@@ -52,6 +52,7 @@ public static class MessageGenerator
     if (context.Kind == DamageKind.Punch && context.KillerUnarmed) return MessagePools.FistsVsFists;
     if (context.Kind == DamageKind.Punch) return MessagePools.Punch;
     if (context.Kind == DamageKind.Boomerang) return MessagePools.Boomerang; // Issue #98.
+    if (context.Kind == DamageKind.Slingshot) return MessagePools.Slingshot; // Issue #99.
     if (context.VictimHeldBananaGun) return MessagePools.HoldingBananaGun;
     if (context.Kind == DamageKind.Laser && context.ThroughBarrier) return MessagePools.ThroughWall; // Pierced a wall/floor first (issue #94).
     if (context.KillerSliding) return MessagePools.SlideShotKiller;

--- a/ui/hud/messages/MessagePools.cs
+++ b/ui/hud/messages/MessagePools.cs
@@ -209,6 +209,15 @@ public static class MessagePools
     "{v} got clipped by {z}'s frisbee with commitment issues"
   };
 
+  // Slingshot zap-outs (issue #99).
+  public static readonly List <string> Slingshot = new()
+  {
+    "{z} slingshotted {v} straight back to the stone age",
+    "{v} was zapped out by a pebble. {z} is very proud",
+    "{z} drew, released, & {v}'s day unraveled",
+    "physics homework by {z}: the arc ended on {v}"
+  };
+
   // {z} zapped {v} with the weapon {v} dropped earlier.
   public static readonly List <string> TheftRevenge = new()
   {
@@ -224,6 +233,6 @@ public static class MessagePools
     Fall, FallStreak, Zapped, ThroughWall, FullCharge, FullAuto, Punch, PunchedOutArmed, FistsVsFists,
     BananaBlast, BananaDirect, HoldingBananaGun, ComboSplatterPunch, JumpShot, SlideShotKiller,
     SlideShotVictim, ZapStreakTier3, ZapStreakTier5, ZapStreakTier7, StreakEnded, StreakLost,
-    ZappedStreak, Boomerang, TheftRevenge
+    ZappedStreak, Boomerang, Slingshot, TheftRevenge
   };
 }


### PR DESCRIPTION
Implements the slingshot weapon (#99): pull back to charge, fling a projectile with drop, draw time scales power & arc.

## What's new

- **Slot-5 slingshot** (key `5`): hold shoot to draw the band (like the laser's charge mechanic, but ballistic), release to sling a stone on a gravity arc. Drawn longer = flatter, faster, & harder: draw scales stone speed 22-60 m/s & damage 15-60 (max ~1.2s draw). The held Y-frame pulls back toward the eye as the band stretches, with a creak on draw & a snappy thwack on release.
- **Fits the weapon lifecycle (#72)**: server-side cap of 1 slingshot in the level (held + dropped + pickups + boomerang escrow), spawn-point respawns, auto-equip on pickup (#128), drop-on-death & punch-loose drops, boomerang steal & scoop compatible (#98), theft-revenge attribution (#84).
- **Victim-authoritative damage**: the shooter's live stone only reports the hit; the victim applies its own damage & knockback via a new `ReceiveSlingshotHit` RPC, same as the laser/banana/boomerang. Never a one-hit zap-out.
- **No new replication indices**: `HeldWeapon.Slingshot` (flag 8) & `SelectedWeapon.Slingshot` (slot 4) ride the existing synced properties; Player.tscn is untouched & indices stay contiguous 0-17.
- **Message pools (#84)**: a 4-template slingshot zap-out pool selected by `DamageKind.Slingshot` - 111 unique templates across 25 pools; unit test counts updated.
- **No downloaded assets**: held model, pickup model, & stone are code-built primitives; sounds reuse existing punch whiff/thud pitched.

## Validation

- `dotnet build`: 0 errors, 0 warnings.
- Full playtest **PASS** (host + shooter + victim), including a new phase: walk to a deterministic spawn-room slingshot pickup, collect (auto-equip), select slot 5, draw & release, & assert a stone projectile spawns.

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a slingshot weapon that charges while held and fires physics-based stones.
  * Added slingshot pickup, spawning, dropping, equipping, and weapon-slot support.
  * Added projectile knockback, energy-based damage, gravity, collision handling, and multiplayer visuals.
  * Added the `5` key as the slingshot selection shortcut.
  * Added dedicated slingshot impact messages to the HUD.

* **Tests**
  * Added playtest coverage for equipping, charging, and firing the slingshot.
  * Added verification for slingshot-specific damage messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->