### PR TITLE
Add the dance emote on G

### DIFF
--- a/core/players/Player.Banana.cs
+++ b/core/players/Player.Banana.cs
@@ -19,7 +19,7 @@ public partial class Player
 
   private void UpdateBananaLauncher()
   {
-    if (!IsBananaSelected || !HasBanana || !_isInputEnabled) return;
+    if (!IsBananaSelected || !HasBanana || !_isInputEnabled || Dancing) return; // Dancing blocks firing (issue #103).
     if (!Input.IsActionJustPressed ("shoot")) return;
     if (!_bananaLauncher.CanFire) return;
     FireBanana();

--- a/core/players/Player.Boomerang.cs
+++ b/core/players/Player.Boomerang.cs
@@ -32,7 +32,7 @@ public partial class Player
 
   private void UpdateBoomerang()
   {
-    if (!IsBoomerangSelected || !HasBoomerang || !_isInputEnabled) return;
+    if (!IsBoomerangSelected || !HasBoomerang || !_isInputEnabled || Dancing) return; // Dancing blocks throwing (issue #103).
     if (IsBoomerangOut || !Input.IsActionJustPressed ("shoot")) return;
     ThrowBoomerang();
   }

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -41,8 +41,9 @@ public partial class Player
   public float ShotReadyFraction => _energyWeapon.CooldownFraction;
   public float PunchReadyFraction => 1.0f - _punchCooldownLeft / PunchCooldownSeconds;
   public float FullAutoReadyFraction => 1.0f - _fullAutoCooldownLeft / FullAutoCooldownSeconds;
-  // The laser only charges & fires while it's the selected weapon (issues #72 & #82).
-  private bool IsChargingWeapon() => _isInputEnabled && IsLaserSelected && HasLaser && !IsFullAutoActive() && Input.IsActionPressed ("shoot");
+  // The laser only charges & fires while it's the selected weapon (issues #72 & #82);
+  // dancing blocks charging - the press cancels the dance instead (issue #103).
+  private bool IsChargingWeapon() => _isInputEnabled && !Dancing && IsLaserSelected && HasLaser && !IsFullAutoActive() && Input.IsActionPressed ("shoot");
   private bool IsDischargingWeapon() => _isInputEnabled && IsLaserSelected && HasLaser && _energyWeapon.IsSpinningUp && Input.IsActionJustReleased ("shoot");
   private void ChargeWeapon() => _energyWeapon.Charge();
   private void DischargeWeapon() => _energyWeapon.Discharge();
@@ -110,7 +111,7 @@ public partial class Player
     _fullAutoCooldownLeft = Mathf.Max (0.0f, _fullAutoCooldownLeft - dt);
     if (wasRecharging && _fullAutoCooldownLeft <= 0.0f) _energyWeapon.PlayFullAutoReadySound();
 
-    if (_isInputEnabled && HasLaser && Input.IsActionJustPressed ("ability") && _fullAutoCooldownLeft <= 0.0f)
+    if (_isInputEnabled && !Dancing && HasLaser && Input.IsActionJustPressed ("ability") && _fullAutoCooldownLeft <= 0.0f) // Dancing blocks the ability (issue #103).
     {
       _fullAutoSecondsLeft = FullAutoDurationSeconds;
       _fullAutoCooldownLeft = FullAutoCooldownSeconds;
@@ -122,16 +123,17 @@ public partial class Player
     _fullAutoSecondsLeft -= dt;
     if (_fullAutoSecondsLeft <= 0.0f) _energyWeapon.SetFullAutoMode (false);
     _nextAutoShotIn -= dt;
-    if (!_isInputEnabled || !IsLaserSelected || !Input.IsActionPressed ("shoot") || _nextAutoShotIn > 0.0f) return;
+    if (!_isInputEnabled || Dancing || !IsLaserSelected || !Input.IsActionPressed ("shoot") || _nextAutoShotIn > 0.0f) return; // Dancing blocks firing (issue #103).
     _nextAutoShotIn = FullAutoShotIntervalSeconds;
     _energyWeapon.FireLowPower (FullAutoEnergy);
   }
 
-  // Punching requires fists as the selected weapon (issue #82).
+  // Punching requires fists as the selected weapon (issue #82); dancing blocks
+  // punching - the press cancels the dance instead (issue #103).
   private void UpdatePunch (double delta)
   {
     _punchCooldownLeft = Mathf.Max (0.0f, _punchCooldownLeft - (float)delta);
-    if (!_isInputEnabled || !IsFistsSelected || _punchCooldownLeft > 0.0f || !Input.IsActionJustPressed ("punch")) return;
+    if (!_isInputEnabled || Dancing || !IsFistsSelected || _punchCooldownLeft > 0.0f || !Input.IsActionJustPressed ("punch")) return;
     _punchCooldownLeft = PunchCooldownSeconds;
     CancelSpawnArmorIfFired(); // Punching drops your spawn armor, same as firing.
     var hand = ChooseRandomPunchHand();
@@ -315,6 +317,7 @@ public partial class Player
     // (+50% per tier gap: Beginner->Intermediate 1.5x, Beginner->Expert 2x,
     // Intermediate->Expert 1.5x). Attacking downward is unchanged - the bigger health
     // pool already is the handicap.
+    Dancing = false; // Getting zapped mid-dance ends the groove on every peer (issue #103).
     var attacker = GetParent().GetNodeOrNull <Player> ($"{attackerId}");
     var handicap = 1.0f + 0.5f * Mathf.Max (0, TierOf (MaxHealth) - TierOf (attacker?.MaxHealth ?? MaxHealth));
     var decrease = Mathf.RoundToInt (CalculateHealthDecrease (energy) * handicap);

--- a/core/players/Player.Dance.cs
+++ b/core/players/Player.Dance.cs
@@ -1,0 +1,140 @@
+using com.forerunnergames.energyshot.core.audio;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Dance emote (issue #103): press G to groove - a rhythmic squash-&-stretch bounce,
+// a lean sway, alternating overhead hand pumps, & a slow spin, looping until
+// canceled. Dancing is a taunt with risk: firing & punching are blocked while
+// dancing, & any movement or combat input - or taking damage - snaps back to normal.
+public partial class Player
+{
+  [Export] public float DanceSpinDegreesPerSecond = 45.0f;
+  [Export] public float DanceBounceScale = 0.12f;
+  [Export] public float DanceLeanRadians = 0.25f;
+  [Export] public float DanceHandLiftMeters = 0.6f;
+  [Export] public float DanceHandPumpMeters = 0.5f;
+  // Loose fixed-tempo guess (issue #103), no beat detection: ~120 BPM (4 bounces per
+  // 2s loop) while the synced soundtrack plays, a lazier ~100 BPM shuffle in silence.
+  private const float MusicDanceLoopSeconds = 2.0f;
+  private const float QuietDanceLoopSeconds = 2.4f;
+  private bool _dancing;
+  private Tween? _danceTween;
+
+  // Replicated like Sliding so every peer sees (& can still shoot at) the dancer;
+  // synced ALWAYS for the same self-healing reason (issue #131), so ApplyDance must
+  // stay idempotent per state.
+  [Export]
+  public bool Dancing
+  {
+    get => _dancing;
+    set
+    {
+      _dancing = value;
+      ApplyDance();
+    }
+  }
+
+  // G toggles the groove (issue #103). Runs after the fire/punch updates in
+  // _PhysicsProcess: those still see Dancing true & swallow the press, so a
+  // canceling combat input never also attacks in the same frame.
+  private void UpdateDance (double delta)
+  {
+    if (Dancing) { ContinueDance (delta); return; }
+    if (!StartsDance()) return;
+    StartDance();
+  }
+
+  private bool StartsDance() => _isInputEnabled && !IsStunned && !Sliding && Input.IsActionJustPressed ("dance");
+
+  private void StartDance()
+  {
+    if (_crouching && IsOverheadBlocked()) return; // No room to stand up & boogie.
+    Crouching = false; // Dancing happens standing.
+    ApplyCameraHeight();
+    Dancing = true;
+  }
+
+  private void ContinueDance (double delta)
+  {
+    if (CanceledDance()) { Dancing = false; return; }
+    RotateY (Mathf.DegToRad (DanceSpinDegreesPerSecond) * (float)delta); // Slow spin; the replicated rotation carries it to peers.
+  }
+
+  // Any movement or combat input - or another G press - ends the dance (issue #103);
+  // the fire/punch gates already swallowed the attack itself this frame.
+  private bool CanceledDance() =>
+    !_isInputEnabled
+    || Input.GetVector ("move_left", "move_right", "move_forward", "move_back") != Vector2.Zero
+    || Input.IsActionPressed ("shoot")
+    || Input.IsActionJustPressed ("jump")
+    || Input.IsActionJustPressed ("slide")
+    || Input.IsActionJustPressed ("crouch")
+    || Input.IsActionJustPressed ("punch")
+    || Input.IsActionJustPressed ("ability")
+    || Input.IsActionJustPressed ("dance");
+
+  // Runs on every peer via the replicated Dancing property; ALWAYS-mode sync re-fires
+  // the setter every tick, so start/stop exactly once per state flip.
+  private void ApplyDance()
+  {
+    if (_mesh == null) return; // Pre-_Ready sync; the next ALWAYS tick re-applies.
+    if (_dancing && _danceTween == null) { StartDanceAnimation(); return; }
+    if (!_dancing && _danceTween != null) StopDanceAnimation();
+  }
+
+  // One looping method tween drives the whole routine from a single 0..tau phase:
+  // all procedural on the existing body & hand nodes, no animation assets (issue #103).
+  private void StartDanceAnimation()
+  {
+    foreach (var tween in _handTweens) tween?.Kill(); // A punch mid-swing releases its hand to the dance.
+    _danceTween = CreateTween().SetLoops();
+    _danceTween.TweenMethod (Callable.From <float> (ApplyDancePose), 0.0f, Mathf.Tau, DanceLoopSeconds());
+    UpdateHandsVisibility(); // Both hands wave regardless of the selected weapon.
+  }
+
+  // Full restore on every peer: the same helpers the respawn reset audit relies on
+  // (issue #103) put the mesh rotation, position, & scale back to canonical.
+  private void StopDanceAnimation()
+  {
+    _danceTween?.Kill();
+    _danceTween = null;
+    ApplySlidePose();
+    ApplyCrouchScale();
+    for (var hand = 0; hand < _hands.Length; ++hand) ResetHandRest (hand);
+    UpdateHandsVisibility();
+  }
+
+  private void ResetHandRest (int hand)
+  {
+    if (_hands[hand] == null) return;
+    _hands[hand]!.Position = HandRestOffset (hand);
+  }
+
+  private float DanceLoopSeconds()
+  {
+    var music = GetNodeOrNull <MusicManager> ("/root/World/MusicManager");
+    return music != null && music.CurrentTrackTitle.Length > 0 ? MusicDanceLoopSeconds : QuietDanceLoopSeconds;
+  }
+
+  // phase runs 0..tau per loop: |sin 2phi| bounces on every beat (4 per loop),
+  // sin phi sways the lean once per loop, & sin 2phi pumps the hands alternately.
+  // Only the mesh squashes - the hitbox stays honest while dancing.
+  private void ApplyDancePose (float phase)
+  {
+    var beat = Mathf.Sin (phase * 2.0f);
+    var bounce = Mathf.Abs (beat);
+    _mesh.Scale = new Vector3 (1.0f + DanceBounceScale * 0.5f * bounce, 1.0f - DanceBounceScale * bounce, 1.0f + DanceBounceScale * 0.5f * bounce);
+    _mesh.Rotation = new Vector3 (0.0f, 0.0f, Mathf.Sin (phase) * DanceLeanRadians);
+    _mesh.Position = new Vector3 (0.0f, 1.0f - DanceBounceScale * 0.5f * bounce, 0.0f); // Feet stay planted through the squash.
+    ApplyDanceHandPose (hand: 0, beat);
+    ApplyDanceHandPose (hand: 1, -beat);
+  }
+
+  // Raised hands pumping in alternation, like a crowd hyped on the beat.
+  private void ApplyDanceHandPose (int hand, float pump)
+  {
+    if (_hands[hand] == null) return;
+    _hands[hand]!.Position = HandRestOffset (hand) + Vector3.Up * (DanceHandLiftMeters + DanceHandPumpMeters * pump);
+  }
+}

--- a/core/players/Player.Dance.cs.uid
+++ b/core/players/Player.Dance.cs.uid
@@ -1,0 +1,1 @@
+uid://4evmn3wr4u3j

--- a/core/players/Player.Hands.cs
+++ b/core/players/Player.Hands.cs
@@ -43,19 +43,21 @@ public partial class Player
     return mesh;
   }
 
-  // Hands render only while fists are the selected weapon (issue #82).
+  // Hands render only while fists are the selected weapon (issue #82) - except while
+  // dancing, when both hands wave regardless of the selected weapon (issue #103).
   private void UpdateHandsVisibility()
   {
     foreach (var hand in _hands)
     {
       if (hand == null) continue;
-      hand.Visible = IsFistsSelected;
+      hand.Visible = IsFistsSelected || Dancing;
     }
   }
 
   // Moving bobs the resting hands up & down (issue #82); a hand mid-punch is left alone.
   private void UpdateHandBob (double delta)
   {
+    if (Dancing) return; // The dance owns the hands (issue #103).
     var speed = new Vector2 (Velocity.X, Velocity.Z).Length();
     _handBobPhase += speed * HandBobFrequency * (float)delta;
     var bob = Vector3.Up * (Mathf.Sin (_handBobPhase) * HandBobMeters * Mathf.Min (1.0f, speed / Speed));

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -94,6 +94,9 @@ public partial class Player
   private void ApplySlidePose()
   {
     if (_mesh == null) return;
+    // The dance owns the mesh (issue #103): Sliding syncs ALWAYS, so this re-runs
+    // every tick on puppets & would fight the dance tween; the dance's stop restores.
+    if (Dancing) return;
     var rotation = Sliding ? new Vector3 (-90.0f, 0.0f, 0.0f) : Vector3.Zero;
     var position = new Vector3 (0.0f, Sliding ? 0.5f : 1.0f, 0.0f);
     _mesh.RotationDegrees = rotation;
@@ -106,6 +109,7 @@ public partial class Player
   private void ApplyCrouchScale()
   {
     if (_mesh == null) return;
+    if (Dancing) return; // Same ALWAYS-sync reason as ApplySlidePose (issue #103).
     var scale = new Vector3 (1.0f, _crouching ? CrouchHeightScale : 1.0f, 1.0f);
     _mesh.Scale = scale;
     _collisionShape.Scale = scale;
@@ -218,6 +222,7 @@ public partial class Player
     _slideSecondsLeft = 0.0f;
     _slideCooldownLeft = 0.0f;
     Crouching = false;
+    Dancing = false; // A new life starts with the pose fully restored on every peer (issue #103).
     ApplyCameraHeight();
     SetInputEnabled (isEnabled: false);
     _respawnSound.Play();

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -393,6 +393,7 @@ public partial class Player : CharacterBody3D
     UpdateBread();
     UpdateFullAuto (delta);
     UpdatePunch (delta);
+    UpdateDance (delta); // After the fire/punch updates, so a canceling press can't also attack (issue #103).
     UpdateHandBob (delta);
     UpdateAirBoost();
     UpdateStickyFlight (delta);

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -108,6 +108,9 @@ properties/16/replication_mode = 2
 properties/17/path = NodePath(".:ColorIndex")
 properties/17/spawn = true
 properties/17/replication_mode = 2
+properties/18/path = NodePath(".:Dancing")
+properties/18/spawn = true
+properties/18/replication_mode = 1
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/project.godot
+++ b/project.godot
@@ -118,6 +118,11 @@ crouch={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":67,"key_label":0,"unicode":99,"location":0,"echo":false,"script":null)
 ]
 }
+dance={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":103,"location":0,"echo":false,"script":null)
+]
+}
 toggle_view={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":86,"key_label":0,"unicode":118,"location":0,"echo":false,"script":null)

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -166,6 +166,10 @@ public partial class PlaytestDriver : Node
     // replicate here so the on-fire glow & pulsing leaderboard entry appear.
     await WaitUntil (() => victim.ZapStreakCount == 3, 15, "victim's simulated 3-streak replicated to shooter");
 
+    // Dance emote (#103): the victim started dancing after its armor expired; the
+    // replicated state must animate this puppet copy too.
+    await WaitUntil (() => victim.Dancing, 15, "victim's dance replicated to shooter (#103)");
+
     // Punch phase: walk up to the victim & punch them; verify melee damage lands.
     // Fists are weapon slot 1 & punching requires them selected (issue #82); unarmed
     // players already default to fists, so this press is just a defensive re-select.
@@ -185,6 +189,8 @@ public partial class PlaytestDriver : Node
     }
 
     Assert (victim.Health < healthBeforePunch, $"punch damaged the victim ({healthBeforePunch} -> {victim.Health})");
+    // Damage cancels the dance (#103) & the cancel must replicate back here too.
+    await WaitUntil (() => !victim.Dancing, 5, "victim's dance cancel replicated to shooter (#103)");
     // Sync property index 14 (#88): the punch stun must replicate to the shooter's copy.
     await WaitUntil (() => victim.StunFactor > 0.0f, 2, "victim's punch stun replicated to shooter");
 
@@ -311,6 +317,17 @@ public partial class PlaytestDriver : Node
     ReleaseAction ("crouch");
     await WaitUntil (() => !Self.Crouching, 5, "stood back up after the canceled slide (#131)");
 
+    // Dance emote (#103): G starts the groove & any movement input cancels it,
+    // restoring the normal standing state.
+    PressAction ("dance");
+    await Task.Delay (100);
+    ReleaseAction ("dance");
+    await WaitUntil (() => Self.Dancing, 5, "own dance started on G (#103)");
+    Input.ActionPress ("move_forward");
+    await Task.Delay (300);
+    Input.ActionRelease ("move_forward");
+    await WaitUntil (() => !Self.Dancing, 5, "moving canceled the dance (#103)");
+
     // Boomerang (#98): collect the deterministic spawn-room pickup, throw it (aimed
     // away from everyone so no incidental steals), & watch it fly back into the hand.
     await WaitUntil (() => WalkedTo (WeaponSpawner.PlaytestBoomerangPosition), 45, "walked to the playtest boomerang pickup");
@@ -375,8 +392,15 @@ public partial class PlaytestDriver : Node
     // Streak replication (#88): simulate an active 3-streak on our own authority so
     // the shooter can verify it replicates - & that the death reset replicates too.
     Self.ZapStreakCount = 3;
+    // Dance emote (#103): groove on G; the shooter verifies the replicated state on
+    // its puppet copy, & the punch damage below must cancel the dance.
+    PressAction ("dance");
+    await Task.Delay (100);
+    ReleaseAction ("dance");
+    await WaitUntil (() => Self.Dancing, 5, "dance started on G (#103)");
     // The shooter opens fire once armor drops; verify damage & then a full respawn.
     await WaitUntil (() => Self.Health < Self.MaxHealth, 120, "took damage from shooter");
+    Assert (!Self.Dancing, "taking damage canceled the dance (#103)");
     // One-hit-kill (#93): after the punch phase, the shooter only fires full-charge
     // shots, & a full-charge shot is lethal on any target - so no partial-damage
     // health value may ever appear between the punch & the respawn reset.


### PR DESCRIPTION
Fixes #103

Press **G** ("groove") to bust out a silly dance visible to every player — a taunt with risk, since dancing blocks all attacking.

## What it does
- **Procedural dance loop, no assets**: one looping method tween drives the whole ~2s routine from a single phase value — squash-&-stretch body bounce (4 bounces per loop), a lean sway, alternating overhead pumps of the sphere hands, & a slow full-body spin. Both hands wave regardless of the selected weapon.
- **Loose music tempo**: ~120 BPM while the synced soundtrack (#137) has a track playing, a lazier ~100 BPM shuffle in silence. A fixed guess by design — no beat detection.
- **Taunt with risk**: laser charge, full-auto, punch, banana, & boomerang are all blocked while dancing. Any movement or combat input cancels the dance, & the fire/punch gates run before the dance update in the frame so the canceling press is swallowed — it never also attacks.
- **Damage & death cancel it**: taking any damage ends the groove; respawn resets `Dancing` alongside `Sliding`/`Crouching`, restoring the normal pose, mesh scale, & hand rest state on every peer.
- **Replication**: a new `Dancing` property at sync index 18 (indices 0–17 unchanged), ALWAYS mode like `Sliding` (#131) so a dropped delta self-heals. The setter is idempotent per state flip, so per-tick re-syncs are cheap. The spin rides the already-replicated rotation. `ApplySlidePose` & `ApplyCrouchScale` yield the mesh while dancing so their ALWAYS-mode re-runs on puppets can't fight the dance tween.
- **Hitbox stays honest**: only the mesh squashes & leans — the collision shape is untouched.

## Validation
- `dotnet build`: 0 errors, 0 warnings.
- Full playtest **PASS** (host + shooter + victim), including 6 new #103 assertions:
  - dance starts on G (victim & shooter local)
  - replicated dance state visible on a peer's puppet copy
  - punch damage cancels the dance on the victim & the cancel replicates back to the shooter
  - movement input cancels the dance & restores normal state

No message-pool changes (kept the 107-template/24-pool counts untouched) & no weapon selection/spawner changes beyond the minimal "dancing blocks firing" gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)