### PR TITLE
Add the full controls reference & sync the README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 
 ## Controls
 
+Full reference: [docs/CONTROLS.md](docs/CONTROLS.md) (movement, all 5 weapon slots, abilities, music voting, & hidden mechanics).
+
 | Input | Action |
 |---|---|
-| W A S D | Move |
-| Mouse | Look |
-| Left mouse (hold & release) | Charge & fire laser |
-| Right mouse | Punch |
-| F | Full-auto ability (3 s, 15 s cooldown) |
-| Space | Jump |
-| V | Toggle first-/third-person view |
+| W A S D / Mouse / Space | Move, look, jump |
+| Left mouse | Fire selected weapon (hold to charge laser / draw slingshot) |
+| Right mouse | Punch (fists) |
+| 1-5 | Fists, laser, banana, boomerang, slingshot |
+| Shift / C / V | Slide, crouch, first-/third-person |
+| F / B / G | Full-auto burst, eat bread, dance |
+| Tab | Message history |
+| . / , | Music vote up / down |
 | Esc | Quit dialog |
 
 ## Multiplayer

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -1,0 +1,50 @@
+# Controls
+
+Current as of v0.8.14.
+
+## Movement
+
+| Input | Action |
+|---|---|
+| W A S D | Move |
+| Mouse | Look / aim |
+| Space | Jump (also cancels a slide, with headroom) |
+| Shift | Slide (5s cooldown; press slide/crouch/jump to cancel early) |
+| C | Crouch (toggle - press again to stand) |
+| V | Toggle first-/third-person view (saved between sessions) |
+
+## Weapons
+
+Slot keys select what's in your hands. You spawn with fists only; everything else is picked up in the arena (picking one up auto-equips it).
+
+| Key | Weapon | How it works |
+|---|---|---|
+| 1 | Fists | Right-click to punch. Punching walls hurts *you*. 20% chance a landed punch knocks the victim's weapon loose |
+| 2 | Laser | Left-click tap = quick shot. Hold = charge - a full charge (click sound + crosshair pop) pierces walls, one-hit zaps anyone, & shows enemies through walls while held |
+| 3 | Banana launcher | Left-click to fire an arcing banana. Direct hits stick, launch the victim, & detonate. Massive recoil - it can also rocket-jump you |
+| 4 | Boomerang | Left-click to throw. Curves out & returns; steals weapons from anyone it clips & scoops pickups it passes; auto-catches on return |
+| 5 | Slingshot | Hold left-click to draw, release to fling a stone. Longer draw = faster, flatter, harder (never a one-hit) |
+
+## Abilities & extras
+
+| Input | Action |
+|---|---|
+| F | Full-auto laser burst (3s of rapid low-power shots, 15s cooldown; needs the laser) |
+| B | Eat bread - full heal, once per life |
+| G | Dance. Blocks your weapons while grooving; any movement or taking a hit cancels it |
+| Shoot the ground beneath you | Rocket boost upward (scales with charge; works once per airtime in the air) |
+
+## Communication & music
+
+| Input | Action |
+|---|---|
+| Tab | Toggle message history (PageUp / PageDown to scroll; it never blocks your aim) |
+| . (period) | Thumbs-up the current music track |
+| , (comma) | Thumbs-down (enough downvotes skips the track) |
+| Esc | Pause / quit dialog |
+
+## Good to know
+
+- White glow = spawn armor (5s of invulnerability after spawning; firing or punching cancels it).
+- Kills heal you 50 HP. Falling off the world costs a point - your score can go negative.
+- Difficulty picks your health pool (Beginner 400 / Intermediate 300 / Expert 200), and lower-tier players hit higher-tier players harder.

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -32,7 +32,7 @@ Slot keys select what's in your hands. You spawn with fists only; everything els
 | F | Full-auto laser burst (3s of rapid low-power shots, 15s cooldown; needs the laser) |
 | B | Eat bread - full heal, once per life |
 | G | Dance. Blocks your weapons while grooving; any movement or taking a hit cancels it |
-| Shoot the ground beneath you | Rocket boost upward (scales with charge; works once per airtime in the air) |
+| Shoot the ground beneath you | Rocket boost upward, scaling with charge. Unlimited from the ground; while airborne it works once per airtime, re-armed when you land |
 
 ## Communication & music
 


### PR DESCRIPTION
Adds docs/CONTROLS.md (complete, current control reference: movement, weapon slots 1-5, abilities, music voting, hidden mechanics like the rocket boost & bread) & replaces the README's stale controls table with a synced summary linking to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive controls reference covering movement, weapons, abilities, communication, music voting, and gameplay mechanics.
  * Updated the main controls overview with consolidated control information and a link to the full reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->