### PR TITLE
Add gold admin announcements with a server message file & deploy warnings

### DIFF
--- a/.github/workflows/export-and-release.yml
+++ b/.github/workflows/export-and-release.yml
@@ -197,8 +197,8 @@ jobs:
           chmod +x energy-shot-server.x86_64
           # Warn players in-game before the swap (issue #158): the running server
           # polls this file once a second (--admin-message-file on the systemd unit)
-          # & broadcasts new content as a gold admin announcement. Owned by the game
-          # user so the server process can truncate it after broadcasting.
+          # & broadcasts new content as a gold admin announcement, consuming the
+          # file (claimed by rename in the game user's home directory).
           echo "Server updating to $TAG - back in about a minute!" > /home/game/admin-message
           chown game:game /home/game/admin-message
           # Record the running version (issue #158): the new build reads this at

--- a/.github/workflows/export-and-release.yml
+++ b/.github/workflows/export-and-release.yml
@@ -195,6 +195,18 @@ jobs:
           unzip -oq server.zip && rm server.zip
           test -f energy-shot-server.x86_64 || { echo "server binary missing from archive"; exit 1; }
           chmod +x energy-shot-server.x86_64
+          # Warn players in-game before the swap (issue #158): the running server
+          # polls this file once a second (--admin-message-file on the systemd unit)
+          # & broadcasts new content as a gold admin announcement. Owned by the game
+          # user so the server process can truncate it after broadcasting.
+          echo "Server updating to $TAG - back in about a minute!" > /home/game/admin-message
+          chown game:game /home/game/admin-message
+          # Record the running version (issue #158): the new build reads this at
+          # startup (--version-file) & shows each joining player "Running <tag>".
+          echo "$TAG" > /home/game/server-version
+          chown game:game /home/game/server-version
+          # Give players a moment to see the warning before the restart.
+          sleep 15
           # Swap in the validated build & restart.
           rm -rf /opt/energy-shot/build
           mv /opt/energy-shot/staging /opt/energy-shot/build

--- a/core/network/AdminMessageFileWatcher.cs
+++ b/core/network/AdminMessageFileWatcher.cs
@@ -1,0 +1,43 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.utilities;
+
+// Server-operator announcement channel (issue #158): with --admin-message-file
+// <path>, the server polls the file once a second & hands any new non-empty
+// content to the broadcast callback, then truncates the file - so the same text
+// can be re-sent later & nothing re-broadcasts on restart. Sending a message
+// from SSH is one line: echo "Back in a minute!" > /path/to/admin-message
+public partial class AdminMessageFileWatcher : Node
+{
+  private readonly string _path;
+  private readonly System.Action <string> _broadcast;
+
+  public AdminMessageFileWatcher (string path, System.Action <string> broadcast)
+  {
+    _path = path;
+    _broadcast = broadcast;
+  }
+
+  public override void _Ready()
+  {
+    var timer = new Timer { WaitTime = 1.0, Autostart = true };
+    timer.Timeout += Poll;
+    AddChild (timer);
+  }
+
+  private void Poll()
+  {
+    var message = TakePendingMessage();
+    if (message.Length == 0) return;
+    _broadcast (message);
+  }
+
+  private string TakePendingMessage()
+  {
+    if (!System.IO.File.Exists (_path)) return string.Empty;
+    var message = System.IO.File.ReadAllText (_path).Trim();
+    if (message.Length == 0) return string.Empty;
+    System.IO.File.WriteAllText (_path, string.Empty);
+    return message;
+  }
+}

--- a/core/network/AdminMessageFileWatcher.cs
+++ b/core/network/AdminMessageFileWatcher.cs
@@ -4,7 +4,7 @@ namespace com.forerunnergames.energyshot.utilities;
 
 // Server-operator announcement channel (issue #158): with --admin-message-file
 // <path>, the server polls the file once a second & hands any new non-empty
-// content to the broadcast callback, then truncates the file - so the same text
+// content to the broadcast callback, consuming the file - so the same text
 // can be re-sent later & nothing re-broadcasts on restart. Sending a message
 // from SSH is one line: echo "Back in a minute!" > /path/to/admin-message
 public partial class AdminMessageFileWatcher : Node
@@ -34,10 +34,21 @@ public partial class AdminMessageFileWatcher : Node
 
   private string TakePendingMessage()
   {
-    if (!System.IO.File.Exists (_path)) return string.Empty;
-    var message = System.IO.File.ReadAllText (_path).Trim();
-    if (message.Length == 0) return string.Empty;
-    System.IO.File.WriteAllText (_path, string.Empty);
+    var claimedPath = $"{_path}.claimed";
+    if (!TryClaim (claimedPath)) return string.Empty;
+    var message = System.IO.File.ReadAllText (claimedPath).Trim();
+    System.IO.File.Delete (claimedPath);
     return message;
+  }
+
+  // Atomic claim (PR #166 review): rename the file aside before reading it, so an
+  // operator echo racing the poll lands in a fresh file at the watched path
+  // instead of being truncated away unread.
+  private bool TryClaim (string claimedPath)
+  {
+    if (!System.IO.File.Exists (_path)) return false;
+    try { System.IO.File.Move (_path, claimedPath, overwrite: true); }
+    catch (System.IO.IOException) { return false; } // Vanished mid-claim; the next poll retries.
+    return true;
   }
 }

--- a/core/network/AdminMessageFileWatcher.cs.uid
+++ b/core/network/AdminMessageFileWatcher.cs.uid
@@ -1,0 +1,1 @@
+uid://b23grm731pp1p

--- a/core/network/NetworkManager.cs
+++ b/core/network/NetworkManager.cs
@@ -8,6 +8,7 @@ public partial class NetworkManager : Node
 {
   // @formatter:off
   public event Action <string>? RemoteMessageReceived;
+  public event Action <string>? AdminMessageReceived;
   public event Action <string, string>? PlayerRespawnedShot;
   public event Action <string>? PlayerRespawnedFell;
   public event Action <string>? PlayerJoinGame;
@@ -25,6 +26,27 @@ public partial class NetworkManager : Node
   private void SendToAllClientsExcept (int excludingId, string method, params Variant[] args) => Multiplayer.GetPeers().Where (id => id != excludingId).ToList().ForEach (id => RpcId (id, method, args));
   private void SendToAllClientsExcept (int excludingId1, int excludingId2, string method, params Variant[] args) => Multiplayer.GetPeers().Where (id => id != excludingId1 && id != excludingId2).ToList().ForEach (id => RpcId (id, method, args));
   // @formatter:on
+
+  // Admin announcements (issue #158): server-only broadcast, shown on every peer
+  // including the host. Same text everywhere (#53).
+  public void NotifyAdminMessage (string message)
+  {
+    AdminMessageReceived?.Invoke (message);
+    SendToAllClients (nameof (OnAdminMessageReceived), message);
+  }
+
+  // Version line for a single joining peer (issue #158): targeted, not a broadcast,
+  // so it doubles as version info without spamming everyone on every join.
+  public void SendAdminMessageTo (int peerId, string message) => RpcId (peerId, nameof (OnAdminMessageReceived), message);
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void OnAdminMessageReceived (string message)
+  {
+    // Admin messages are only honored from peer 1, the server (issue #158);
+    // a forged send from any other peer is dropped.
+    if (Multiplayer.GetRemoteSenderId() != 1) return;
+    AdminMessageReceived?.Invoke (message);
+  }
 
   public void NotifyPlayerJoinGame (string playerName)
   {

--- a/core/network/NetworkManager.cs
+++ b/core/network/NetworkManager.cs
@@ -28,16 +28,22 @@ public partial class NetworkManager : Node
   // @formatter:on
 
   // Admin announcements (issue #158): server-only broadcast, shown on every peer
-  // including the host. Same text everywhere (#53).
+  // including the host. Same text everywhere (#53). The server guard runs before
+  // local delivery, so a misused call on a client can neither display nor send.
   public void NotifyAdminMessage (string message)
   {
+    if (!IsServer) return;
     AdminMessageReceived?.Invoke (message);
     SendToAllClients (nameof (OnAdminMessageReceived), message);
   }
 
   // Version line for a single joining peer (issue #158): targeted, not a broadcast,
   // so it doubles as version info without spamming everyone on every join.
-  public void SendAdminMessageTo (int peerId, string message) => RpcId (peerId, nameof (OnAdminMessageReceived), message);
+  public void SendAdminMessageTo (int peerId, string message)
+  {
+    if (!IsServer) return;
+    RpcId (peerId, nameof (OnAdminMessageReceived), message);
+  }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
   private void OnAdminMessageReceived (string message)

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -18,6 +18,7 @@ public partial class World : Node3D
   [Signal] public delegate void SelfPlayerPunchedEventHandler();
   [Signal] public delegate void SelfPlayerSplatteredEventHandler();
   [Signal] public delegate void RemoteMessageReceivedEventHandler (string message);
+  [Signal] public delegate void AdminMessageReceivedEventHandler (string message);
   [Signal] public delegate void KickedFromServerEventHandler (string reason);
   [Signal] public delegate void ServerShutDownEventHandler();
   private const int DefaultServerPort = 55556;
@@ -27,6 +28,8 @@ public partial class World : Node3D
   private int _maxPlayers = MaxPlayers;
   // Required to join (issue #90); empty only on a dedicated server whose owner set no --password.
   private string _serverPassword = string.Empty;
+  // Running build tag from --version-file (issue #158); empty = no version line on join.
+  private string _serverVersion = string.Empty;
   private UI _ui = null!;
   private Callable _onServerDisconnectedCallable;
   private PackedScene _playerScene = null!;
@@ -79,11 +82,52 @@ public partial class World : Node3D
     _networkManager.PlayerRespawnedShot += (playerName, shotByPlayerName) => { if (IsActiveServer()) ServerLog.Event (FindPlayerId (playerName), $"death: {playerName} zapped out by {shotByPlayerName}"); };
     _networkManager.PlayerRespawnedFell += playerName => { if (IsActiveServer()) ServerLog.Event (FindPlayerId (playerName), $"death: {playerName} fell off the world"); };
     _networkManager.RemoteMessageReceived += message => EmitSignal (SignalName.RemoteMessageReceived, message);
+    _networkManager.AdminMessageReceived += message => EmitSignal (SignalName.AdminMessageReceived, message);
     _networkManager.PlayerJoinGame += playerName => EmitSignal (SignalName.PlayerJoinedGame, playerName);
     _networkManager.PlayerLeftGame += playerName => EmitSignal (SignalName.PlayerLeftGame, playerName);
     if (OS.GetCmdlineUserArgs().Contains ("--playtest")) CallDeferred (MethodName.StartPlaytest);
     if (IsDedicatedServer()) StartDedicatedServer();
+    StartAdminMessagePolling();
+    _serverVersion = ReadServerVersion();
     StartCrownTicker();
+  }
+
+  // Admin announcements (issue #158): only active with --admin-message-file; no
+  // polling otherwise. Broadcasts only run on a live server session.
+  private void StartAdminMessagePolling()
+  {
+    var path = ParseArgValue ("--admin-message-file");
+    if (path.Length == 0) return;
+    AddChild (new AdminMessageFileWatcher (path, BroadcastAdminMessage));
+  }
+
+  private void BroadcastAdminMessage (string message)
+  {
+    if (!IsActiveServer()) return;
+    ServerLog.Event ($"admin announcement: {message}");
+    _networkManager.NotifyAdminMessage (message);
+  }
+
+  // Release announcement (issue #158): --version-file <path> names the running
+  // build; read once at startup & shown to each joining peer as "Running <tag>".
+  // Absent file/flag = skipped silently (self-hosted games don't show it).
+  private static string ReadServerVersion()
+  {
+    var path = ParseArgValue ("--version-file");
+    if (path.Length == 0 || !System.IO.File.Exists (path)) return string.Empty;
+    return System.IO.File.ReadAllText (path).Trim();
+  }
+
+  // The version line goes to the joining peer only - not a broadcast, so it
+  // doubles as version info without spamming everyone on every join (issue #158).
+  // Delayed past the client's spawn: NewGameStarted resets the message scroller,
+  // which would wipe a line that arrives before the HUD is up.
+  private async void SendVersionTo (int peerId)
+  {
+    if (_serverVersion.Length == 0) return;
+    await ToSignal (GetTree().CreateTimer (2.0), SceneTreeTimer.SignalName.Timeout);
+    if (!Multiplayer.GetPeers().Contains (peerId)) return; // Already left.
+    _networkManager.SendAdminMessageTo (peerId, $"Running {_serverVersion}");
   }
 
   private void StartPlaytest() => AddChild (new playtest.PlaytestDriver());
@@ -135,10 +179,12 @@ public partial class World : Node3D
 
   // Dedicated-server password (issue #90): --password <p>; empty means no password
   // required, so the official server keeps working until its owner sets one.
-  private static string ParseServerPassword()
+  private static string ParseServerPassword() => ParseArgValue ("--password");
+
+  private static string ParseArgValue (string name)
   {
     var args = OS.GetCmdlineUserArgs();
-    var index = System.Array.IndexOf (args, "--password");
+    var index = System.Array.IndexOf (args, name);
     if (index == -1 || index + 1 >= args.Length) return string.Empty;
     return args[index + 1];
   }
@@ -207,6 +253,7 @@ public partial class World : Node3D
     }
 
     AddPlayer (senderId, playerName, Player.MaxHealthFor (difficulty), colorIndex);
+    SendVersionTo (senderId);
   }
 
   // Delay the disconnect so the kick-reason RPC isn't dropped by an immediate peer disconnect (see issue #23).

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -30,6 +30,8 @@ public partial class World : Node3D
   private string _serverPassword = string.Empty;
   // Running build tag from --version-file (issue #158); empty = no version line on join.
   private string _serverVersion = string.Empty;
+  // Peers already told the version line, so the ready handshake & its fallback can't double-send (PR #166 review).
+  private readonly System.Collections.Generic.HashSet <int> _versionLinePeerIds = new();
   private UI _ui = null!;
   private Callable _onServerDisconnectedCallable;
   private PackedScene _playerScene = null!;
@@ -120,14 +122,42 @@ public partial class World : Node3D
 
   // The version line goes to the joining peer only - not a broadcast, so it
   // doubles as version info without spamming everyone on every join (issue #158).
-  // Delayed past the client's spawn: NewGameStarted resets the message scroller,
-  // which would wipe a line that arrives before the HUD is up.
-  private async void SendVersionTo (int peerId)
+  // Sent on the client's readiness confirmation, not a guessed delay (PR #166
+  // review): NewGameStarted resets the message scroller, which would wipe a line
+  // that arrives before the HUD is up.
+  private void SendVersionTo (int peerId)
   {
     if (_serverVersion.Length == 0) return;
-    await ToSignal (GetTree().CreateTimer (2.0), SceneTreeTimer.SignalName.Timeout);
-    if (!Multiplayer.GetPeers().Contains (peerId)) return; // Already left.
+    if (!_versionLinePeerIds.Add (peerId)) return; // Already sent (ready + fallback paths).
     _networkManager.SendAdminMessageTo (peerId, $"Running {_serverVersion}");
+  }
+
+  // A joined client confirmed its HUD is up: safe to send its version line now (PR #166 review).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ConfirmClientReady()
+  {
+    if (!Multiplayer.IsServer()) return;
+    var senderId = Multiplayer.GetRemoteSenderId();
+    if (FindPlayer (senderId) == null) return; // Only joined players get the line.
+    SendVersionTo (senderId);
+  }
+
+  // Tell the server our HUD finished NewGameStarted; the host is the server
+  // itself & needs no confirmation (PR #166 review).
+  private void NotifyServerClientReady()
+  {
+    if (Multiplayer.GetUniqueId() == 1) return;
+    RpcId (1, MethodName.ConfirmClientReady);
+  }
+
+  // Fallback (PR #166 review): a client whose readiness confirmation is lost
+  // still gets its version line, just on the old fixed-delay timing.
+  private async void SendVersionToAfterFallbackDelay (int peerId)
+  {
+    if (_serverVersion.Length == 0) return;
+    await ToSignal (GetTree().CreateTimer (10.0), SceneTreeTimer.SignalName.Timeout);
+    if (!Multiplayer.GetPeers().Contains (peerId)) return; // Already left.
+    SendVersionTo (peerId);
   }
 
   private void StartPlaytest() => AddChild (new playtest.PlaytestDriver());
@@ -253,7 +283,7 @@ public partial class World : Node3D
     }
 
     AddPlayer (senderId, playerName, Player.MaxHealthFor (difficulty), colorIndex);
-    SendVersionTo (senderId);
+    SendVersionToAfterFallbackDelay (senderId);
   }
 
   // Delay the disconnect so the kick-reason RPC isn't dropped by an immediate peer disconnect (see issue #23).
@@ -297,6 +327,7 @@ public partial class World : Node3D
   private void OnClientDisconnectedFromServer (long id)
   {
     RemovePlayer (id);
+    _versionLinePeerIds.Remove ((int)id); // A rejoin counts as a fresh join (PR #166 review).
     ServerLog.Event (id, "disconnected");
   }
 
@@ -346,6 +377,9 @@ public partial class World : Node3D
     selfPlayer.Scored += (playerName, shotPlayerName) => EmitSignal (SignalName.PlayerScored, ++_score, playerName, shotPlayerName);
     GD.Print ($"{_selfPlayer.NetworkId}: Registered my player {_selfPlayer.DisplayName}");
     EmitSignal (SignalName.NewGameStarted, _selfPlayer.DisplayName, _selfPlayer.MaxHealth);
+    // NewGameStarted handlers (incl. the HUD's scroller reset) ran synchronously
+    // above, so the version line can't be wiped after this (PR #166 review).
+    NotifyServerClientReady();
   }
 
   private void RemovePlayer (long peerId)

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using com.forerunnergames.energyshot.core.audio;
@@ -25,12 +26,17 @@ public partial class PlaytestDriver : Node
   private const int HostColor = 1;
   private const int ShooterColor = 3;
   private const int VictimColor = 5;
+  // Admin messages (issue #158): announcement text written into the host's operator
+  // file mid-run; the version must match run-playtest.sh's version file content.
+  private const string AdminAnnouncement = "Playtest admin announcement";
+  private const string ServerVersion = "v9.9.9-playtest";
   private World _world = null!;
   private string _role = string.Empty;
   private string _address = "127.0.0.1";
   private int _boltsSpawned;
   private int _boomerangsSpawned;
   private Player? _self;
+  private readonly List <string> _adminMessages = new();
   private Player Self => _self ??= _world.GetPlayers().First (player => player.IsMultiplayerAuthority());
   private MusicManager Music => _world.GetNode <MusicManager> ("MusicManager");
   private Player? FindPlayer (string name) => _world.GetPlayers().FirstOrDefault (player => player.DisplayName == name);
@@ -41,6 +47,7 @@ public partial class PlaytestDriver : Node
     // ENet, dilating in-game time far behind the wall clock this driver waits on.
     Engine.MaxFps = 30;
     _world = GetNode <World> ("/root/World");
+    _world.AdminMessageReceived += message => _adminMessages.Add (message);
     _world.ChildEnteredTree += node => _boltsSpawned += node is LaserBolt ? 1 : 0;
     _world.ChildEnteredTree += node => _boomerangsSpawned += node is BoomerangProjectile ? 1 : 0;
     var args = OS.GetCmdlineUserArgs();
@@ -111,6 +118,13 @@ public partial class PlaytestDriver : Node
     // vote came back through the server tally.
     await WaitUntil (() => Music.CurrentTrackTitle.Length > 0, 15, "music track started on the server");
     await WaitUntil (() => Music.CurrentUpVotes == 1, 30, "shooter's music vote tallied on host");
+    // Admin messages (issue #158): drop an announcement into the operator file; the
+    // 1s poller must broadcast it to every peer (host included) & truncate the file
+    // so the same text can be re-sent later.
+    var adminFile = ArgValue (OS.GetCmdlineUserArgs(), "--admin-message-file")!;
+    System.IO.File.WriteAllText (adminFile, AdminAnnouncement);
+    await WaitUntil (() => _adminMessages.Contains (AdminAnnouncement), 15, "admin announcement broadcast from the message file (#158)");
+    await WaitUntil (() => System.IO.File.ReadAllText (adminFile).Length == 0, 10, "admin message file truncated after broadcast (#158)");
     // Shooter kills victim once (plus possibly the host itself in the line of
     // fire); wait to observe the replicated score.
     await WaitUntil (() => FindPlayer (ShooterName)?.Score >= 1, 120, "shooter's kill replicated to host");
@@ -120,12 +134,19 @@ public partial class PlaytestDriver : Node
     await WaitUntil (() => FindPlayer (VictimName)?.Score == -1, 60, "victim's fall penalty (-1) replicated to host");
     // Stay up until both clients have finished & disconnected.
     await WaitUntil (() => _world.GetPlayers().Count() == 1, 120, "clients disconnected");
+    // The version line goes only to joining clients, never broadcast (#158), so the
+    // host must never have seen one.
+    Assert (_adminMessages.All (message => !message.Contains ("Running")), "version line was not broadcast to the host (#158)");
   }
 
   private async Task RunShooter()
   {
     _world.StartClientSession (ShooterName, difficulty: 1, _address, Port, Password, ShooterColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
+    // Forged admin RPC (issue #158): a client impersonating the server must be
+    // dropped by the server's peer-1 check; every role asserts the text never
+    // arrives. Sent by name: the RPC is private to NetworkManager on purpose.
+    _world.GetNode <Node> ("NetworkManager").Rpc ("OnAdminMessageReceived", "FORGED announcement");
     // DisplayName is an on-change sync that can land a beat after the spawn itself
     // under CI load (issue #78): wait for both names before dereferencing the
     // lookups, or FindPlayer returns null right here.
@@ -357,6 +378,15 @@ public partial class PlaytestDriver : Node
     // The toggle persists to the shared user settings (#119); restore the starting
     // view so a playtest run never flips the developer's real preference.
     await ToggleViewUntil (startedThirdPerson);
+
+    // Admin messages (issue #158), asserted here so the waits don't stall the
+    // timing-sensitive phases above: the join-time version line reached only us
+    // (targeted send) & the host's file-driven announcement reached everyone.
+    await WaitUntil (() => _adminMessages.Contains ($"Running {ServerVersion}"), 30, "version line received on join (#158)");
+    await WaitUntil (() => _adminMessages.Contains (AdminAnnouncement), 30, "admin announcement received from the server (#158)");
+    // Our forged admin RPC from the start of the run was dropped by the server:
+    // it never echoed back here through any relay (#158).
+    Assert (_adminMessages.All (message => !message.Contains ("FORGED")), "forged admin RPC was rejected (#158)");
   }
 
   // Presses V until the view matches; the toggle only persists on a real key press,
@@ -388,6 +418,10 @@ public partial class PlaytestDriver : Node
     // propagated here through the server broadcast.
     await WaitUntil (() => Music.CurrentTrackTitle.Length > 0, 15, "current music track synced from server");
     await WaitUntil (() => Music.CurrentUpVotes == 1, 30, "shooter's music vote visible to victim");
+    // Admin messages (issue #158): the join-time version line & the host's
+    // file-driven announcement both arrive as admin messages here too.
+    await WaitUntil (() => _adminMessages.Contains ($"Running {ServerVersion}"), 30, "version line received on join (#158)");
+    await WaitUntil (() => _adminMessages.Contains (AdminAnnouncement), 30, "admin announcement received from the server (#158)");
     await WaitUntil (() => !Self.SpawnArmor, 15, "spawn armor expired on its own");
     // Streak replication (#88): simulate an active 3-streak on our own authority so
     // the shooter can verify it replicates - & that the death reset replicates too.
@@ -421,6 +455,9 @@ public partial class PlaytestDriver : Node
     await WaitUntil (() => Self.Score == -1, 60, "fall at score 0 dropped own score to -1");
     // Give the shooter time to finish its solo phases (fire-rate & full-auto) before we vanish.
     await Task.Delay (8000);
+    // The shooter's forged admin RPC must never have been relayed to us: the
+    // server drops admin messages from any sender but peer 1 (#158).
+    Assert (_adminMessages.All (message => !message.Contains ("FORGED")), "forged admin RPC never relayed to the victim (#158)");
   }
 
   // Negative password check (issue #109): join with a bogus password, expect the

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -121,12 +121,12 @@ public partial class PlaytestDriver : Node
     await WaitUntil (() => Music.CurrentTrackTitle.Length > 0, 15, "music track started on the server");
     await WaitUntil (() => Music.CurrentUpVotes == 1, 30, "shooter's music vote tallied on host");
     // Admin messages (issue #158): drop an announcement into the operator file; the
-    // 1s poller must broadcast it to every peer (host included) & truncate the file
-    // so the same text can be re-sent later.
+    // 1s poller must broadcast it to every peer (host included) & consume the file
+    // (claimed atomically by rename) so the same text can be re-sent later.
     var adminFile = ArgValue (OS.GetCmdlineUserArgs(), "--admin-message-file")!;
     System.IO.File.WriteAllText (adminFile, AdminAnnouncement);
     await WaitUntil (() => _adminMessages.Contains (AdminAnnouncement), 15, "admin announcement broadcast from the message file (#158)");
-    await WaitUntil (() => System.IO.File.ReadAllText (adminFile).Length == 0, 10, "admin message file truncated after broadcast (#158)");
+    await WaitUntil (() => !System.IO.File.Exists (adminFile), 10, "admin message file consumed after broadcast (#158)");
     // Shooter kills victim once (plus possibly the host itself in the line of
     // fire); wait to observe the replicated score.
     await WaitUntil (() => FindPlayer (ShooterName)?.Score >= 1, 120, "shooter's kill replicated to host");

--- a/tests/playtest/run-playtest.sh
+++ b/tests/playtest/run-playtest.sh
@@ -14,7 +14,13 @@ echo "== Importing & building =="
 dotnet build "$DIR" > "$LOGS/build.log" 2>&1 || { echo "BUILD FAILED"; tail -20 "$LOGS/build.log"; exit 1; }
 
 echo "== Launching host + 2 clients =="
-"$GODOT_BIN" --headless --path "$DIR" -- --playtest host > "$LOGS/host.log" 2>&1 &
+# Admin messages (issue #158): the host runs with the operator file channel & a
+# version file; the driver writes an announcement mid-run & every role asserts it.
+ADMIN_FILE="$LOGS/admin-message"
+VERSION_FILE="$LOGS/server-version"
+: > "$ADMIN_FILE"
+echo "v9.9.9-playtest" > "$VERSION_FILE"
+"$GODOT_BIN" --headless --path "$DIR" -- --playtest host --admin-message-file "$ADMIN_FILE" --version-file "$VERSION_FILE" > "$LOGS/host.log" 2>&1 &
 HOST=$!
 sleep 5
 "$GODOT_BIN" --headless --path "$DIR" -- --playtest victim > "$LOGS/victim.log" 2>&1 &

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -38,6 +38,8 @@ public partial class Hud : Control
   private int _fallStreak;
   private string _selfPlayerName = string.Empty;
   private void OnRemoteMessageReceived (string message) => _messageScroller.AddMessage (message);
+  // Server-operator announcements render gold with a [SERVER] prefix (issue #158).
+  private void OnAdminMessageReceived (string message) => PrintMessage ($"[SERVER] {message}", MessageScroller.MessageImportance.Admin);
 
   private void OnSelfPlayerHealthChanged (string playerName, int health)
   {
@@ -104,6 +106,7 @@ public partial class Hud : Control
     _world.PlayerJoinedGame += OnPlayerJoinedGame;
     _world.PlayerLeftGame += OnPlayerLeftGame;
     _world.RemoteMessageReceived += OnRemoteMessageReceived;
+    _world.AdminMessageReceived += OnAdminMessageReceived;
     _world.PlayerScored += OnPlayerScored;
     _world.PlayerRespawnedShot += OnPlayerRespawnedShot;
     _world.PlayerRespawnedFell += OnPlayerRespawnedFell;

--- a/ui/hud/messages/MessageScroller.cs
+++ b/ui/hud/messages/MessageScroller.cs
@@ -11,11 +11,15 @@ public partial class MessageScroller : Control
   [Export] public float MediumMessageImportanceDisplayTimeSeconds = 1.0f;
   [Export] public float HighMessageImportanceDisplayTimeSeconds = 2.0f;
   [Export] public float CriticalMessageImportanceDisplayTimeSeconds = 3.0f;
+  // Admin announcements linger longer than normal messages (issue #158).
+  [Export] public float AdminMessageImportanceDisplayTimeSeconds = 6.0f;
   [Export] public float LoadingCompleteMessageImportanceDisplayTimeSeconds = 1.0f;
   [Export] public Color LowMessageImportanceColor = Colors.White;
   [Export] public Color MediumMessageImportanceColor = Colors.White;
   [Export] public Color HighMessageImportanceColor = Colors.LightSkyBlue;
   [Export] public Color CriticalMessageImportanceColor = Colors.IndianRed;
+  // Gold reads well on the dark arena & is distinct from the red/white/blue above (issue #158).
+  [Export] public Color AdminMessageImportanceColor = Colors.Gold;
   [Export] public Color LoadingStartMessageImportanceColor = Colors.White;
   [Export] public Color LoadingCompleteMessageImportanceColor = Colors.White;
   [Export] public int MaxMessageHistoryLines = 1000;
@@ -44,6 +48,7 @@ public partial class MessageScroller : Control
     Medium,
     High,
     Critical,
+    Admin, // Server-operator announcements (issue #158).
     Stop,
     Resume
   }
@@ -58,6 +63,7 @@ public partial class MessageScroller : Control
       { MessageImportance.Medium, MediumMessageImportanceDisplayTimeSeconds },
       { MessageImportance.High, HighMessageImportanceDisplayTimeSeconds },
       { MessageImportance.Critical, CriticalMessageImportanceDisplayTimeSeconds },
+      { MessageImportance.Admin, AdminMessageImportanceDisplayTimeSeconds },
       { MessageImportance.Stop, float.MaxValue }, // Shows message immediately & indefinitely until a 'Resume' message is received
       { MessageImportance.Resume, LoadingCompleteMessageImportanceDisplayTimeSeconds }
     };
@@ -68,6 +74,7 @@ public partial class MessageScroller : Control
       { MessageImportance.Medium, MediumMessageImportanceColor },
       { MessageImportance.High, HighMessageImportanceColor },
       { MessageImportance.Critical, CriticalMessageImportanceColor },
+      { MessageImportance.Admin, AdminMessageImportanceColor },
       { MessageImportance.Stop, LoadingStartMessageImportanceColor },
       { MessageImportance.Resume, LoadingCompleteMessageImportanceColor }
     };


### PR DESCRIPTION
Fixes #158

The server operator can now broadcast announcements to all players, rendered in-game in gold with a `[SERVER]` prefix, e.g. "Server restarting in 2 minutes for an update." - & joining players are told which version the server is running.

## Transport
- New `Admin` message importance in the scroller: gold (readable on the dark arena, distinct from the existing red/white/blue), kept in the message history in its color (#101 style), & displayed twice as long as death messages (6s vs 3s).
- Server -> all peers through NetworkManager; the admin RPC is only honored when the sender is peer 1 (the server) - forged sends from any other peer are dropped. Shown on every peer including the host; identical text everywhere (#53).

## Operator channel
- `--admin-message-file <path>`: the server polls the file once a second (no flag = no polling). New non-empty content is broadcast as an admin message, logged via ServerLog, & the file is truncated - so the same text can be re-sent later & nothing re-broadcasts on restart.
- Sending from SSH is one line: `echo "Server restarting in 2 minutes for an update." > /home/game/admin-message`

## Release announcements
- `--version-file <path>`: read once at startup; each joining peer alone receives a gold "[SERVER] Running <tag>" line (targeted send, not a broadcast, so it doubles as version info without spamming everyone on every join). Absent flag/file = skipped silently, so self-hosted games show nothing. The send is delayed 2s past the join so the client's HUD reset can't wipe it.

## Deploy integration
- Before swapping/restarting the droplet server, the deploy step writes "Server updating to <tag> - back in about a minute!" into `/home/game/admin-message`, writes the tag into `/home/game/server-version` for the new build, & sleeps 15s so players see the warning. Secrets guards stay inside the script body, matching the existing style (no `secrets` in step-level `if`). The systemd unit gains `--admin-message-file` / `--version-file` separately.

## Validation
- `dotnet build`: 0 errors, 0 warnings.
- Full three-instance playtest green, including new assertions: file-driven broadcast received by all three roles, file truncated after broadcast, join-time version line received by both clients & never broadcast to the host, & a client-forged admin RPC rejected by the server (never relayed).

## Non-goals
No in-game admin UI, no chat system, no permissions system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server announcements that appear in-game with a `[SERVER]` label.
  * Announcements are broadcast to all connected players and displayed in gold for six seconds.
  * Added server-version delivery when players join.
  * Deployment updates now notify players before restarting the server and record the active release version.

* **Tests**
  * Added coverage for announcement delivery, file handling, version reporting, and unauthorized message attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->