### PR TITLE
Validate weapon drops against current-or-recently-held

### DIFF
--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -29,17 +29,28 @@ public partial class Player
   // right after sending the drop RPC, & the synchronizer delta can beat the RPC to the
   // server (different channels, no cross-ordering guarantee) - so the server validates
   // masks against current-or-recently-held instead of denying the legit drop.
-  public HeldWeapon HeldOrRecentlyHeld => Time.GetTicksMsec() < _recentlyHeldUntilMs ? _heldWeapon | _recentlyHeld : _heldWeapon;
-  private HeldWeapon _recentlyHeld = HeldWeapon.None;
-  private ulong _recentlyHeldUntilMs;
+  public HeldWeapon HeldOrRecentlyHeld => _heldWeapon | RecentlyHeld();
+  // Per-flag grace deadlines (CodeRabbit on #168): a single shared pair let a second
+  // removal inside the window overwrite the first weapon's remaining grace.
+  private readonly Dictionary <HeldWeapon, ulong> _recentlyHeldUntilMs = new();
   private const float RecentlyHeldGraceSeconds = 2.0f;
 
+  private HeldWeapon RecentlyHeld()
+  {
+    var now = Time.GetTicksMsec();
+    var recent = HeldWeapon.None;
+    foreach (var (flag, until) in _recentlyHeldUntilMs) recent |= now < until ? flag : HeldWeapon.None;
+    return recent;
+  }
+
+  // Each removed weapon keeps its own full grace period (CodeRabbit on #168), even
+  // when another removal follows inside the first one's window.
   private void RememberRecentlyHeld (HeldWeapon incoming)
   {
     var removed = _heldWeapon & ~incoming;
     if (removed == HeldWeapon.None) return;
-    _recentlyHeld = removed;
-    _recentlyHeldUntilMs = Time.GetTicksMsec() + (ulong)(RecentlyHeldGraceSeconds * 1000.0f);
+    var until = Time.GetTicksMsec() + (ulong)(RecentlyHeldGraceSeconds * 1000.0f);
+    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot }) { if ((removed & flag) != 0) _recentlyHeldUntilMs[flag] = until; }
   }
 
   // Which slot is out (issue #82). Replicated so every peer renders the right model

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -19,9 +19,27 @@ public partial class Player
     get => _heldWeapon;
     set
     {
+      RememberRecentlyHeld (value);
       _heldWeapon = value;
       UpdateWeaponVisibility();
     }
+  }
+
+  // Drop-validation grace (issue #167): a death drop clears the replicated HeldWeapon
+  // right after sending the drop RPC, & the synchronizer delta can beat the RPC to the
+  // server (different channels, no cross-ordering guarantee) - so the server validates
+  // masks against current-or-recently-held instead of denying the legit drop.
+  public HeldWeapon HeldOrRecentlyHeld => Time.GetTicksMsec() < _recentlyHeldUntilMs ? _heldWeapon | _recentlyHeld : _heldWeapon;
+  private HeldWeapon _recentlyHeld = HeldWeapon.None;
+  private ulong _recentlyHeldUntilMs;
+  private const float RecentlyHeldGraceSeconds = 2.0f;
+
+  private void RememberRecentlyHeld (HeldWeapon incoming)
+  {
+    var removed = _heldWeapon & ~incoming;
+    if (removed == HeldWeapon.None) return;
+    _recentlyHeld = removed;
+    _recentlyHeldUntilMs = Time.GetTicksMsec() + (ulong)(RecentlyHeldGraceSeconds * 1000.0f);
   }
 
   // Which slot is out (issue #82). Replicated so every peer renders the right model

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -50,7 +50,11 @@ public partial class WeaponSpawner : Node3D
   private static bool IsFree (Vector3 point, IEnumerable <WeaponPickup> pickups) => pickups.All (pickup => pickup.Position.DistanceTo (point) > OccupiedRadius);
   // Escrowed boomerang cargo counts too (issue #98), or a reconcile pass mid-flight
   // would over-spawn the weapon the boomerang is carrying.
-  private int Count (HeldWeapon type, List <WeaponPickup> pickups, List <Player> players) => pickups.Count (pickup => pickup.Weapon == type) + players.Count (player => player.Holds (type)) + _escrow.Count (cargo => cargo.Type == type);
+  // Players count via HeldOrRecentlyHeld (CodeRabbit on #168): a weapon inside its
+  // drop-grace window (cleared from HeldWeapon, drop RPC not yet processed) still
+  // exists, & counting only current holds let a reconcile pass over-spawn it. The
+  // union per player counts once - recently-held includes any still-held flags.
+  private int Count (HeldWeapon type, List <WeaponPickup> pickups, List <Player> players) => pickups.Count (pickup => pickup.Weapon == type) + players.Count (player => (player.HeldOrRecentlyHeld & type) != 0) + _escrow.Count (cargo => cargo.Type == type);
   private void GrantToSelf (int type, string previousOwner) => (GetParent() as World)?.SelfPlayer?.GrantWeapon ((HeldWeapon)type, previousOwner);
   [Rpc] private void ConfirmPickup (int type, string previousOwner) => GrantToSelf (type, previousOwner);
   // A direct (non-RPC) call means the host itself sent it, so there's no remote sender.

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -211,7 +211,9 @@ public partial class WeaponSpawner : Node3D
     if (!Multiplayer.IsServer()) return;
     var senderId = SenderOrSelf();
     var dropper = Players().FirstOrDefault (player => player.NetworkId == senderId);
-    var dropped = (HeldWeapon)droppedMask & (dropper?.HeldWeapon ?? HeldWeapon.None);
+    // Current-or-recently-held (issue #167): the death-drop clear can replicate ahead
+    // of this RPC, so a strict current-held check denied every kill's weapon drop.
+    var dropped = (HeldWeapon)droppedMask & (dropper?.HeldOrRecentlyHeld ?? HeldWeapon.None);
 
     if (dropped == HeldWeapon.None)
     {


### PR DESCRIPTION
Fixes the v0.8.14 regression where killed players' weapons vanished: the death-drop's HeldWeapon clear could replicate ahead of the drop RPC, so the server's strict current-held validation denied every legit death drop. The server now keeps a 2s recently-held grace per player. Forged-mask protection intact.

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weapon drop validation when state updates and drop requests arrive out of order.
  * Death drops now remain valid briefly after a weapon is removed from the currently held state.
  * Prevented recently dropped weapons from being respawned prematurely while their drop state is still being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->