### PR TITLE
Block mismatched client versions at join with an update-required message

### DIFF
--- a/.github/workflows/export-and-release.yml
+++ b/.github/workflows/export-and-release.yml
@@ -51,6 +51,21 @@ jobs:
           # Checkout the entire commit history.
           fetch-depth: 0
 
+      # Stamp the release tag into the project version (issue #170) so every exported
+      # build carries it: the server compares client versions at join & blocks
+      # mismatched (usually outdated) clients with an update-required message.
+      # The canonical form is the tag without the leading "v" (e.g. 0.8.15);
+      # dev builds keep project.godot's "-dev" value.
+      - name: Stamp release version
+        env:
+          # Passed as an environment value (never interpolated into the script)
+          # so a hostile ref name can't inject shell commands.
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          sed -i "s|^config/version=.*|config/version=\"$VERSION\"|" project.godot
+          grep "^config/version=" project.godot
+
       # Remove the addons directory before the build, to avoid failing the
       # build with this error:
       # "Error: The process '.../Godot_v4.7.1-stable_mono_linux.x86_64' failed with exit code null"

--- a/.github/workflows/export-and-release.yml
+++ b/.github/workflows/export-and-release.yml
@@ -62,6 +62,9 @@ jobs:
           # so a hostile ref name can't inject shell commands.
           TAG: ${{ github.ref_name }}
         run: |
+          # Refuse to stamp anything that isn't a release version tag: a malformed
+          # tag would ship builds whose versions never match & lock everyone out.
+          echo "$TAG" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([-.].+)?$' || { echo "Refusing to stamp non-version tag [$TAG]"; exit 1; }
           VERSION="${TAG#v}"
           sed -i "s|^config/version=.*|config/version=\"$VERSION\"|" project.godot
           grep "^config/version=" project.godot

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -125,6 +125,17 @@ public partial class World : Node3D
     Multiplayer.Connect (MultiplayerApi.SignalName.ConnectedToServer, Callable.From (() => RequestSlot (playerName, difficulty, password, colorIndex, version ?? GameVersion)), (uint)ConnectFlags.OneShot);
   }
 
+  // Playtest-only probe (issue #170): joins exactly the way a pre-#170 client does -
+  // the legacy 4-argument RequestPlayerSlot RPC that carries no version.
+  public void StartLegacyClientSession (string playerName, int difficulty, string address, int port, string password)
+  {
+    var peer = new ENetMultiplayerPeer();
+    var error = peer.CreateClient (address, port);
+    if (error != Error.Ok) GD.PrintErr ($"Playtest join failed: {error}");
+    Multiplayer.MultiplayerPeer = peer;
+    Multiplayer.Connect (MultiplayerApi.SignalName.ConnectedToServer, Callable.From (() => RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty, password, 0)), (uint)ConnectFlags.OneShot);
+  }
+
   // Dedicated-server exports carry the feature tag, so the server binary needs no flag;
   // --server also works for running from a normal build (e.g. local testing).
   private static bool IsDedicatedServer() => OS.HasFeature ("dedicated_server") || OS.GetCmdlineUserArgs().Contains ("--server");
@@ -170,8 +181,24 @@ public partial class World : Node3D
     GD.Print ($"Server: Dedicated server v{GameVersion} listening on port [{port}], password {(_serverPassword.Length > 0 ? "required" : "not required")}");
   }
 
+  // Legacy pre-#170 join entry point: old clients send this 4-argument RPC, which
+  // carries no version. Kept at its original name & arity - Godot drops RPCs whose
+  // argument count doesn't match, so removing it would strand old clients with a
+  // silently dropped join instead of the readable update prompt their own
+  // kick-reason display (#109) can already show.
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void RequestPlayerSlot (string playerName, int difficulty, string password, int colorIndex, string version)
+  private void RequestPlayerSlot (string playerName, int difficulty, string password, int colorIndex)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var senderId = Multiplayer.GetRemoteSenderId();
+    ServerLog.Event (senderId, $"join denied: [{playerName}] legacy versionless join (server {GameVersion})");
+    Kick (senderId, $"Update required: server is v{GameVersion}, you have an older version.");
+  }
+
+  // Versioned join handshake (issue #170); the version parameter is why this can't
+  // share the legacy RPC's name - see RequestPlayerSlot above.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestPlayerSlotV2 (string playerName, int difficulty, string password, int colorIndex, string version)
   {
     if (!Multiplayer.IsServer()) return;
     var senderId = Multiplayer.GetRemoteSenderId();
@@ -251,7 +278,7 @@ public partial class World : Node3D
     _selfDifficulty = difficulty;
     _selfColorIndex = colorIndex;
     if (!Multiplayer.IsConnected (MultiplayerApi.SignalName.ServerDisconnected, _onServerDisconnectedCallable)) Multiplayer.Connect (MultiplayerApi.SignalName.ServerDisconnected, _onServerDisconnectedCallable);
-    RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty, password, colorIndex, version);
+    RpcId (1, MethodName.RequestPlayerSlotV2, playerName, difficulty, password, colorIndex, version);
   }
 
   private void OnServerDisconnected() => EmitSignal (SignalName.ServerShutDown);

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -21,6 +21,9 @@ public partial class World : Node3D
   [Signal] public delegate void KickedFromServerEventHandler (string reason);
   [Signal] public delegate void ServerShutDownEventHandler();
   private const int DefaultServerPort = 55556;
+  // Build version (issue #170): the release workflow stamps the tag (without the
+  // leading "v") into project.godot at export time; dev builds keep the "-dev" value.
+  public static string GameVersion => (string)ProjectSettings.GetSetting ("application/config/version", "unknown");
   // Hard engine limit on players per game (issue #73); hosts can choose fewer.
   public const int MaxPlayers = 12;
   private NetworkManager _networkManager = null!;
@@ -109,7 +112,9 @@ public partial class World : Node3D
     OnHostGameSuccess (playerName, difficulty, MaxPlayers, password, colorIndex);
   }
 
-  public void StartClientSession (string playerName, int difficulty, string address, int port, string password, int colorIndex = 0)
+  // The version override exists only for the playtest's wrong-version probe (issue
+  // #170); real joins always report this build's own version.
+  public void StartClientSession (string playerName, int difficulty, string address, int port, string password, int colorIndex = 0, string? version = null)
   {
     var peer = new ENetMultiplayerPeer();
     var error = peer.CreateClient (address, port);
@@ -117,7 +122,7 @@ public partial class World : Node3D
     Multiplayer.MultiplayerPeer = peer;
     // One-shot: a retried session (e.g. the playtest's wrong-password probe, issue
     // #109) must not replay stale credentials from an earlier attempt's handler.
-    Multiplayer.Connect (MultiplayerApi.SignalName.ConnectedToServer, Callable.From (() => OnJoinGameSuccess (playerName, difficulty, password, colorIndex)), (uint)ConnectFlags.OneShot);
+    Multiplayer.Connect (MultiplayerApi.SignalName.ConnectedToServer, Callable.From (() => RequestSlot (playerName, difficulty, password, colorIndex, version ?? GameVersion)), (uint)ConnectFlags.OneShot);
   }
 
   // Dedicated-server exports carry the feature tag, so the server binary needs no flag;
@@ -162,15 +167,24 @@ public partial class World : Node3D
     Multiplayer.PeerConnected += OnClientConnectedToServer;
     Multiplayer.PeerDisconnected += OnClientDisconnectedFromServer;
     _serverPassword = ParseServerPassword();
-    GD.Print ($"Server: Dedicated server listening on port [{port}], password {(_serverPassword.Length > 0 ? "required" : "not required")}");
+    GD.Print ($"Server: Dedicated server v{GameVersion} listening on port [{port}], password {(_serverPassword.Length > 0 ? "required" : "not required")}");
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void RequestPlayerSlot (string playerName, int difficulty, string password, int colorIndex)
+  private void RequestPlayerSlot (string playerName, int difficulty, string password, int colorIndex, string version)
   {
     if (!Multiplayer.IsServer()) return;
     var senderId = Multiplayer.GetRemoteSenderId();
-    ServerLog.Event (senderId, $"join request: [{playerName}] (difficulty {difficulty})");
+    ServerLog.Event (senderId, $"join request: [{playerName}] (difficulty {difficulty}, version {version})");
+
+    // Mixed client versions silently break RPCs between peers (issue #170): block
+    // any mismatch up front with an update prompt, same UX as the password kick (#109).
+    if (version != GameVersion)
+    {
+      ServerLog.Event (senderId, $"join denied: [{playerName}] version mismatch (server {GameVersion}, client {version})");
+      Kick (senderId, $"Update required: server is v{GameVersion}, you have v{version}.");
+      return;
+    }
 
     // Server-enforced game password (issue #90); empty server password = open server.
     if (_serverPassword.Length > 0 && password != _serverPassword)
@@ -228,13 +242,16 @@ public partial class World : Node3D
     AddPlayer (Multiplayer.GetUniqueId(), playerName, Player.MaxHealthFor (difficulty), colorIndex);
   }
 
-  private void OnJoinGameSuccess (string playerName, int difficulty, string password, int colorIndex)
+  // The UI join path always reports this build's own version (issue #170).
+  private void OnJoinGameSuccess (string playerName, int difficulty, string password, int colorIndex) => RequestSlot (playerName, difficulty, password, colorIndex, GameVersion);
+
+  private void RequestSlot (string playerName, int difficulty, string password, int colorIndex, string version)
   {
     _selfPlayerName = playerName;
     _selfDifficulty = difficulty;
     _selfColorIndex = colorIndex;
     if (!Multiplayer.IsConnected (MultiplayerApi.SignalName.ServerDisconnected, _onServerDisconnectedCallable)) Multiplayer.Connect (MultiplayerApi.SignalName.ServerDisconnected, _onServerDisconnectedCallable);
-    RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty, password, colorIndex);
+    RpcId (1, MethodName.RequestPlayerSlot, playerName, difficulty, password, colorIndex, version);
   }
 
   private void OnServerDisconnected() => EmitSignal (SignalName.ServerShutDown);

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="energy-shot"
+config/version="0.8.15-dev"
 run/main_scene="res://core/world/World.tscn"
 config/features=PackedStringArray("4.7", "C#", "Forward Plus")
 config/icon="res://icon.svg"

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -397,6 +397,9 @@ public partial class PlaytestDriver : Node
 
   private async Task RunVictim()
   {
+    // Version enforcement (issue #170): a mismatched client version must get kicked
+    // with the update-required reason before anything else is checked.
+    await AssertWrongVersionIsKicked();
     // Password enforcement (issue #109): a wrong password must get kicked with
     // "Wrong password." before the real join succeeds.
     await AssertWrongPasswordIsKicked();
@@ -444,6 +447,21 @@ public partial class PlaytestDriver : Node
     await WaitUntil (() => Self.Score == -1, 60, "fall at score 0 dropped own score to -1");
     // Give the shooter time to finish its solo phases (fire-rate & full-auto) before we vanish.
     await Task.Delay (8000);
+  }
+
+  // Negative version check (issue #170): join with a spoofed version & the right
+  // password, expect the server to kick us with the exact update-required reason,
+  // then wait out the disconnect so the next join starts clean.
+  private async Task AssertWrongVersionIsKicked()
+  {
+    var kickReason = string.Empty;
+    _world.KickedFromServer += reason => kickReason = reason;
+    _world.StartClientSession (VictimName, difficulty: 0, _address, Port, Password, version: "0.0.0-spoofed");
+    await WaitUntil (() => kickReason.Length > 0, 30, "wrong-version join was kicked");
+    var expected = $"Update required: server is v{World.GameVersion}, you have v0.0.0-spoofed.";
+    Assert (kickReason == expected, $"kick reason is \"{expected}\", got \"{kickReason}\"");
+    await WaitUntil (() => Multiplayer.MultiplayerPeer.GetConnectionStatus() != MultiplayerPeer.ConnectionStatus.Connected, 15, "kicked connection fully closed");
+    await Task.Delay (500); // Let the peer teardown settle before reconnecting.
   }
 
   // Negative password check (issue #109): join with a bogus password, expect the

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -397,8 +397,10 @@ public partial class PlaytestDriver : Node
 
   private async Task RunVictim()
   {
-    // Version enforcement (issue #170): a mismatched client version must get kicked
+    // Version enforcement (issue #170): a pre-#170 client joining via the legacy
+    // versionless RPC, & a client with a mismatched version, must each get kicked
     // with the update-required reason before anything else is checked.
+    await AssertLegacyJoinIsKicked();
     await AssertWrongVersionIsKicked();
     // Password enforcement (issue #109): a wrong password must get kicked with
     // "Wrong password." before the real join succeeds.
@@ -447,6 +449,22 @@ public partial class PlaytestDriver : Node
     await WaitUntil (() => Self.Score == -1, 60, "fall at score 0 dropped own score to -1");
     // Give the shooter time to finish its solo phases (fire-rate & full-auto) before we vanish.
     await Task.Delay (8000);
+  }
+
+  // Legacy-client check (issue #170): join the way a pre-#170 client does (the
+  // 4-argument RequestPlayerSlot RPC with no version), expect the server to kick
+  // us with the exact update-required reason old clients can already display
+  // (#109), then wait out the disconnect so the next join starts clean.
+  private async Task AssertLegacyJoinIsKicked()
+  {
+    var kickReason = string.Empty;
+    _world.KickedFromServer += reason => kickReason = reason;
+    _world.StartLegacyClientSession (VictimName, difficulty: 0, _address, Port, Password);
+    await WaitUntil (() => kickReason.Length > 0, 30, "legacy versionless join was kicked");
+    var expected = $"Update required: server is v{World.GameVersion}, you have an older version.";
+    Assert (kickReason == expected, $"kick reason is \"{expected}\", got \"{kickReason}\"");
+    await WaitUntil (() => Multiplayer.MultiplayerPeer.GetConnectionStatus() != MultiplayerPeer.ConnectionStatus.Connected, 15, "kicked connection fully closed");
+    await Task.Delay (500); // Let the peer teardown settle before reconnecting.
   }
 
   // Negative version check (issue #170): join with a spoofed version & the right


### PR DESCRIPTION
Fixes #170

Mixed client versions joining the same server silently break RPCs between peers — the live server logged `ERROR: RPC SpawnVisualBoomerang: Method not found`, & players reported banana hits doing nothing (victim-authoritative RPCs from newer clients never execute on older clients). The server now enforces an exact client-server version match at join.

## Changes

- **Version source**: `project.godot` now carries `application/config/version`. The release workflow stamps the pushed tag into it (canonical form: no leading `v`, e.g. `0.8.15`) right after checkout, before the export step, so every released build — client & dedicated server alike — carries its true version. Local/dev builds carry `0.8.15-dev`, so dev-vs-dev testing also matches only itself. The stamping step passes the ref name as an environment value (never interpolated into the script), matching the deploy step's existing injection guard, & keeps all conditionals inside the script body.
- **Handshake**: the client includes its version in the `RequestPlayerSlot` join request; the server compares it against its own & kicks mismatches with `Update required: server is vX, you have vY.` — the exact same kick path as the wrong-password check (#109), so the client-side kick-reason display works unchanged (verified: the #109 unhook-before-emit fix keeps the reason from being overwritten). The version gate runs before the password check, so an outdated client's very first answer is the update prompt.
- **Server logging**: every version rejection is recorded via `ServerLog` (`join denied: [name] version mismatch (server X, client Y)`), & the dedicated server logs its own version at startup for easy deploy verification.
- **Playtest**: the victim role now probes a join with a spoofed version (`0.0.0-spoofed`) first & asserts the exact update-required kick reason, mirroring `AssertWrongPasswordIsKicked`, then waits out the disconnect before the wrong-password probe & the real join.

## Notes

- Pre-#170 clients send a 4-argument `RequestPlayerSlot`, which a new server drops as a signature mismatch — they can't receive a kick reason no matter what, but they can no longer get in & quietly break the match for everyone.

## Validation

- `dotnet build`: 0 errors, 0 warnings.
- Full playtest PASS (host + shooter + victim), including the new wrong-version kick assertion:
  - `PLAYTEST OK: kick reason is "Update required: server is v0.8.15-dev, you have v0.0.0-spoofed."`
  - server log: `join denied: [Victim] version mismatch (server 0.8.15-dev, client 0.0.0-spoofed)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build version tracking for client and server sessions.
  * Dedicated servers now display their running version.
* **Bug Fixes**
  * Clients using an incompatible version are rejected before joining, with an update-required message.
  * Playtest connections now verify version compatibility before password validation.
* **Release Information**
  * Updated the project version to `0.8.15-dev`.
  * Release exports now automatically apply the version from the release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->