### PR TITLE
Own-vote memory & hints, incumbent crown rules, & the hostname default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 | F | Full-auto ability (3 s, 15 s cooldown) |
 | Space | Jump |
 | V | Toggle first-/third-person view |
+| . / , | Vote the current music track up / down |
 | Esc | Quit dialog |
 
 ## Multiplayer

--- a/core/audio/MusicManager.cs
+++ b/core/audio/MusicManager.cs
@@ -29,6 +29,9 @@ public partial class MusicManager : Node
   // The local player's remembered vote for the current track (issue #162), recalled
   // by the server on each track start & confirmed after every vote.
   public int CurrentOwnVote { get; private set; }
+  // Authoritative all-time totals for the playing track - populated server-side
+  // only; the playtest host reads it to assert the vote-memory transitions (#162).
+  public (int Up, int Down) CurrentTrackAllTimeVotes => _currentTrack != -1 && _allTimeVotes.TryGetValue (TrackStems[_currentTrack], out var totals) ? totals : (0, 0);
   private const float MusicVolumeDb = -12.0f;
   private const float SilentDb = -80.0f;
   private const float FadeSeconds = 2.0f;
@@ -269,13 +272,18 @@ public partial class MusicManager : Node
 
   // One vote per player per play; re-voting switches the vote (issue #137). The
   // permanent totals track one remembered vote per player per track (issue #162).
+  // Only a named, spawned player may vote: an AnyPeer RPC from a connected-but-
+  // unjoined peer must neither move the skip tally nor receive an own-vote state
+  // that has nothing durable to persist against (issue #162).
   private void ApplyVote (long peerId, bool isUpVote)
   {
     if (_currentTrack == -1) return;
+    var name = DisplayNameFor (peerId);
+    if (name.Length == 0) return;
     _playVotes[peerId] = isUpVote ? 1 : -1;
     var upCount = _playVotes.Values.Count (vote => vote == 1);
     var downCount = _playVotes.Values.Count (vote => vote == -1);
-    UpdateRememberedVote (peerId, isUpVote ? 1 : -1);
+    UpdateRememberedVote (name, isUpVote ? 1 : -1);
     ServerLog.Event (peerId, $"music vote {(isUpVote ? "up" : "down")} for [{CurrentTrackTitle}]: play now {upCount} up / {downCount} down");
     Rpc (MethodName.OnVoteCounts, upCount, downCount);
     SendOwnVote (peerId, isUpVote ? 1 : -1); // Instant pressed-thumb feedback for the voter (issue #162).
@@ -287,17 +295,23 @@ public partial class MusicManager : Node
   // Own-vote memory (issue #162): the all-time totals hold one vote per player per
   // track - switching stance removes the old vote & adds the new one, & a repeat of
   // the same vote changes nothing, so nothing ever double-counts.
-  private void UpdateRememberedVote (long peerId, int vote)
+  private void UpdateRememberedVote (string name, int vote)
   {
-    var name = DisplayNameFor (peerId);
-    if (name.Length == 0) return; // No spawned player yet: nothing durable to key the memory on.
     var stem = TrackStems[_currentTrack];
     var previous = _voterVotes[stem].GetValueOrDefault (name, 0);
     if (previous == vote) return;
-    var (up, down) = _allTimeVotes[stem];
-    _allTimeVotes[stem] = (up - (previous == 1 ? 1 : 0) + (vote == 1 ? 1 : 0), down - (previous == -1 ? 1 : 0) + (vote == -1 ? 1 : 0));
+    _allTimeVotes[stem] = AdjustTotals (_allTimeVotes[stem], previous, vote);
     _voterVotes[stem][name] = vote;
     SaveVotes();
+  }
+
+  // Pure vote-memory arithmetic (issue #162), public so the stance transitions are
+  // directly unit-testable: a fresh vote adds it, a switch moves it, & a repeat
+  // returns the totals untouched.
+  public static (int Up, int Down) AdjustTotals ((int Up, int Down) totals, int previousVote, int newVote)
+  {
+    if (previousVote == newVote) return totals;
+    return (totals.Up - (previousVote == 1 ? 1 : 0) + (newVote == 1 ? 1 : 0), totals.Down - (previousVote == -1 ? 1 : 0) + (newVote == -1 ? 1 : 0));
   }
 
   private void CrossfadeTo (int track, float fromPosition) => CrossfadeToFile (FileFor (track), fromPosition);

--- a/core/audio/MusicManager.cs
+++ b/core/audio/MusicManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using com.forerunnergames.energyshot.core.world;
 using com.forerunnergames.energyshot.utilities;
 using Godot;
 
@@ -17,6 +18,7 @@ public partial class MusicManager : Node
 {
   [Signal] public delegate void TrackChangedEventHandler (string title);
   [Signal] public delegate void VoteCountsChangedEventHandler (int upCount, int downCount);
+  [Signal] public delegate void OwnVoteChangedEventHandler (int vote); // +1 up, -1 down, 0 none (issue #162).
   public const string BusName = "Music";
   // Thumbs-down votes in the current play that trigger a skip; the dedicated
   // server overrides this with --skip-votes N (issue #137).
@@ -24,6 +26,9 @@ public partial class MusicManager : Node
   public string CurrentTrackTitle { get; private set; } = string.Empty;
   public int CurrentUpVotes { get; private set; }
   public int CurrentDownVotes { get; private set; }
+  // The local player's remembered vote for the current track (issue #162), recalled
+  // by the server on each track start & confirmed after every vote.
+  public int CurrentOwnVote { get; private set; }
   private const float MusicVolumeDb = -12.0f;
   private const float SilentDb = -80.0f;
   private const float FadeSeconds = 2.0f;
@@ -43,7 +48,10 @@ public partial class MusicManager : Node
   private readonly RandomNumberGenerator _rng = new();
   private readonly Dictionary <long, int> _playVotes = new(); // Peer id -> +1 (up) / -1 (down) for the current play.
   private Dictionary <string, (int Up, int Down)> _allTimeVotes = new();
-  private (int Up, int Down) _playBaseVotes; // All-time totals when the current play began.
+  // Own-vote memory (issue #162): per-track voter map keyed by DisplayName - the best
+  // identity available without accounts, so rename collisions are an accepted limitation.
+  private Dictionary <string, Dictionary <string, int>> _voterVotes = new();
+  private World _world = null!;
   private Timer _trackTimer = null!;
   private Tween? _fadeTween;
   private int _currentTrack = -1;
@@ -77,6 +85,10 @@ public partial class MusicManager : Node
     _trackTimer.Timeout += OnTrackFinished;
     AddChild (_trackTimer);
     Multiplayer.PeerConnected += OnPeerConnected;
+    _world = GetParent <World>();
+    // A joiner's spawn is when its DisplayName exists server-side, so that's the
+    // moment to recall its remembered vote for the playing track (issue #162).
+    _world.PlayerJoinedGame += OnPlayerJoinedGame;
     StartPlaylistPoller();
   }
 
@@ -159,7 +171,8 @@ public partial class MusicManager : Node
     var next = PickNextTrack();
     _trackTimer.Start (LengthOf (next));
     Rpc (MethodName.OnTrackStarted, next, 0.0f);
-    ResetPlayVotes (next);
+    ResetPlayVotes();
+    RecallRememberedVotes();
   }
 
   private int PickNextTrack()
@@ -176,11 +189,37 @@ public partial class MusicManager : Node
     return candidates[^1];
   }
 
-  private void ResetPlayVotes (int track)
+  private void ResetPlayVotes()
   {
     _playVotes.Clear();
-    _playBaseVotes = _allTimeVotes[TrackStems[track]];
     Rpc (MethodName.OnVoteCounts, 0, 0);
+  }
+
+  // Own-vote memory (issue #162): on each track start the server tells every spawned
+  // player which way it last voted on this track, so the mini player can render that
+  // thumb as already pressed.
+  private void RecallRememberedVotes()
+  {
+    foreach (var player in _world.GetPlayers()) SendOwnVote (player.NetworkId, RememberedVoteFor (player.DisplayName));
+  }
+
+  private int RememberedVoteFor (string displayName) => _voterVotes[TrackStems[_currentTrack]].GetValueOrDefault (displayName, 0);
+  private string DisplayNameFor (long peerId) => _world.GetPlayers().FirstOrDefault (player => player.NetworkId == peerId)?.DisplayName ?? string.Empty;
+
+  // RpcId to our own peer id doesn't loop back locally, so the hosting player's
+  // recall is a direct call (issue #162).
+  private void SendOwnVote (long peerId, int vote)
+  {
+    if (peerId == Multiplayer.GetUniqueId()) OnOwnVote (vote);
+    else RpcId (peerId, MethodName.OnOwnVote, vote);
+  }
+
+  private void OnPlayerJoinedGame (string playerName)
+  {
+    if (!IsActiveServer() || _currentTrack == -1) return;
+    var player = _world.GetPlayers().FirstOrDefault (candidate => candidate.DisplayName == playerName);
+    if (player == null) return;
+    SendOwnVote (player.NetworkId, RememberedVoteFor (playerName));
   }
 
   // Late joiners pick up the current track mid-song & the current play's counts.
@@ -200,7 +239,17 @@ public partial class MusicManager : Node
     _currentTrack = track;
     CurrentTrackTitle = TitleFor (track);
     CrossfadeTo (track, fromPosition);
+    OnOwnVote (0); // Clear the pressed thumb until the server recalls a remembered vote (issue #162).
     EmitSignal (SignalName.TrackChanged, CurrentTrackTitle);
+  }
+
+  // The server's word on which way this player voted on the current track (issue
+  // #162): recalled memory on track start & join, or confirmation of a fresh vote.
+  [Rpc]
+  private void OnOwnVote (int vote)
+  {
+    CurrentOwnVote = vote;
+    EmitSignal (SignalName.OwnVoteChanged, vote);
   }
 
   [Rpc (CallLocal = true)]
@@ -218,21 +267,37 @@ public partial class MusicManager : Node
     ApplyVote (Multiplayer.GetRemoteSenderId(), isUpVote);
   }
 
-  // One vote per player per play; re-voting switches the vote (issue #137). Every
-  // vote lands in the permanent per-track totals that drive the weighting.
+  // One vote per player per play; re-voting switches the vote (issue #137). The
+  // permanent totals track one remembered vote per player per track (issue #162).
   private void ApplyVote (long peerId, bool isUpVote)
   {
     if (_currentTrack == -1) return;
     _playVotes[peerId] = isUpVote ? 1 : -1;
     var upCount = _playVotes.Values.Count (vote => vote == 1);
     var downCount = _playVotes.Values.Count (vote => vote == -1);
-    _allTimeVotes[TrackStems[_currentTrack]] = (_playBaseVotes.Up + upCount, _playBaseVotes.Down + downCount);
-    SaveVotes();
+    UpdateRememberedVote (peerId, isUpVote ? 1 : -1);
     ServerLog.Event (peerId, $"music vote {(isUpVote ? "up" : "down")} for [{CurrentTrackTitle}]: play now {upCount} up / {downCount} down");
     Rpc (MethodName.OnVoteCounts, upCount, downCount);
+    SendOwnVote (peerId, isUpVote ? 1 : -1); // Instant pressed-thumb feedback for the voter (issue #162).
     if (downCount < SkipVotes) return;
     ServerLog.Event ($"music skip: [{CurrentTrackTitle}] reached {downCount} thumbs-down (threshold {SkipVotes})");
     StartNextTrack();
+  }
+
+  // Own-vote memory (issue #162): the all-time totals hold one vote per player per
+  // track - switching stance removes the old vote & adds the new one, & a repeat of
+  // the same vote changes nothing, so nothing ever double-counts.
+  private void UpdateRememberedVote (long peerId, int vote)
+  {
+    var name = DisplayNameFor (peerId);
+    if (name.Length == 0) return; // No spawned player yet: nothing durable to key the memory on.
+    var stem = TrackStems[_currentTrack];
+    var previous = _voterVotes[stem].GetValueOrDefault (name, 0);
+    if (previous == vote) return;
+    var (up, down) = _allTimeVotes[stem];
+    _allTimeVotes[stem] = (up - (previous == 1 ? 1 : 0) + (vote == 1 ? 1 : 0), down - (previous == -1 ? 1 : 0) + (vote == -1 ? 1 : 0));
+    _voterVotes[stem][name] = vote;
+    SaveVotes();
   }
 
   private void CrossfadeTo (int track, float fromPosition) => CrossfadeToFile (FileFor (track), fromPosition);
@@ -291,11 +356,13 @@ public partial class MusicManager : Node
     return threshold;
   }
 
-  // All-time per-track vote totals (issue #137): loaded on start, saved on every
-  // vote, so rankings & weights survive server restarts.
+  // All-time per-track vote totals & per-track voter memory (issues #137/#162):
+  // loaded on start, saved on every vote, so rankings, weights, & each player's
+  // remembered stance survive server restarts.
   private void LoadVotes()
   {
     _allTimeVotes = TrackStems.ToDictionary (name => name, _ => (Up: 0, Down: 0));
+    _voterVotes = TrackStems.ToDictionary (name => name, _ => new Dictionary <string, int>());
     if (!FileAccess.FileExists (VotesFilePath)) return;
     using var file = FileAccess.Open (VotesFilePath, FileAccess.ModeFlags.Read);
     if (file == null) return;
@@ -309,13 +376,29 @@ public partial class MusicManager : Node
     var up = entry.TryGetValue ("up", out var upValue) ? (int)upValue : 0;
     var down = entry.TryGetValue ("down", out var downValue) ? (int)downValue : 0;
     _allTimeVotes[name] = (up, down);
+    LoadTrackVoters (entry, name);
+  }
+
+  // Per-track voter map keyed by DisplayName (issue #162); rename collisions are an
+  // accepted limitation of account-less identity.
+  private void LoadTrackVoters (Godot.Collections.Dictionary entry, string name)
+  {
+    if (!entry.TryGetValue ("voters", out var value) || value.Obj is not Godot.Collections.Dictionary voters) return;
+    foreach (var key in voters.Keys) _voterVotes[name][(string)key] = (int)voters[key];
   }
 
   private void SaveVotes()
   {
     var root = new Godot.Collections.Dictionary();
-    foreach (var (name, votes) in _allTimeVotes) root[name] = new Godot.Collections.Dictionary { { "up", votes.Up }, { "down", votes.Down } };
+    foreach (var (name, votes) in _allTimeVotes) root[name] = new Godot.Collections.Dictionary { { "up", votes.Up }, { "down", votes.Down }, { "voters", VotersFor (name) } };
     using var file = FileAccess.Open (VotesFilePath, FileAccess.ModeFlags.Write);
     file?.StoreString (Json.Stringify (root, "  "));
+  }
+
+  private Godot.Collections.Dictionary VotersFor (string name)
+  {
+    var voters = new Godot.Collections.Dictionary();
+    foreach (var (voter, vote) in _voterVotes[name]) voters[voter] = vote;
+    return voters;
   }
 }

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -78,6 +78,10 @@ public partial class World : Node3D
     // Deaths reach the server through these notifications on every path (issue #111).
     _networkManager.PlayerRespawnedShot += (playerName, shotByPlayerName) => { if (IsActiveServer()) ServerLog.Event (FindPlayerId (playerName), $"death: {playerName} zapped out by {shotByPlayerName}"); };
     _networkManager.PlayerRespawnedFell += playerName => { if (IsActiveServer()) ServerLog.Event (FindPlayerId (playerName), $"death: {playerName} fell off the world"); };
+    // Crown rules (issue #178): every peer sees these death broadcasts, so the
+    // tied-incumbent handover stays consistent everywhere without new networking.
+    _networkManager.PlayerRespawnedShot += (playerName, _) => OnCrownIncumbentDied (playerName);
+    _networkManager.PlayerRespawnedFell += playerName => OnCrownIncumbentDied (playerName);
     _networkManager.RemoteMessageReceived += message => EmitSignal (SignalName.RemoteMessageReceived, message);
     _networkManager.PlayerJoinGame += playerName => EmitSignal (SignalName.PlayerJoinedGame, playerName);
     _networkManager.PlayerLeftGame += playerName => EmitSignal (SignalName.PlayerLeftGame, playerName);
@@ -310,9 +314,11 @@ public partial class World : Node3D
   }
 
   // Golden crown (issue #89): every peer computes the score leader locally from the
-  // replicated Scores each second - no new networking; ties break by the
-  // leaderboard's sort order (highest score, then name). The same tick samples pings
-  // server-side (issue #100).
+  // replicated Scores each second - no new networking; every peer sees the same
+  // replicated scores & death broadcasts, so the incumbent state (issue #178) stays
+  // consistent everywhere. The same tick samples pings server-side (issue #100).
+  private string _crownHolderName = string.Empty;
+
   private void StartCrownTicker()
   {
     var timer = new Timer { WaitTime = 1.0, Autostart = true };
@@ -321,11 +327,36 @@ public partial class World : Node3D
     AddChild (timer);
   }
 
+  // Crown rules (issue #178): no crown anywhere until the leader's score is above
+  // zero, & in ties the incumbent keeps it until strictly surpassed.
   private void UpdateCrownHolder()
   {
     var players = GetPlayers().ToList();
-    var leader = players.OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName).FirstOrDefault();
-    players.ForEach (player => player.SetCrowned (player == leader));
+    var holder = PickCrownHolder (players);
+    _crownHolderName = holder?.DisplayName ?? string.Empty;
+    players.ForEach (player => player.SetCrowned (player == holder));
+  }
+
+  private Player? PickCrownHolder (System.Collections.Generic.List <Player> players)
+  {
+    var top = players.OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName).FirstOrDefault();
+    if (top == null || top.Score <= 0) return null; // Nobody's earned it yet (issue #178).
+    var incumbent = players.FirstOrDefault (player => player.DisplayName == _crownHolderName);
+    if (incumbent != null && incumbent.Score >= top.Score) return incumbent; // Tying alone never steals the crown (issue #178).
+    return top;
+  }
+
+  // Crown rules (issue #178): the incumbent dying while tied at the top hands the
+  // crown to the tied player immediately; dying while strictly ahead changes nothing.
+  private void OnCrownIncumbentDied (string playerName)
+  {
+    if (playerName != _crownHolderName) return;
+    var players = GetPlayers().ToList();
+    var incumbent = players.FirstOrDefault (player => player.DisplayName == playerName);
+    var rival = players.Where (player => player != incumbent).OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName).FirstOrDefault();
+    if (incumbent == null || rival == null || rival.Score < incumbent.Score) return;
+    _crownHolderName = rival.DisplayName;
+    UpdateCrownHolder();
   }
 
   // Per-player ping (issue #100): the server samples each peer's ENet round-trip time

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using com.forerunnergames.energyshot.core.audio;
@@ -101,6 +102,11 @@ public partial class PlaytestDriver : Node
   private async Task RunHost()
   {
     _world.StartHostSession (HostName, difficulty: 2, Port, Password, HostColor);
+    // Vote-memory transitions (#162): record every server-side tally change with
+    // the authoritative all-time totals at that exact moment - votes only flow
+    // through this instance, so hooking before any client joins misses nothing.
+    var voteHistory = new List <(int Up, int Down, (int Up, int Down) AllTime)>();
+    Music.VoteCountsChanged += (up, down) => voteHistory.Add ((up, down, Music.CurrentTrackAllTimeVotes));
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players joined");
     // Chosen body colors (issue #43): own pick stuck & both clients' picks replicate to the host.
     Assert (Self.ColorIndex == HostColor, $"own chosen color is {HostColor}, got {Self.ColorIndex}");
@@ -113,7 +119,16 @@ public partial class PlaytestDriver : Node
     // Synced music (issue #137): the server picked a track & the shooter's thumbs-up
     // vote came back through the server tally.
     await WaitUntil (() => Music.CurrentTrackTitle.Length > 0, 15, "music track started on the server");
-    await WaitUntil (() => Music.CurrentUpVotes == 1, 30, "shooter's music vote tallied on host");
+    await WaitUntil (() => voteHistory.Any (entry => entry.Up == 1 && entry.Down == 0), 30, "shooter's up-vote tallied on host");
+    // The shooter re-votes up (a no-op) & then switches to down (#162): the same
+    // peer's reliable RPCs arrive in order, so once the switch lands both up
+    // entries are recorded - they must share identical totals (no double-count),
+    // & the switch must have moved exactly one all-time vote across.
+    await WaitUntil (() => voteHistory.Any (entry => entry.Up == 0 && entry.Down == 1), 60, "shooter's up-to-down switch tallied on host (#162)");
+    var upEntries = voteHistory.Where (entry => entry.Up == 1 && entry.Down == 0).ToList();
+    var downEntry = voteHistory.First (entry => entry.Up == 0 && entry.Down == 1);
+    Assert (upEntries.Count >= 2 && upEntries.All (entry => entry.AllTime == upEntries[0].AllTime), "repeated up-vote never double-counted the all-time totals (#162)");
+    Assert (downEntry.AllTime == (upEntries[0].AllTime.Up - 1, upEntries[0].AllTime.Down + 1), $"up-to-down switch moved one all-time vote (#162), got {upEntries[0].AllTime} -> {downEntry.AllTime}");
     // Shooter kills victim once (plus possibly the host itself in the line of
     // fire); wait to observe the replicated score.
     await WaitUntil (() => FindPlayer (ShooterName)?.Score >= 1, 120, "shooter's kill replicated to host");
@@ -158,7 +173,15 @@ public partial class PlaytestDriver : Node
     Music.SubmitVote (isUpVote: true);
     // Own-vote memory (issue #162): the server confirms the vote back to the voter,
     // which is what drives the mini player's pressed-thumb highlight.
-    await WaitUntil (() => Music.CurrentOwnVote == 1, 15, "own vote confirmed back by the server (#162)");
+    await WaitUntil (() => Music.CurrentOwnVote == 1 && Music.CurrentUpVotes == 1, 15, "own up-vote confirmed back by the server (#162)");
+    // Vote-memory transitions (#162): a repeated identical vote must change nothing
+    // (the host asserts the authoritative totals stayed put), then an up-to-down
+    // switch must press the other thumb & move the play tally by exactly one.
+    Music.SubmitVote (isUpVote: true);
+    await Task.Delay (1000);
+    Assert (Music.CurrentOwnVote == 1 && Music.CurrentUpVotes == 1 && Music.CurrentDownVotes == 0, "repeated up-vote was a no-op (#162)");
+    Music.SubmitVote (isUpVote: false);
+    await WaitUntil (() => Music.CurrentOwnVote == -1 && Music.CurrentUpVotes == 0 && Music.CurrentDownVotes == 1, 15, "up-to-down switch confirmed & re-tallied (#162)");
 
     // Movement: hold forward briefly & verify we actually moved.
     var startPosition = Self.GlobalPosition;
@@ -421,7 +444,10 @@ public partial class PlaytestDriver : Node
     // Synced music (issue #137): same track as everyone & the shooter's vote
     // propagated here through the server broadcast.
     await WaitUntil (() => Music.CurrentTrackTitle.Length > 0, 15, "current music track synced from server");
-    await WaitUntil (() => Music.CurrentUpVotes == 1, 30, "shooter's music vote visible to victim");
+    // The shooter's settled stance after its #162 transitions (up, repeat, down):
+    // waiting on the final state instead of the transient up-vote avoids racing
+    // the quick up-to-down switch.
+    await WaitUntil (() => Music.CurrentUpVotes == 0 && Music.CurrentDownVotes == 1, 60, "shooter's settled music vote (down after switch) visible to victim (#162)");
     await WaitUntil (() => !Self.SpawnArmor, 15, "spawn armor expired on its own");
     // Streak replication (#88): simulate an active 3-streak on our own authority so
     // the shooter can verify it replicates - & that the death reset replicates too.

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -105,8 +105,9 @@ public partial class PlaytestDriver : Node
     // Chosen body colors (issue #43): own pick stuck & both clients' picks replicate to the host.
     Assert (Self.ColorIndex == HostColor, $"own chosen color is {HostColor}, got {Self.ColorIndex}");
     await WaitUntil (() => FindPlayer (ShooterName)?.ColorIndex == ShooterColor && FindPlayer (VictimName)?.ColorIndex == VictimColor, 15, "clients' chosen colors replicated to host (#43)");
-    // Exactly one player wears the crown even at 0-0 (issue #107).
-    await WaitUntil (() => _world.GetPlayers().Count (player => player.IsCrowned) == 1, 10, "exactly one player crowned at 0-0");
+    // Crown rules (issue #178): nobody wears the crown at 0-0 - it must be earned.
+    await Task.Delay (3000); // Let a few 1s crown ticks pass before judging.
+    Assert (_world.GetPlayers().All (player => !player.IsCrowned), "no crown at 0-0 (#178)");
     // Server-measured pings replicate back to every peer (issue #100).
     await WaitUntil (() => FindPlayer (ShooterName)?.PingMs >= 0, 15, "shooter's ping measured & replicated to host");
     // Synced music (issue #137): the server picked a track & the shooter's thumbs-up
@@ -116,10 +117,17 @@ public partial class PlaytestDriver : Node
     // Shooter kills victim once (plus possibly the host itself in the line of
     // fire); wait to observe the replicated score.
     await WaitUntil (() => FindPlayer (ShooterName)?.Score >= 1, 120, "shooter's kill replicated to host");
+    // Crown rules (issue #178): the first score puts the crown on the scorer - & on
+    // nobody else. (A tie handover isn't cheaply reachable in this scenario's score
+    // flow, so the incumbent rules beyond these are covered by the logic itself.)
+    await WaitUntil (() => FindPlayer (ShooterName)?.IsCrowned == true, 10, "crown appeared on the first scorer (#178)");
+    await WaitUntil (() => _world.GetPlayers().Count (player => player.IsCrowned) == 1, 10, "exactly one crown after the first score (#178)");
     // Victim respawns with armor visible to the host too.
     await WaitUntil (() => FindPlayer (VictimName)?.SpawnArmor == true, 30, "victim respawn armor replicated to host");
     // The victim's fall at score 0 goes negative & replicates (issue #108).
     await WaitUntil (() => FindPlayer (VictimName)?.Score == -1, 60, "victim's fall penalty (-1) replicated to host");
+    // Crown rules (issue #178): a lower score moving (the fall) never moves the crown.
+    Assert (FindPlayer (ShooterName)?.IsCrowned == true, "crown stayed on the leader after the fall penalty (#178)");
     // Stay up until both clients have finished & disconnected.
     await WaitUntil (() => _world.GetPlayers().Count() == 1, 120, "clients disconnected");
   }
@@ -148,6 +156,9 @@ public partial class PlaytestDriver : Node
     // thumbs-up vote here must show up on every other peer's tally.
     await WaitUntil (() => Music.CurrentTrackTitle.Length > 0, 15, "current music track synced from server");
     Music.SubmitVote (isUpVote: true);
+    // Own-vote memory (issue #162): the server confirms the vote back to the voter,
+    // which is what drives the mini player's pressed-thumb highlight.
+    await WaitUntil (() => Music.CurrentOwnVote == 1, 15, "own vote confirmed back by the server (#162)");
 
     // Movement: hold forward briefly & verify we actually moved.
     var startPosition = Self.GlobalPosition;

--- a/tests/unit/MusicVoteMemoryTest.cs
+++ b/tests/unit/MusicVoteMemoryTest.cs
@@ -1,0 +1,30 @@
+using com.forerunnergames.energyshot.core.audio;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Own-vote memory transitions (issue #162): the all-time totals hold one vote per
+// player per track - a fresh vote adds it, switching stance moves it, & a repeat
+// of the same vote changes nothing, so nothing ever double-counts.
+[TestSuite]
+public class MusicVoteMemoryTest
+{
+  [TestCase]
+  public void FirstUpVoteAddsOneUp() => AssertBool (MusicManager.AdjustTotals ((0, 0), previousVote: 0, newVote: 1) == (1, 0)).IsTrue();
+
+  [TestCase]
+  public void FirstDownVoteAddsOneDown() => AssertBool (MusicManager.AdjustTotals ((0, 0), previousVote: 0, newVote: -1) == (0, 1)).IsTrue();
+
+  [TestCase]
+  public void UpToDownSwitchMovesTheVote() => AssertBool (MusicManager.AdjustTotals ((3, 2), previousVote: 1, newVote: -1) == (2, 3)).IsTrue();
+
+  [TestCase]
+  public void DownToUpSwitchMovesTheVote() => AssertBool (MusicManager.AdjustTotals ((3, 2), previousVote: -1, newVote: 1) == (4, 1)).IsTrue();
+
+  [TestCase]
+  public void RepeatedUpVoteChangesNothing() => AssertBool (MusicManager.AdjustTotals ((3, 2), previousVote: 1, newVote: 1) == (3, 2)).IsTrue();
+
+  [TestCase]
+  public void RepeatedDownVoteChangesNothing() => AssertBool (MusicManager.AdjustTotals ((3, 2), previousVote: -1, newVote: -1) == (3, 2)).IsTrue();
+}

--- a/tests/unit/MusicVoteMemoryTest.cs.uid
+++ b/tests/unit/MusicVoteMemoryTest.cs.uid
@@ -1,0 +1,1 @@
+uid://devjsllt2na67

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -60,7 +60,8 @@ public partial class Hud : Control
   }
 
   // 3+ streak entries glow & pulse so the hot player stands out (see issue #77); the
-  // current leader wears the crown (issue #107) & every entry shows its ping (issue #100).
+  // crown holder wears the crown here too - only above zero points, & ties don't
+  // steal it (issues #107/#178) - & every entry shows its ping (issue #100).
   // Entries are ranked by sorted position, ties keep list order (issue #126).
   // Names are tinted with each player's chosen body color (issue #43).
   private static string LeaderboardEntry (players.Player player, int rank)
@@ -68,7 +69,7 @@ public partial class Hud : Control
     var name = $"[color=#{players.PlayerColors.TextHex (player.ColorIndex)}]{player.DisplayName}[/color]";
     var entry = $"{rank}. {name}  {player.Score}  ({Mathf.Max (0, player.PingMs)}ms)";
     if (player.IsOnStreak) entry = $"[pulse freq=1.5 color=#ffd24d ease=-2.0][wave amp=18.0 freq=4.0][b]{entry}[/b][/wave][/pulse]";
-    return rank == 1 ? $"\U0001F451 {entry}" : entry;
+    return player.IsCrowned ? $"\U0001F451 {entry}" : entry;
   }
 
   // Score can also drop (fall penalty), so the label reads the replicated value.

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -62,7 +62,8 @@ public partial class Hud : Control
   // 3+ streak entries glow & pulse so the hot player stands out (see issue #77); the
   // crown holder wears the crown here too - only above zero points, & ties don't
   // steal it (issues #107/#178) - & every entry shows its ping (issue #100).
-  // Entries are ranked by sorted position, ties keep list order (issue #126).
+  // Entries are ranked by sorted position; equal scores order by ascending display
+  // name (issue #126), matching World.PickCrownHolder's tie ordering (issue #178).
   // Names are tinted with each player's chosen body color (issue #43).
   private static string LeaderboardEntry (players.Player player, int rank)
   {

--- a/ui/hud/MusicPlayer.cs
+++ b/ui/hud/MusicPlayer.cs
@@ -1,29 +1,40 @@
 using com.forerunnergames.energyshot.core.audio;
+using com.forerunnergames.energyshot.ui.hud.messages;
 using com.forerunnergames.energyshot.utilities;
 using Godot;
 
 namespace com.forerunnergames.energyshot.ui.hud;
 
 // Mini music player (issue #137): a mostly transparent bottom-right HUD panel
-// showing the current song, this play's thumbs up/down counts (with the "." &
-// "," key hints) & a small spectrum visualizer. Never captures the mouse; a
-// "Show music player" toggle in the pause dialog hides it without stopping music.
+// showing the current song, this play's thumbs up/down counts (with bigger,
+// brighter "." & "," key hints, issue #155) & a small spectrum visualizer. Your
+// own remembered vote renders as a pressed thumb (issue #162). Never captures the
+// mouse; a "Show music player" toggle in the pause dialog hides it without
+// stopping music.
 public partial class MusicPlayer : Control
 {
   private MusicManager _music = null!;
   private Control _panel = null!;
   private Label _title = null!;
-  private Label _votes = null!;
-  private void OnVoteCountsChanged (int upCount, int downCount) => _votes.Text = $". ▲ {upCount}      , ▼ {downCount}";
+  private Label _upVote = null!;
+  private Label _downVote = null!;
+  private StyleBoxFlat _pressedStyle = null!;
+  private StyleBoxFlat _restStyle = null!;
+  private bool _hintShown;
 
   public override void _Ready()
   {
     _music = GetNode <MusicManager> ("/root/World/MusicManager");
     _panel = GetNode <Control> ("Panel");
     _title = GetNode <Label> ("Panel/MarginContainer/VBoxContainer/Title");
-    _votes = GetNode <Label> ("Panel/MarginContainer/VBoxContainer/Votes");
+    _upVote = GetNode <Label> ("Panel/MarginContainer/VBoxContainer/Votes/UpVote");
+    _downVote = GetNode <Label> ("Panel/MarginContainer/VBoxContainer/Votes/DownVote");
+    _pressedStyle = ChipStyle (new Color (1.0f, 0.84f, 0.3f, 0.3f));
+    _restStyle = ChipStyle (Colors.Transparent);
+    OnOwnVoteChanged (0); // Both chips start unpressed with identical margins, so toggling never shifts layout.
     _music.TrackChanged += OnTrackChanged;
     _music.VoteCountsChanged += OnVoteCountsChanged;
+    _music.OwnVoteChanged += OnOwnVoteChanged;
     AddShowToggleToPauseDialog();
     OnVoteCountsChanged (0, 0);
     _panel.Visible = false; // Nothing to show until the first track starts.
@@ -36,10 +47,49 @@ public partial class MusicPlayer : Control
     if (Input.IsActionJustPressed ("music_vote_down")) _music.SubmitVote (isUpVote: false);
   }
 
+  private void OnVoteCountsChanged (int upCount, int downCount)
+  {
+    _upVote.Text = $". ▲ {upCount}";
+    _downVote.Text = $", ▼ {downCount}";
+  }
+
+  // Own-vote memory (issue #162): the thumb you've cast - now or in any earlier
+  // play the server remembers - renders as a clearly pressed amber chip.
+  private void OnOwnVoteChanged (int vote)
+  {
+    ApplyPressedStyle (_upVote, vote == 1);
+    ApplyPressedStyle (_downVote, vote == -1);
+  }
+
+  private void ApplyPressedStyle (Label label, bool isPressed)
+  {
+    label.AddThemeStyleboxOverride ("normal", isPressed ? _pressedStyle : _restStyle);
+    if (isPressed) label.AddThemeColorOverride ("font_color", new Color (1.0f, 0.92f, 0.55f));
+    else label.RemoveThemeColorOverride ("font_color");
+  }
+
+  private static StyleBoxFlat ChipStyle (Color background)
+  {
+    var style = new StyleBoxFlat { BgColor = background };
+    style.SetCornerRadiusAll (10);
+    style.SetContentMarginAll (8.0f);
+    return style;
+  }
+
   private void OnTrackChanged (string title)
   {
     _title.Text = title;
     _panel.Visible = Settings.ShowMusicPlayer;
+    ShowVoteHintOnce();
+  }
+
+  // Vote-key discoverability (issue #155): a one-time hint when the session's first
+  // track starts, since the keys were invisible to new players.
+  private void ShowVoteHintOnce()
+  {
+    if (_hintShown) return;
+    _hintShown = true;
+    GetNodeOrNull <MessageScroller> ("../MessageScroller")?.AddMessage ("Vote on the music: . up / , down", MessageScroller.MessageImportance.High);
   }
 
   // The pause (quit) dialog is the only in-game UI with a visible mouse, so the

--- a/ui/hud/MusicPlayer.tscn
+++ b/ui/hud/MusicPlayer.tscn
@@ -56,10 +56,23 @@ theme_override_font_sizes/font_size = 40
 text = ""
 horizontal_alignment = 1
 
-[node name="Votes" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+[node name="Votes" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 0.8)
-theme_override_font_sizes/font_size = 32
+mouse_filter = 2
+alignment = 1
+theme_override_constants/separation = 40
+
+[node name="UpVote" type="Label" parent="Panel/MarginContainer/VBoxContainer/Votes"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.95)
+theme_override_font_sizes/font_size = 36
+text = ""
+horizontal_alignment = 1
+
+[node name="DownVote" type="Label" parent="Panel/MarginContainer/VBoxContainer/Votes"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.95)
+theme_override_font_sizes/font_size = 36
 text = ""
 horizontal_alignment = 1
 

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -15,8 +15,10 @@ public static class Settings
     set => Set ("name", value);
   }
 
-  // First-time players get the official dedicated server pre-filled.
-  public const string OfficialServerAddress = "137.184.43.105";
+  // First-time players get the official dedicated server pre-filled. A hostname
+  // instead of a raw IP (issue #138): ENet resolves it, & the client survives any
+  // future server IP change.
+  public const string OfficialServerAddress = "es1.forerunner.games";
 
   public static string LastJoinAddress
   {


### PR DESCRIPTION
## Summary

Batch covering music voting UX, crown rules, & the default join address.

### Own-vote memory (#162)
- The server's `music-votes.json` gains a per-track `voters` map keyed by DisplayName (best identity without accounts; rename collisions are an accepted, code-commented limitation).
- On each track start (& when a player joins mid-track) the server RPCs each peer its remembered vote; the mini player renders that thumb as a clearly pressed amber chip.
- Re-voting switches stance: the all-time totals remove the old vote & add the new one, & a repeat of the same vote changes nothing - no double-counting.
- The current-play skip tally is unchanged.

### Vote-key discoverability (#155)
- Bigger, brighter `.` & `,` key hints on the mini player (split into per-thumb labels, larger & near-full-bright).
- One-time hint message when the session's first track starts: "Vote on the music: . up / , down".
- Vote keys added to the README controls table. (There is no `docs/CONTROLS.md` in the repo; the README table is the controls doc.)

### Crown rules (#178)
- No crown anywhere - head or leaderboard - unless the leader's score is above zero.
- In ties the incumbent keeps the crown until strictly surpassed; tying alone never transfers it.
- Per the spec refinement on the issue: the incumbent dying while tied at the top hands the crown to the tied player immediately (wired into the existing death broadcasts, so every peer transfers identically with no new networking).
- The leaderboard crown now follows the crown holder instead of blindly decorating rank 1.

### Default join address (#138)
- `utilities/Settings.cs` `OfficialServerAddress` is now `es1.forerunner.games` instead of the raw IP; ENet resolves hostnames, so the client survives future IP changes. The join dialog placeholder was already generic (no raw IP shown anywhere else).

## Validation

- `dotnet build`: 0 errors, 0 warnings.
- Full headless multiplayer playtest (host + shooter + victim): PASS, including the new assertions - no crown at 0-0, crown appears on the first score, exactly one crown, crown survives the victim's fall penalty, & the shooter's own vote confirmed back by the server (#162). A tie handover isn't cheaply reachable in the playtest's score flow, so that path is covered by the shared deterministic logic.

Fixes #138
Fixes #155
Fixes #162
Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Music votes are now remembered per player and track.
  * Vote totals update accurately when changing between upvotes and downvotes.
  * The music player shows separate upvote/downvote counts and highlights your selected vote.
  * Added a one-time message explaining the vote key.
  * Crown ownership now updates correctly after player deaths, ties, and zero-score rounds.
* **Improvements**
  * Server connection settings now use the official hostname for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->