### PR TITLE
Bread feedback, giant readable history, brutal splatter, & contextual cooldown meters

### DIFF
--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -294,11 +294,24 @@ public partial class Player
     Call ("DropHeldWeapon");
   }
 
-  // One-per-life full heal (issue #62): restocked on every (re)spawn.
+  // One-per-life full heal (issue #62): restocked on every (re)spawn. A press that
+  // can't eat is never silent anymore (issue #160): it emits a soft denied cue.
   private void UpdateBread()
   {
     if (!_isInputEnabled || !Input.IsActionJustPressed ("eat_bread")) return;
-    if (Health >= MaxHealth) return; // Don't waste the bread at full health.
+
+    if (!_bread.IsAvailable)
+    {
+      EmitSignal (SignalName.BreadDenied, true); // No bread left this life (issue #160).
+      return;
+    }
+
+    if (Health >= MaxHealth)
+    {
+      EmitSignal (SignalName.BreadDenied, false); // Don't waste the bread at full health.
+      return;
+    }
+
     if (!_bread.TryEat()) return;
     Health = MaxHealth;
     GD.Print ($"{DisplayName}: I ate my bread & feel brand new!");

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -41,6 +41,9 @@ public partial class Player : CharacterBody3D
 
   [Signal] public delegate void HealthChangedEventHandler (int value);
   [Signal] public delegate void BreadEatenEventHandler (string playerName);
+  // Soft feedback for a bread press that can't eat (issue #160): isOut = the loaf is
+  // gone this life; otherwise the player is already at full health.
+  [Signal] public delegate void BreadDeniedEventHandler (bool isOut);
   [Signal] public delegate void PunchedEventHandler();
   [Signal] public delegate void ScoredEventHandler (string playerName, string shotPlayerName);
   [Signal] public delegate void RespawnedShotEventHandler (string playerName, string shotByPlayerName);
@@ -232,6 +235,8 @@ public partial class Player : CharacterBody3D
   [Export] public float HealthTagNameTagMaxSpacing = 3.0f;
   [Export] public float NameTagBaseHeight = 2.3f;
   public int NetworkId => Name.ToString().ToInt();
+  // Whether the one-per-life loaf is still uneaten, for the HUD bread icon (issue #160).
+  public bool HasBread => _bread.IsAvailable;
   public float LastZapEnergy { get; private set; }
   // Whether the last zap this player took came through a pierced barrier (issue #94).
   public bool LastZapThroughBarrier { get; private set; }

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -17,6 +17,9 @@ public partial class World : Node3D
   [Signal] public delegate void SelfPlayerHealthChangedEventHandler (string playerName, int health);
   [Signal] public delegate void SelfPlayerPunchedEventHandler();
   [Signal] public delegate void SelfPlayerSplatteredEventHandler();
+  // Bread feedback (issue #160): eaten + soft denied cues, forwarded to the HUD.
+  [Signal] public delegate void SelfPlayerAteBreadEventHandler();
+  [Signal] public delegate void SelfPlayerBreadDeniedEventHandler (bool isOut);
   [Signal] public delegate void RemoteMessageReceivedEventHandler (string message);
   [Signal] public delegate void KickedFromServerEventHandler (string reason);
   [Signal] public delegate void ServerShutDownEventHandler();
@@ -296,6 +299,8 @@ public partial class World : Node3D
     selfPlayer.HealthChanged += value => EmitSignal (SignalName.SelfPlayerHealthChanged, selfPlayer.DisplayName, value);
     selfPlayer.Punched += () => EmitSignal (SignalName.SelfPlayerPunched);
     selfPlayer.Splattered += () => EmitSignal (SignalName.SelfPlayerSplattered);
+    selfPlayer.BreadEaten += _ => EmitSignal (SignalName.SelfPlayerAteBread); // Bread feedback (issue #160).
+    selfPlayer.BreadDenied += isOut => EmitSignal (SignalName.SelfPlayerBreadDenied, isOut);
     selfPlayer.Scored += (playerName, shotPlayerName) => EmitSignal (SignalName.PlayerScored, ++_score, playerName, shotPlayerName);
     GD.Print ($"{_selfPlayer.NetworkId}: Registered my player {_selfPlayer.DisplayName}");
     EmitSignal (SignalName.NewGameStarted, _selfPlayer.DisplayName, _selfPlayer.MaxHealth);

--- a/ui/hud/CooldownMeter.cs
+++ b/ui/hud/CooldownMeter.cs
@@ -1,0 +1,43 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.ui.hud;
+
+// A tiny center-screen cooldown indicator (issue #177): visible only while its
+// cooldown is actually recovering, fading in & out fast, with a brief green flash
+// the moment it comes back ready. Replaces the old permanent bar row.
+public partial class CooldownMeter : HBoxContainer
+{
+  private const float FadeInPerSecond = 10.0f;
+  private const float FadeOutPerSecond = 5.0f;
+  private const float ReadyFlashSeconds = 0.35f;
+  private static readonly Color ReadyFlashColor = new(0.55f, 1.0f, 0.55f);
+  private ProgressBar _bar = null!;
+  private float _alpha;
+  private float _flashSecondsLeft;
+  private bool _isRecovering;
+
+  public override void _Ready()
+  {
+    _bar = GetNode <ProgressBar> ("Bar");
+    Modulate = Colors.White with { A = 0.0f };
+  }
+
+  // 0..1 readiness (1 = ready); the Hud feeds this every frame.
+  public void SetFraction (float fraction)
+  {
+    _bar.Value = fraction;
+    var recovering = fraction < 1.0f;
+    if (_isRecovering && !recovering) _flashSecondsLeft = ReadyFlashSeconds; // Brief ready-flash (issue #177).
+    _isRecovering = recovering;
+  }
+
+  public override void _Process (double delta)
+  {
+    var dt = (float)delta;
+    _flashSecondsLeft = Mathf.Max (0.0f, _flashSecondsLeft - dt);
+    var isRelevant = _isRecovering || _flashSecondsLeft > 0.0f;
+    _alpha = Mathf.Clamp (_alpha + (isRelevant ? FadeInPerSecond : -FadeOutPerSecond) * dt, 0.0f, 1.0f);
+    var color = _flashSecondsLeft > 0.0f ? ReadyFlashColor : Colors.White;
+    Modulate = color with { A = _alpha };
+  }
+}

--- a/ui/hud/CooldownMeter.cs.uid
+++ b/ui/hud/CooldownMeter.cs.uid
@@ -1,0 +1,1 @@
+uid://ceiotrrmlrl1t

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -24,10 +24,13 @@ public partial class Hud : Control
   private ShaderMaterial _vignette = null!;
   private ShaderMaterial _blur = null!;
   private ShaderMaterial _splatter = null!;
-  private ProgressBar _shotBar = null!;
-  private ProgressBar _slideBar = null!;
-  private ProgressBar _fullAutoBar = null!;
-  private ProgressBar _bananaBar = null!;
+  private CooldownMeter _shotMeter = null!;
+  private CooldownMeter _slideMeter = null!;
+  private CooldownMeter _fullAutoMeter = null!;
+  private CooldownMeter _bananaMeter = null!;
+  private TextureRect _breadIcon = null!;
+  private AudioStreamPlayer _munchSound = null!;
+  private AudioStreamPlayer _breadDeniedSound = null!;
   private float _blurIntensity;
   private float _splatterSecondsLeft;
   private float _splatterSlide;
@@ -89,12 +92,16 @@ public partial class Hud : Control
     _vignette = (ShaderMaterial)GetNode <ColorRect> ("Vignette").Material;
     _blur = (ShaderMaterial)GetNode <ColorRect> ("Blur").Material;
     _splatter = (ShaderMaterial)GetNode <ColorRect> ("Splatter").Material;
-    _shotBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Shot/Bar");
-    _slideBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Slide/Bar");
-    _fullAutoBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/FullAuto/Bar");
-    _bananaBar = GetNode <ProgressBar> ("VBoxContainer/Cooldowns/Banana/Bar");
+    _shotMeter = GetNode <CooldownMeter> ("CooldownMeters/Shot");
+    _slideMeter = GetNode <CooldownMeter> ("CooldownMeters/Slide");
+    _fullAutoMeter = GetNode <CooldownMeter> ("CooldownMeters/FullAuto");
+    _bananaMeter = GetNode <CooldownMeter> ("CooldownMeters/Banana");
+    _breadIcon = GetNode <TextureRect> ("VBoxContainer/Bread/Icon");
+    CreateBreadSounds();
     _world.SelfPlayerPunched += OnSelfPlayerPunched;
     _world.SelfPlayerSplattered += OnSelfPlayerSplattered;
+    _world.SelfPlayerAteBread += OnSelfPlayerAteBread;
+    _world.SelfPlayerBreadDenied += OnSelfPlayerBreadDenied;
     GetNode <Timer> ("LeaderboardTimer").Timeout += UpdateLeaderboard;
     _quitDialog = GetNode <ConfirmationDialog2> ("QuitDialog");
     _quitDialog.Confirmed += () => EmitSignal (SignalName.GameQuit);
@@ -122,7 +129,17 @@ public partial class Hud : Control
   {
     UpdateBlur (delta);
     UpdateSplatter (delta);
-    UpdateCooldownBars();
+    UpdateCooldownMeters();
+    UpdateBreadIcon();
+  }
+
+  // Bread munch & soft denied cues are code-generated (issue #160): no downloaded assets.
+  private void CreateBreadSounds()
+  {
+    _munchSound = new AudioStreamPlayer { Stream = ProceduralSounds.Munch() };
+    _breadDeniedSound = new AudioStreamPlayer { Stream = ProceduralSounds.Denied() };
+    AddChild (_munchSound);
+    AddChild (_breadDeniedSound);
   }
 
   // Punch blur stacks per hit & fades back to sharp; a heavy stack fades slower, so
@@ -145,14 +162,38 @@ public partial class Hud : Control
     _splatter.SetShaderParameter ("intensity", _splatterSecondsLeft / SplatterSeconds);
   }
 
-  private void UpdateCooldownBars()
+  // Tiny center-screen meters near the crosshair (issue #177), each visible only
+  // while its cooldown is recovering; the fade & ready-flash live in CooldownMeter.
+  private void UpdateCooldownMeters()
   {
     var self = _world.SelfPlayer;
     if (self == null || !Visible) return;
-    _shotBar.Value = self.ShotReadyFraction;
-    _slideBar.Value = self.SlideReadyFraction; // The slide bar replaced the punch bar (issue #127).
-    _fullAutoBar.Value = self.FullAutoReadyFraction;
-    _bananaBar.Value = self.BananaReadyFraction;
+    _shotMeter.SetFraction (self.ShotReadyFraction);
+    _slideMeter.SetFraction (self.SlideReadyFraction); // The slide meter replaced the punch bar (issue #127).
+    _fullAutoMeter.SetFraction (self.FullAutoReadyFraction);
+    _bananaMeter.SetFraction (self.BananaReadyFraction);
+  }
+
+  // The bread icon dims once the loaf is eaten & brightens when a respawn restocks
+  // it (issue #160); polling covers the restock, which has no signal.
+  private void UpdateBreadIcon()
+  {
+    var self = _world.SelfPlayer;
+    if (self == null || !Visible) return;
+    _breadIcon.Modulate = self.HasBread ? Colors.White : new Color (0.4f, 0.4f, 0.4f, 0.35f);
+  }
+
+  private void OnSelfPlayerAteBread()
+  {
+    _munchSound.Play();
+    PrintMessage ("You scarf your bread & feel brand new!", MessageScroller.MessageImportance.High);
+  }
+
+  // Soft denied cues (issue #160): a pressed B that can't eat is never silent.
+  private void OnSelfPlayerBreadDenied (bool isOut)
+  {
+    _breadDeniedSound.Play();
+    PrintMessage (isOut ? "No bread left this life" : "Already at full health");
   }
 
   // ~3 hits reach max blur (issue #68): the shader's top LOD is a near-whiteout.
@@ -168,6 +209,7 @@ public partial class Hud : Control
     _splatterSlide = 0.0f;
     _splatter.SetShaderParameter ("slide", 0.0f);
     _splatter.SetShaderParameter ("intensity", 1.0f);
+    _splatter.SetShaderParameter ("seed", GD.Randf() * 100.0f); // Fresh splat layout per hit (issue #165).
   }
 
   private void OnNewGameStarted (string selfPlayerName, int selfMaxHealth)

--- a/ui/hud/Hud.tscn
+++ b/ui/hud/Hud.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=15 format=3 uid="uid://cobme7o27cxru"]
+[gd_scene load_steps=16 format=3 uid="uid://cobme7o27cxru"]
 
 [ext_resource type="Script" path="res://ui/hud/Hud.cs" id="1_5s36p"]
+[ext_resource type="Script" path="res://ui/hud/CooldownMeter.cs" id="1_cldmtr"]
+[ext_resource type="Texture2D" uid="uid://bgn55fmmm2khe" path="res://assets/items/Bread.png" id="2_bread"]
 [ext_resource type="PackedScene" uid="uid://huun2vjv0k1v" path="res://ui/hud/messages/MessageScroller.tscn" id="1_6ovnf"]
 [ext_resource type="PackedScene" uid="uid://bmpjrf8pqokyu" path="res://ui/dialogs/confirm/ConfirmationDialog2.tscn" id="3_v7kl8"]
 [ext_resource type="Shader" path="res://ui/hud/vignette.gdshader" id="4_vgntt"]
@@ -20,6 +22,7 @@ shader_parameter/intensity = 0.0
 shader = ExtResource("6_spltr")
 shader_parameter/intensity = 0.0
 shader_parameter/slide = 0.0
+shader_parameter/seed = 0.0
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ldrbd"]
 bg_color = Color(0, 0, 0, 0.392157)
@@ -117,85 +120,19 @@ max_value = 200.0
 value = 200.0
 show_percentage = false
 
-[node name="Cooldowns" type="VBoxContainer" parent="VBoxContainer"]
+[node name="Bread" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
-theme_override_constants/separation = 4
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 5
 
-[node name="Shot" type="HBoxContainer" parent="VBoxContainer/Cooldowns"]
+[node name="Icon" type="TextureRect" parent="VBoxContainer/Bread"]
+custom_minimum_size = Vector2(56, 56)
 layout_mode = 2
-
-[node name="Label" type="Label" parent="VBoxContainer/Cooldowns/Shot"]
-custom_minimum_size = Vector2(220, 0)
-layout_mode = 2
-theme_override_font_sizes/font_size = 28
-text = "Shot"
-
-[node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/Shot"]
-custom_minimum_size = Vector2(0, 22)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 4
-max_value = 1.0
-step = 0.01
-value = 1.0
-show_percentage = false
-
-[node name="Slide" type="HBoxContainer" parent="VBoxContainer/Cooldowns"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="VBoxContainer/Cooldowns/Slide"]
-custom_minimum_size = Vector2(220, 0)
-layout_mode = 2
-theme_override_font_sizes/font_size = 28
-text = "Slide"
-
-[node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/Slide"]
-custom_minimum_size = Vector2(0, 22)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 4
-max_value = 1.0
-step = 0.01
-value = 1.0
-show_percentage = false
-
-[node name="FullAuto" type="HBoxContainer" parent="VBoxContainer/Cooldowns"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="VBoxContainer/Cooldowns/FullAuto"]
-custom_minimum_size = Vector2(220, 0)
-layout_mode = 2
-theme_override_font_sizes/font_size = 28
-text = "Full-Auto"
-
-[node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/FullAuto"]
-custom_minimum_size = Vector2(0, 22)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 4
-max_value = 1.0
-step = 0.01
-value = 1.0
-show_percentage = false
-
-[node name="Banana" type="HBoxContainer" parent="VBoxContainer/Cooldowns"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="VBoxContainer/Cooldowns/Banana"]
-custom_minimum_size = Vector2(220, 0)
-layout_mode = 2
-theme_override_font_sizes/font_size = 28
-text = "Banana"
-
-[node name="Bar" type="ProgressBar" parent="VBoxContainer/Cooldowns/Banana"]
-custom_minimum_size = Vector2(0, 22)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 4
-max_value = 1.0
-step = 0.01
-value = 1.0
-show_percentage = false
+size_flags_horizontal = 0
+mouse_filter = 2
+texture = ExtResource("2_bread")
+expand_mode = 1
+stretch_mode = 5
 
 [node name="Score" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -206,6 +143,126 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 60
 text = "Score: 0"
 vertical_alignment = 1
+
+[node name="CooldownMeters" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -78.0
+offset_top = 34.0
+offset_right = 78.0
+offset_bottom = 110.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 3
+mouse_filter = 2
+
+[node name="Shot" type="HBoxContainer" parent="CooldownMeters"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+theme_override_constants/separation = 8
+mouse_filter = 2
+script = ExtResource("1_cldmtr")
+
+[node name="Label" type="Label" parent="CooldownMeters/Shot"]
+custom_minimum_size = Vector2(52, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 13
+text = "Shot"
+horizontal_alignment = 2
+
+[node name="Bar" type="ProgressBar" parent="CooldownMeters/Shot"]
+custom_minimum_size = Vector2(96, 6)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 1.0
+show_percentage = false
+
+[node name="Slide" type="HBoxContainer" parent="CooldownMeters"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+theme_override_constants/separation = 8
+mouse_filter = 2
+script = ExtResource("1_cldmtr")
+
+[node name="Label" type="Label" parent="CooldownMeters/Slide"]
+custom_minimum_size = Vector2(52, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 13
+text = "Slide"
+horizontal_alignment = 2
+
+[node name="Bar" type="ProgressBar" parent="CooldownMeters/Slide"]
+custom_minimum_size = Vector2(96, 6)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 1.0
+show_percentage = false
+
+[node name="FullAuto" type="HBoxContainer" parent="CooldownMeters"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+theme_override_constants/separation = 8
+mouse_filter = 2
+script = ExtResource("1_cldmtr")
+
+[node name="Label" type="Label" parent="CooldownMeters/FullAuto"]
+custom_minimum_size = Vector2(52, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 13
+text = "Auto"
+horizontal_alignment = 2
+
+[node name="Bar" type="ProgressBar" parent="CooldownMeters/FullAuto"]
+custom_minimum_size = Vector2(96, 6)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 1.0
+show_percentage = false
+
+[node name="Banana" type="HBoxContainer" parent="CooldownMeters"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+theme_override_constants/separation = 8
+mouse_filter = 2
+script = ExtResource("1_cldmtr")
+
+[node name="Label" type="Label" parent="CooldownMeters/Banana"]
+custom_minimum_size = Vector2(52, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 13
+text = "Banana"
+horizontal_alignment = 2
+
+[node name="Bar" type="ProgressBar" parent="CooldownMeters/Banana"]
+custom_minimum_size = Vector2(96, 6)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 1.0
+show_percentage = false
 
 [node name="Leaderboard" type="PanelContainer" parent="."]
 layout_mode = 1

--- a/ui/hud/ProceduralSounds.cs
+++ b/ui/hud/ProceduralSounds.cs
@@ -1,0 +1,76 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.ui.hud;
+
+// Tiny code-generated sound effects (issue #160): built as 16-bit PCM in memory,
+// so bread feedback needs no downloaded audio assets.
+public static class ProceduralSounds
+{
+  private const int SampleRate = 22050;
+
+  // A satisfying munch: three quick, soft crunches followed by a warm rising heal chime.
+  public static AudioStreamWav Munch()
+  {
+    var samples = new float[(int)(SampleRate * 0.7f)];
+    AddCrunch (samples, startSeconds: 0.0f, brightness: 0.30f);
+    AddCrunch (samples, startSeconds: 0.13f, brightness: 0.22f);
+    AddCrunch (samples, startSeconds: 0.26f, brightness: 0.16f);
+    AddChime (samples, startSeconds: 0.38f, fromHz: 440.0f, toHz: 660.0f, seconds: 0.3f, amplitude: 0.22f);
+    return FromSamples (samples);
+  }
+
+  // A soft "uh-uh" denied cue (issue #160): two low, gentle blips - clearly not an error buzzer.
+  public static AudioStreamWav Denied()
+  {
+    var samples = new float[(int)(SampleRate * 0.35f)];
+    AddChime (samples, startSeconds: 0.0f, fromHz: 220.0f, toHz: 200.0f, seconds: 0.1f, amplitude: 0.2f);
+    AddChime (samples, startSeconds: 0.16f, fromHz: 180.0f, toHz: 160.0f, seconds: 0.12f, amplitude: 0.2f);
+    return FromSamples (samples);
+  }
+
+  // A short burst of low-passed noise with an exponential decay reads as a bread crunch.
+  private static void AddCrunch (float[] samples, float startSeconds, float brightness)
+  {
+    var rng = new RandomNumberGenerator();
+    rng.Seed = (ulong)(startSeconds * 1000.0f) + 42;
+    var start = (int)(startSeconds * SampleRate);
+    var length = (int)(0.09f * SampleRate);
+    var filtered = 0.0f;
+
+    for (var i = 0; i < length && start + i < samples.Length; i++)
+    {
+      var envelope = Mathf.Exp (-10.0f * i / length);
+      filtered += brightness * (rng.Randf() * 2.0f - 1.0f - filtered); // One-pole low-pass tames the hiss.
+      samples[start + i] += filtered * envelope * 0.9f;
+    }
+  }
+
+  private static void AddChime (float[] samples, float startSeconds, float fromHz, float toHz, float seconds, float amplitude)
+  {
+    var start = (int)(startSeconds * SampleRate);
+    var length = (int)(seconds * SampleRate);
+    var phase = 0.0f;
+
+    for (var i = 0; i < length && start + i < samples.Length; i++)
+    {
+      var progress = (float)i / length;
+      phase += Mathf.Lerp (fromHz, toHz, progress) * Mathf.Tau / SampleRate;
+      var envelope = Mathf.Sin (Mathf.Pi * progress); // Smooth fade in & out.
+      samples[start + i] += Mathf.Sin (phase) * envelope * amplitude;
+    }
+  }
+
+  private static AudioStreamWav FromSamples (float[] samples)
+  {
+    var data = new byte[samples.Length * 2];
+
+    for (var i = 0; i < samples.Length; i++)
+    {
+      var value = (short)(Mathf.Clamp (samples[i], -1.0f, 1.0f) * short.MaxValue);
+      data[i * 2] = (byte)(value & 0xff);
+      data[i * 2 + 1] = (byte)((value >> 8) & 0xff);
+    }
+
+    return new AudioStreamWav { Data = data, Format = AudioStreamWav.FormatEnum.Format16Bits, MixRate = SampleRate, Stereo = false };
+  }
+}

--- a/ui/hud/ProceduralSounds.cs.uid
+++ b/ui/hud/ProceduralSounds.cs.uid
@@ -1,0 +1,1 @@
+uid://dvtkfd3g2qwqd

--- a/ui/hud/messages/MessageScroller.cs
+++ b/ui/hud/messages/MessageScroller.cs
@@ -20,7 +20,6 @@ public partial class MessageScroller : Control
   [Export] public Color LoadingCompleteMessageImportanceColor = Colors.White;
   [Export] public int MaxMessageHistoryLines = 1000;
   [Export] public int MessageHistoryPercentToRemoveWhenOverMax = 10;
-  [Export] public int MaxMessageHistoryContainerHeight = 900;
   private Label _messageLabel1 = null!;
   private Label _messageLabel2 = null!;
   private Label _messageLabel3 = null!;
@@ -78,7 +77,9 @@ public partial class MessageScroller : Control
     _messageLabel4 = GetNode <Label> ("MarginContainer/VBoxContainer/Label4");
     _messageContainer = GetNode <MarginContainer> ("MarginContainer");
     _messageHistoryContainer = GetNode <MarginContainer> ("History");
-    _messageHistoryLabel = GetNode <RichTextLabel> ("History/VBoxContainer/MarginContainer/RichTextLabel");
+    // Big comfortable history (issue #161): a near-fullscreen translucent panel with
+    // a font larger than the live scroller's.
+    _messageHistoryLabel = GetNode <RichTextLabel> ("History/Backdrop/MarginContainer/RichTextLabel");
     _messageTimer = GetNode <Timer> ("MessageTimer");
     _messageTimer.Timeout += _OnMessageTimerTimeout;
     Reset();
@@ -214,11 +215,8 @@ public partial class MessageScroller : Control
     // @formatter:on
   }
 
-  private void UpdateMessageHistory()
-  {
-    _messageHistoryLabel.Text = $"[center]{string.Join ("\n", _messageHistory)}[/center]";
-    _messageHistoryLabel.CustomMinimumSize = new Vector2 (_messageHistoryLabel.CustomMinimumSize.X, Mathf.Min (MaxMessageHistoryContainerHeight, _messageHistoryLabel.GetContentHeight()));
-  }
+  // The history fills its big backdrop panel (issue #161); no height clamp needed.
+  private void UpdateMessageHistory() => _messageHistoryLabel.Text = $"[center]{string.Join ("\n", _messageHistory)}[/center]";
 
   private void ShowMessageHistory()
   {

--- a/ui/hud/messages/MessageScroller.tscn
+++ b/ui/hud/messages/MessageScroller.tscn
@@ -1,6 +1,13 @@
-[gd_scene load_steps=2 format=3 uid="uid://huun2vjv0k1v"]
+[gd_scene load_steps=3 format=3 uid="uid://huun2vjv0k1v"]
 
 [ext_resource type="Script" path="res://ui/hud/messages/MessageScroller.cs" id="1"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hstry"]
+bg_color = Color(0, 0, 0, 0.65)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
 
 [node name="MessageScroller" type="Control"]
 layout_mode = 3
@@ -83,77 +90,31 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 70
+theme_override_constants/margin_top = 40
+theme_override_constants/margin_right = 70
+theme_override_constants/margin_bottom = 40
+mouse_filter = 2
+
+[node name="Backdrop" type="PanelContainer" parent="History"]
+layout_mode = 2
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_hstry")
+
+[node name="MarginContainer" type="MarginContainer" parent="History/Backdrop"]
+layout_mode = 2
+theme_override_constants/margin_left = 40
+theme_override_constants/margin_top = 30
+theme_override_constants/margin_right = 40
+theme_override_constants/margin_bottom = 30
+mouse_filter = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="History/Backdrop/MarginContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="History"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 9
-mouse_filter = 2
-
-[node name="MarginContainer" type="MarginContainer" parent="History/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 11
-mouse_filter = 2
-
-[node name="RichTextLabel" type="RichTextLabel" parent="History/VBoxContainer/MarginContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 9
-mouse_filter = 2
+theme_override_font_sizes/normal_font_size = 54
 bbcode_enabled = true
-text = "Test First
-TestTestTestTestTestTestTestTestTestTestTest
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-TestTestTestTestTestTestTestTestTestTestTestTest
-Test
-Test
-Test
-Test
-Test
-Test
-TestTestTestTestTestTestTestTestTestTestTestTest
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-TestTestTestTestTest TestTestTestTestTestTest Test TestTestTestTestTestTestTestTestTestTestTest
-TestTestTestTestTestTestTestTestTestTestTestTest
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-Test
-TestTestTestTestTestTestTestTestTestTestTestTest
-Test
-Test
-TestTestTestTestTestTestTestTestTestTestTestTest
-Test Last TestTestTestTestTestTestTestTestTestTestTest"
 scroll_active = false
 scroll_following = true

--- a/ui/hud/splatter.gdshader
+++ b/ui/hud/splatter.gdshader
@@ -1,24 +1,51 @@
 shader_type canvas_item;
 
-// Banana splatter (issue #70): procedural semi-transparent yellow blobs that slide
-// slowly down the screen & fade out, synced with the banana stun. No external assets.
+// Banana splatter (issues #70 & #165): a dense layer of goopy splat chunks at
+// randomized positions & sizes (re-seeded per hit), opaque enough to genuinely
+// block the view - getting banana'd should be brutal to see through, but the tone
+// stays goofy banana goo. Chunks slide slowly down at varied speeds & drop off
+// piece by piece as the 5s stun fades. No external assets.
 uniform float intensity : hint_range(0.0, 1.0) = 0.0;
 uniform float slide = 0.0;
+uniform float seed = 0.0;
 
-float blob(vec2 uv, vec2 center, float radius) {
-	return 1.0 - smoothstep(radius * 0.55, radius, distance(uv, center));
+float hash(float n) {
+	return fract(sin(n * 91.17 + seed * 13.73) * 43758.5453);
+}
+
+vec2 hash2(float n) {
+	return vec2(hash(n), hash(n + 57.31));
+}
+
+// An irregular blob: the radius wobbles around the rim so chunks read as goo, not circles.
+float splat(vec2 uv, vec2 center, float radius, float wobble) {
+	vec2 d = uv - center;
+	float angle = atan(d.y, d.x);
+	float rim = radius * (0.68 + 0.20 * sin(angle * 5.0 + wobble * 6.28) + 0.12 * sin(angle * 9.0 + wobble * 12.6));
+	return 1.0 - smoothstep(rim * 0.75, rim, length(d));
 }
 
 void fragment() {
-	vec2 uv = vec2(UV.x, UV.y - slide);
-	float a = 0.0;
-	a = max(a, blob(uv, vec2(0.18, 0.22), 0.16));
-	a = max(a, blob(uv, vec2(0.52, 0.10), 0.22));
-	a = max(a, blob(uv, vec2(0.82, 0.28), 0.14));
-	a = max(a, blob(uv, vec2(0.30, 0.52), 0.19));
-	a = max(a, blob(uv, vec2(0.68, 0.60), 0.17));
-	a = max(a, blob(uv, vec2(0.10, 0.75), 0.13));
-	a = max(a, blob(uv, vec2(0.90, 0.80), 0.18));
-	a = max(a, blob(uv, vec2(0.45, 0.85), 0.15));
-	COLOR = vec4(0.95, 0.82, 0.15, a * intensity * 0.85);
+	float goo = 0.0;
+	float shade = 0.0;
+	for (int i = 0; i < 48; i++) {
+		float fi = float(i);
+		vec2 rnd = hash2(fi * 7.31);
+		float sizeRnd = hash(fi * 3.77);
+		float radius = mix(0.03, 0.17, sizeRnd * sizeRnd); // Lots of small bits, a few huge ones.
+		float fall = 0.5 + 1.0 * hash(fi * 5.13); // Heavier goo slides at its own pace.
+		vec2 center = vec2(rnd.x * 1.15 - 0.075, rnd.y * 1.15 - 0.075 + slide * fall);
+		// Chunks let go one at a time through the stun instead of one uniform fade.
+		float dropAt = 0.45 * hash(fi * 9.29);
+		float life = smoothstep(dropAt, dropAt + 0.12, intensity);
+		float body = splat(UV, center, radius, hash(fi * 11.71)) * life;
+		goo = max(goo, body);
+		shade = max(shade, body * hash(fi * 2.71));
+	}
+	// Mostly-opaque goo with per-chunk tonal variety; a final global fade near the end.
+	vec3 bright = vec3(0.98, 0.87, 0.30);
+	vec3 dark = vec3(0.78, 0.62, 0.08);
+	vec3 color = mix(bright, dark, shade);
+	float alpha = smoothstep(0.05, 0.6, goo) * 0.96 * smoothstep(0.0, 0.22, intensity);
+	COLOR = vec4(color, alpha);
 }


### PR DESCRIPTION
## HUD feedback batch

### Bread feedback (#160)
- Pressing B is never silent anymore: eating plays a satisfying code-generated munch + heal chime & prints "You scarf your bread & feel brand new!"
- Soft denied cues (gentle low double-blip + message): "Already at full health" & "No bread left this life"
- A small bread icon in the HUD (below the health bar) shows whether the loaf is still available this life - it dims when eaten & brightens when a respawn restocks it
- All sounds are generated as 16-bit PCM in code (`ui/hud/ProceduralSounds.cs`) - nothing downloaded

### Giant readable message history (#161)
- The Tab history is now a near-fullscreen translucent dark panel (rounded corners, most of the screen)
- 54px font - larger than the live scroller's 50px
- Keeps PageUp/PageDown scrolling, per-message colors (red own-deaths #101 & gold admin messages #158 included), newest-at-bottom, & the passive no-input-capture overlay behavior (#118)

### Brutal banana splatter (#165)
- The few large transparent circles are replaced by 48 irregular goo chunks at randomized positions & sizes, re-seeded per hit so no two splatters look alike
- Mostly opaque & genuinely view-blocking - getting banana'd is brutal to see through, in a goofy banana-goo way
- Keeps the 5s stun sync (#70), the slow downward slide (now at varied per-chunk speeds), & fades out with chunks letting go piece by piece

### Contextual cooldown meters (#177)
- The permanent bar row is gone; shot, full-auto, slide, & banana are now tiny labeled meters centered just below the crosshair (not obscuring it)
- Each meter is visible ONLY while its cooldown is actually recovering: fast fade in/out plus a brief green ready-flash the moment it's back

### Validation
- `dotnet build`: 0 errors, 0 warnings
- Full headless multiplayer playtest (host + shooter + victim): PASSED all three roles

Fixes #160
Fixes #161
Fixes #165
Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bread-use feedback with distinct notifications and audio for unavailable bread, full health, and invalid areas.
  * Added bread availability display to the HUD.
  * Added animated cooldown meters that fade in during recovery and flash when ready.
  * Improved message history with a rounded, translucent backdrop and clearer presentation.
  * Enhanced stun splatter effects with more varied, dynamic goo patterns.
* **Bug Fixes**
  * Prevented bread from being consumed when the player is already at full health.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->