### PR TITLE
Slingshot rework, left-click punch, charge-cancel on switch, & grounded drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 ## How it plays
 
 - **Charge-up lasers**: hold the trigger to spin up your energy weapon — the longer the charge, the faster, bigger, & meaner the bolt (blue → red). Release to fire a visible laser burst that travels (with a little drop), so shots can be dodged.
-- **Punching**: right-click for close-range brawling. Getting punched blurs your screen for a bit.
+- **Punching**: with fists out (slot 1), left-click for close-range brawling. Getting punched blurs your screen for a bit.
 - **Full-auto ability**: press F for 3 seconds of low-damage rapid fire (15 s cooldown).
 - **Difficulty handicap**: pick Beginner / Intermediate / Expert when you join. Lower tiers get bigger health pools *and* hit higher tiers harder, so mixed-skill lobbies stay fair.
 - **Spawn armor**: 5 seconds of invulnerability after every spawn (white glow). Firing or punching cancels it.
@@ -18,12 +18,14 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 |---|---|
 | W A S D | Move |
 | Mouse | Look |
-| Left mouse (hold & release) | Charge & fire laser |
-| Right mouse | Punch |
+| Left mouse | Use the selected weapon — punch with fists; hold & release to charge & fire the laser or draw & sling the slingshot |
+| 1 – 5 | Select weapon slot (1 fists, 2 laser, 3 banana, 4 boomerang, 5 slingshot) |
 | F | Full-auto ability (3 s, 15 s cooldown) |
 | Space | Jump |
 | V | Toggle first-/third-person view |
 | Esc | Quit dialog |
+
+Full list: [docs/CONTROLS.md](docs/CONTROLS.md)
 
 ## Multiplayer
 

--- a/core/players/Player.Boomerang.cs
+++ b/core/players/Player.Boomerang.cs
@@ -110,11 +110,15 @@ public partial class Player
   {
     var type = PickDroppableWeapon();
     if (type == HeldWeapon.None) return;
+    // Request BEFORE clearing, like DropHeldWeapon (issue #154): clearing first let
+    // the replicated HeldWeapon delta beat the escrow RPC to the server, & a
+    // reconcile pass in that window counted the weapon as gone & spawned a
+    // duplicate - the suspected banana-launcher double.
+    Spawner.SendStolenEscrowRequest (throwerId, type);
     HeldWeapon &= ~type;
     ForgetTheft (type);
     DeselectUnheldWeapon();
     GD.Print ($"{DisplayName}: That boomerang made off with my {type}!");
-    Spawner.SendStolenEscrowRequest (throwerId, type);
   }
 
   private void OnBoomerangScoopedPickup (string pickupName) => Spawner.SendScoopRequest (pickupName);
@@ -135,9 +139,12 @@ public partial class Player
   {
     _liveBoomerang = null;
     Rpc (MethodName.FreeVisualBoomerang);
+    // Request BEFORE clearing, like DropHeldWeapon (issue #154): the release RPC
+    // must reach the server while its replicated view still shows the boomerang
+    // held, or a reconcile pass in the gap spawns a duplicate.
+    Spawner.SendBoomerangReleaseRequest (position);
     HeldWeapon &= ~HeldWeapon.Boomerang;
     DeselectUnheldWeapon();
-    Spawner.SendBoomerangReleaseRequest (position);
   }
 
   // Zapping out (or falling off the world) mid-flight: the boomerang & its cargo

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -45,6 +45,19 @@ public partial class Player
   // dancing blocks charging - the press cancels the dance instead (issue #103).
   private bool IsChargingWeapon() => _isInputEnabled && !Dancing && IsLaserSelected && HasLaser && !IsFullAutoActive() && Input.IsActionPressed ("shoot");
   private bool IsDischargingWeapon() => _isInputEnabled && IsLaserSelected && HasLaser && _energyWeapon.IsSpinningUp && Input.IsActionJustReleased ("shoot");
+
+  // Leaving the laser slot cancels the charge (issue #156): ResetCharge spins down,
+  // resets the accumulated energy, stops the charging sound, & clears the full-charge
+  // lock-in (#113); the x-ray reveal (#105) keys off IsFullyCharged & clears on the
+  // next UpdateXrayReveal poll. Poll-based like the slingshot's CancelSlingshotDraw,
+  // so weapon switches, drops, theft, death, & respawn all self-heal through the one
+  // path instead of each needing its own hook.
+  private void CancelStaleLaserCharge()
+  {
+    if (!_energyWeapon.IsSpinningUp) return;
+    if (IsLaserSelected && HasLaser) return;
+    _energyWeapon.ResetCharge();
+  }
   private void ChargeWeapon() => _energyWeapon.Charge();
   private void DischargeWeapon() => _energyWeapon.Discharge();
   // Capped at 200: only banana energies exceed 1.0, & the sticky one-hit kill needs
@@ -351,7 +364,13 @@ public partial class Player
     var horizontal = new Vector3 (away.X, 0.0f, away.Z);
     if (horizontal.LengthSquared() < 0.001f) return;
     var strength = KnockbackStrength * energy * scale;
-    Velocity += horizontal.Normalized() * strength + Vector3.Up * strength * 0.3f;
+    var push = horizontal.Normalized() * strength;
+    // Mostly-horizontal shove (issue #163): the up-pop compounded with energy & scale
+    // & stacked additively across rapid hits, launching full-draw slingshot victims
+    // sky-high. Knockback may never push upward speed past the cap; an already-faster
+    // ascent (a jump, a rocket boost) keeps its own speed.
+    var poppedUp = Mathf.Min (Velocity.Y + strength * 0.3f, KnockbackUpPopCap);
+    Velocity = new Vector3 (Velocity.X + push.X, Mathf.Max (Velocity.Y, poppedUp), Velocity.Z + push.Z);
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]

--- a/core/players/Player.Slingshot.cs
+++ b/core/players/Player.Slingshot.cs
@@ -10,19 +10,29 @@ namespace com.forerunnergames.energyshot.players;
 public partial class Player
 {
   [Export] public float SlingshotMaxDrawSeconds = 1.2f;
+  // Fire-rate cap (issue #163): a sub-minimum release just relaxes the band (no
+  // stone), & the band needs a beat between shots, so tap-spam does nothing.
+  [Export] public float SlingshotMinDrawSeconds = 0.2f;
+  [Export] public float SlingshotCooldownSeconds = 0.5f;
   [Export] public float SlingshotMinSpeed = 22.0f;
-  [Export] public float SlingshotMaxSpeed = 60.0f;
+  // Raised from 60 (issue #163): a full draw is a genuinely long shot.
+  [Export] public float SlingshotMaxSpeed = 90.0f;
   // 15-60 damage via CalculateHealthDecrease (issue #99): a nuisance at a tap,
   // a proper wallop at full draw, never a one-hit zap-out.
   [Export] public float SlingshotMinEnergy = 0.15f;
   [Export] public float SlingshotMaxEnergy = 0.6f;
   [Export] public float SlingshotKnockbackScale = 0.6f;
+  // Arc flattening (issue #163): stone gravity eases off as the draw rises, so
+  // full-draw stones fly flat long shots while taps stay lobbed.
+  [Export] public float SlingshotMinDrawGravity = 24.0f;
+  [Export] public float SlingshotMaxDrawGravity = 10.0f;
   // How far the held frame pulls back toward the eye at full draw (issue #99).
   private const float SlingshotDrawPullMeters = 0.25f;
   private static readonly Vector3 SlingshotRestPosition = new(0.5f, -0.5f, -0.9f);
   private Node3D _slingshotHeld = null!;
   private AudioStreamPlayer _slingshotStretchSound = null!;
   private float _slingshotDrawSeconds;
+  private float _slingshotCooldownLeft;
   private float SlingshotDrawFraction => Mathf.Clamp (_slingshotDrawSeconds / SlingshotMaxDrawSeconds, 0.0f, 1.0f);
 
   // Held model: the same code-built Y-frame as the pickup, resting in the hand
@@ -34,7 +44,8 @@ public partial class Player
     _slingshotHeld.Position = SlingshotRestPosition;
     _slingshotHeld.RotationDegrees = new Vector3 (0.0f, 10.0f, -8.0f);
     GetNode <Node3D> ("Camera3D").AddChild (_slingshotHeld);
-    _slingshotStretchSound = new AudioStreamPlayer { Stream = ResourceLoader.Load <AudioStream> ("res://assets/sounds/punch-whiff.wav"), PitchScale = 0.55f };
+    // MaxPolyphony 4 (issue #182): quick draw-cancel-draw retriggers inside the slowed creak's tail.
+    _slingshotStretchSound = new AudioStreamPlayer { Stream = ResourceLoader.Load <AudioStream> ("res://assets/sounds/punch-whiff.wav"), PitchScale = 0.55f, MaxPolyphony = 4 };
     AddChild (_slingshotStretchSound);
   }
 
@@ -43,6 +54,7 @@ public partial class Player
   // slingshot (or selection) mid-draw cancels cleanly.
   private void UpdateSlingshot (double delta)
   {
+    _slingshotCooldownLeft = Mathf.Max (0.0f, _slingshotCooldownLeft - (float)delta);
     var active = IsSlingshotSelected && HasSlingshot && _isInputEnabled;
     if (!active) { CancelSlingshotDraw(); return; }
     if (Input.IsActionPressed ("shoot")) { AccumulateSlingshotDraw ((float)delta); return; }
@@ -52,6 +64,7 @@ public partial class Player
 
   private void AccumulateSlingshotDraw (float dt)
   {
+    if (_slingshotCooldownLeft > 0.0f) return; // Fire-rate cap (issue #163): no new draw mid-cooldown.
     if (_slingshotDrawSeconds <= 0.0f) _slingshotStretchSound.Play(); // Once per draw.
     _slingshotDrawSeconds = Mathf.Min (SlingshotMaxDrawSeconds, _slingshotDrawSeconds + dt);
     ApplySlingshotDrawPose();
@@ -65,37 +78,48 @@ public partial class Player
     ApplySlingshotDrawPose();
   }
 
-  // The frame pulls back toward the eye as the band stretches (issue #99).
-  private void ApplySlingshotDrawPose() => _slingshotHeld.Position = SlingshotRestPosition + Vector3.Back * (SlingshotDrawPullMeters * SlingshotDrawFraction);
+  // The frame pulls back toward the eye as the band stretches (issue #99), the
+  // nocked stone & pouch pull further back with the draw, & the band halves stretch
+  // with them - snapping forward when the draw resets to zero (issue #163).
+  private void ApplySlingshotDrawPose()
+  {
+    _slingshotHeld.Position = SlingshotRestPosition + Vector3.Back * (SlingshotDrawPullMeters * SlingshotDrawFraction);
+    SlingshotStone.PoseBand (_slingshotHeld, SlingshotDrawFraction);
+  }
 
   private void FireSlingshotStone()
   {
-    CancelSpawnArmorIfFired();
     var draw = SlingshotDrawFraction;
+    var drawSeconds = _slingshotDrawSeconds;
     CancelSlingshotDraw();
+    if (drawSeconds < SlingshotMinDrawSeconds) return; // Sub-minimum release: the band just relaxes, no shot (issue #163).
+    CancelSpawnArmorIfFired();
+    _slingshotCooldownLeft = SlingshotCooldownSeconds; // Fire-rate cap (issue #163).
     var speed = Mathf.Lerp (SlingshotMinSpeed, SlingshotMaxSpeed, draw);
     var energy = Mathf.Lerp (SlingshotMinEnergy, SlingshotMaxEnergy, draw);
+    var gravity = Mathf.Lerp (SlingshotMinDrawGravity, SlingshotMaxDrawGravity, draw); // Flatter arc at full draw (issue #163).
     var direction = -_camera.GlobalTransform.Basis.Z;
-    var origin = _camera.GlobalPosition + direction * MuzzleOffsetMeters;
-    SpawnStone (origin, direction, speed, energy, isLive: true);
-    Rpc (MethodName.SpawnVisualStone, origin, direction, speed);
+    var sweepStart = _camera.GlobalPosition; // First sweep covers camera->muzzle (issues #112 & #163).
+    var origin = sweepStart + direction * MuzzleOffsetMeters;
+    SpawnStone (origin, sweepStart, direction, speed, gravity, energy, isLive: true);
+    Rpc (MethodName.SpawnVisualStone, origin, sweepStart, direction, speed, gravity);
   }
 
   // Visual-only copy of the shooter's stone on every other peer. Firing proves the
   // shooter's spawn armor is gone, so stale armor whitewash clears here (issue #114).
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void SpawnVisualStone (Vector3 origin, Vector3 direction, float speed)
+  private void SpawnVisualStone (Vector3 origin, Vector3 sweepStart, Vector3 direction, float speed, float gravity)
   {
     ClearArmorDisplayOnRemoteAttack();
-    SpawnStone (origin, direction, speed, energy: 0.0f, isLive: false);
+    SpawnStone (origin, sweepStart, direction, speed, gravity, energy: 0.0f, isLive: false);
   }
 
-  private void SpawnStone (Vector3 origin, Vector3 direction, float speed, float energy, bool isLive)
+  private void SpawnStone (Vector3 origin, Vector3 sweepStart, Vector3 direction, float speed, float gravity, float energy, bool isLive)
   {
     PlaySlingshotThwack (origin);
     var stone = new SlingshotStone();
     GetParent().AddChild (stone);
-    stone.Launch (origin, direction, speed, energy, isLive, this);
+    stone.Launch (origin, sweepStart, direction, speed, gravity, energy, isLive, this);
     if (isLive) stone.HitPlayer += OnStoneHitPlayer;
   }
 

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -220,6 +220,9 @@ public partial class Player : CharacterBody3D
   // still connects (issue #86).
   [Export] public float AirRocketBoostRange = 8.0f;
   [Export] public float KnockbackStrength = 16.0f;
+  // Hits shove mostly horizontally (issue #163): knockback never pushes upward speed
+  // past this, so stacked or full-draw hits can't launch victims sky-high.
+  [Export] public float KnockbackUpPopCap = 6.0f;
   [Export] public int KillHealAmount = 50;
   [Export] public float PunchKnockbackScale = 0.33f;
   [Export] public float JumpVelocity = 20.0f;
@@ -331,6 +334,11 @@ public partial class Player : CharacterBody3D
     _zapOutSound = GetNode <AudioStreamPlayer> ("ZapOutSound");
     _respawnSound = GetNode <AudioStreamPlayer> ("RespawnSound");
     _jumpSound = GetNode <AudioStreamPlayer> ("JumpSound");
+    // Rapid-retrigger sfx mix instead of cutting each other off (issue #182): the
+    // default polyphony (1) restarts the stream on every play, glitching quick
+    // punches, full-auto hitmarker bursts, & back-to-back damage hits; extra voices
+    // let overlapping plays ring out their tails.
+    foreach (var sound in new[] { _punchSound, _punchWhiffSound, _punchThudSound, _weaponPickupSound, _throughWallZapSound, _hitmarkerSound, _damageSound, _jumpSound }) sound.MaxPolyphony = 6;
     _healthBar.MaxValue = MaxHealth;
     _health = MaxHealth;
     _healthBar.Value = _health;
@@ -389,6 +397,7 @@ public partial class Player : CharacterBody3D
     UpdateXrayReveal();
     UpdateViewToggle(); // Third-person toggle on V (issue #119).
     UpdateWeaponSelection();
+    CancelStaleLaserCharge(); // Leaving the laser slot cancels the charge (issue #156).
     UpdateBananaLauncher();
     UpdateBoomerang();
     UpdateSlingshot (delta); // Draw-&-release stones (issue #99).

--- a/core/weapons/BananaLauncher.cs
+++ b/core/weapons/BananaLauncher.cs
@@ -22,6 +22,8 @@ public partial class BananaLauncher : Node3D
   public override void _Ready()
   {
     _fireSound = GetNode <AudioStreamPlayer3D> ("FireSound");
+    // A follow-up launch inside the thump's tail mixes instead of restarting it (issue #182).
+    _fireSound.MaxPolyphony = 4;
     ApplyRifleVisuals();
   }
   public override void _PhysicsProcess (double delta) => _cooldownLeft = Mathf.Max (0.0f, _cooldownLeft - (float)delta);

--- a/core/weapons/EnergyWeapon.cs
+++ b/core/weapons/EnergyWeapon.cs
@@ -113,6 +113,9 @@ public partial class EnergyWeapon : Node3D
   {
     _pivot = GetNode <Node3D> ("Pivot");
     _shootingSound = GetNode <AudioStreamPlayer3D> ("ShootingSound");
+    // Full-auto retriggers the shot every 0.15s (issue #182): extra voices keep each
+    // blast's tail ringing instead of restarting the stream mid-play.
+    _shootingSound.MaxPolyphony = 6;
     _chargingSound = GetNode <AudioStreamPlayer3D> ("ChargingSound");
     _fullAutoSwitchSound = GetNode <AudioStreamPlayer3D> ("FullAutoSwitchSound");
     _fullAutoReadySound = GetNode <AudioStreamPlayer3D> ("FullAutoReadySound");

--- a/core/weapons/SlingshotStone.cs
+++ b/core/weapons/SlingshotStone.cs
@@ -4,20 +4,32 @@ using Godot;
 namespace com.forerunnergames.energyshot.weapons;
 
 // A slung stone (issue #99): flies a gravity arc whose speed & sting scale with how
-// long the shooter drew the band - drawn longer = flatter, faster, & harder. Only the
-// shooter's own stone is "live" (reports the hit); other peers fly visual-only copies,
-// like BananaProjectile. Impacts are detected by sweeping a ray along the path
-// traveled each physics frame, so fast stones can't tunnel. Built entirely from a
-// primitive sphere & existing sounds - no downloaded assets.
+// long the shooter drew the band - drawn longer = flatter, faster, & harder (the
+// shooter passes a draw-scaled gravity, issue #163). Only the shooter's own stone is
+// "live" (reports the hit); other peers fly visual-only copies, like BananaProjectile.
+// Impacts are detected by sweeping a ray along the path traveled each physics frame,
+// so fast stones can't tunnel; the first frame sweeps from the camera, so a wall
+// closer than the muzzle offset can't be skipped either (issues #112 & #163). Built
+// entirely from primitive meshes & existing sounds - no downloaded assets.
 public partial class SlingshotStone : Node3D
 {
   [Export] public float GravityAcceleration = 24.0f;
-  [Export] public float MaxLifetimeSeconds = 6.0f;
+  // Doubled from 6 (issue #163): stones fly their full arc & only despawn on impact
+  // or well past relevance.
+  [Export] public float MaxLifetimeSeconds = 12.0f;
   [Signal] public delegate void HitPlayerEventHandler (Player victim, float energy);
   private static readonly Color StoneGray = new(0.55f, 0.55f, 0.58f);
   private static readonly Color FrameBrown = new(0.45f, 0.28f, 0.12f);
   private static readonly Color BandTan = new(0.85f, 0.72f, 0.35f);
+  // Prong-tip band anchors & the pouch's rest spot, in the visual's local space; the
+  // pouch (with the nocked stone) pulls straight back with the draw (issue #163).
+  private static readonly Vector3 BandTipLeft = new(-0.19f, 0.42f, 0.0f);
+  private static readonly Vector3 BandTipRight = new(0.19f, 0.42f, 0.0f);
+  private static readonly Vector3 PouchRest = new(0.0f, 0.42f, 0.03f);
+  private const float PouchPullMeters = 0.4f;
   private Vector3 _velocity;
+  private Vector3 _sweepStart;
+  private bool _sweptFromStart;
   private float _energy;
   private float _age;
   private bool _isLive;
@@ -25,18 +37,44 @@ public partial class SlingshotStone : Node3D
 
   // Shared look for the world pickup & the held model (issue #99): a simple Y-frame
   // slingshot built from primitive boxes - a wooden handle, two angled prongs, & a
-  // band across the tips. Fresh materials per call so the first-person overlay tweak
-  // (issue #124) can't bleed into pickups.
+  // two-half band running from the prong tips to a pouch holding a nocked stone, so
+  // the held model can stretch the band back with the draw (issue #163). Fresh
+  // materials per call so the first-person overlay tweak (issue #124) can't bleed
+  // into pickups.
   public static Node3D CreateSlingshotVisual()
   {
     var wood = new StandardMaterial3D { AlbedoColor = FrameBrown, Roughness = 0.9f };
     var band = new StandardMaterial3D { AlbedoColor = BandTan, Roughness = 0.6f };
+    var stone = new StandardMaterial3D { AlbedoColor = StoneGray, Roughness = 0.8f };
     var visual = new Node3D();
     visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.07f, 0.4f, 0.07f) }, MaterialOverride = wood });
     visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.06f, 0.3f, 0.06f) }, MaterialOverride = wood, Position = new Vector3 (-0.1f, 0.3f, 0.0f), RotationDegrees = new Vector3 (0.0f, 0.0f, 35.0f) });
     visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.06f, 0.3f, 0.06f) }, MaterialOverride = wood, Position = new Vector3 (0.1f, 0.3f, 0.0f), RotationDegrees = new Vector3 (0.0f, 0.0f, -35.0f) });
-    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.38f, 0.035f, 0.035f) }, MaterialOverride = band, Position = new Vector3 (0.0f, 0.43f, 0.0f) });
+    visual.AddChild (new MeshInstance3D { Name = "BandLeft", Mesh = new BoxMesh { Size = new Vector3 (0.035f, 0.035f, 1.0f) }, MaterialOverride = band });
+    visual.AddChild (new MeshInstance3D { Name = "BandRight", Mesh = new BoxMesh { Size = new Vector3 (0.035f, 0.035f, 1.0f) }, MaterialOverride = band });
+    visual.AddChild (new MeshInstance3D { Name = "NockedStone", Mesh = new SphereMesh { Radius = 0.05f, Height = 0.1f }, MaterialOverride = stone });
+    PoseBand (visual, 0.0f);
     return visual;
+  }
+
+  // Draw pose for the shared visual (issue #163): the pouch & nocked stone pull back
+  // toward the eye with the draw, & both band halves stretch from the prong tips to
+  // meet them; drawFraction 0 is the relaxed rest pose (used by pickups & on release,
+  // so the band visibly snaps forward).
+  public static void PoseBand (Node3D visual, float drawFraction)
+  {
+    var pouch = PouchRest + Vector3.Back * (PouchPullMeters * drawFraction);
+    visual.GetNode <Node3D> ("NockedStone").Position = pouch;
+    StretchBandSegment (visual.GetNode <MeshInstance3D> ("BandLeft"), BandTipLeft, pouch);
+    StretchBandSegment (visual.GetNode <MeshInstance3D> ("BandRight"), BandTipRight, pouch);
+  }
+
+  // Orients & scales a unit-length band box to connect two local-space points.
+  private static void StretchBandSegment (MeshInstance3D segment, Vector3 from, Vector3 to)
+  {
+    var span = to - from;
+    segment.Position = (from + to) * 0.5f;
+    segment.Basis = Basis.LookingAt (span.Normalized(), Vector3.Up) * Basis.FromScale (new Vector3 (1.0f, 1.0f, span.Length()));
   }
 
   public override void _Ready()
@@ -48,10 +86,15 @@ public partial class SlingshotStone : Node3D
     });
   }
 
-  public void Launch (Vector3 origin, Vector3 direction, float speed, float energy, bool isLive, CharacterBody3D shooter)
+  // sweepStart is the shooter's camera position: the stone spawns at the muzzle, but
+  // the first sweep covers camera->muzzle too, so a wall closer than the muzzle
+  // offset can't be skipped (issues #112 & #163).
+  public void Launch (Vector3 origin, Vector3 sweepStart, Vector3 direction, float speed, float gravity, float energy, bool isLive, CharacterBody3D shooter)
   {
     GlobalPosition = origin;
+    _sweepStart = sweepStart;
     _velocity = direction.Normalized() * speed;
+    GravityAcceleration = gravity; // Draw-scaled (issue #163): full draws fly flatter arcs.
     _energy = energy;
     _isLive = isLive;
     _shooterRid = shooter.GetRid();
@@ -62,9 +105,10 @@ public partial class SlingshotStone : Node3D
     var dt = (float)delta;
     _age += dt;
     if (_age > MaxLifetimeSeconds) { QueueFree(); return; }
-    var from = GlobalPosition;
+    var from = _sweptFromStart ? GlobalPosition : _sweepStart;
+    _sweptFromStart = true;
     _velocity.Y -= GravityAcceleration * dt;
-    var to = from + _velocity * dt;
+    var to = GlobalPosition + _velocity * dt;
     var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { _shooterRid });
     query.HitFromInside = true;
     var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -33,6 +33,14 @@ public partial class WeaponSpawner : Node3D
   // between the grab & the thrower's catch, so the caps still count them.
   private readonly record struct BoomerangCargo (int OwnerId, HeldWeapon Type, string PreviousOwner);
   private readonly List <BoomerangCargo> _escrow = new();
+  // Award->replication bridge (issue #154): between despawning a claimed pickup (or
+  // delivering escrowed cargo) & the collector's replicated HeldWeapon showing the
+  // weapon, the count dips below the cap - a reconcile pass in that window would
+  // spawn a duplicate. Pending grants keep the weapon counted until the flag lands;
+  // the timeout covers a collector that vanishes mid-grant (the caps then respawn it).
+  private readonly record struct PendingGrant (int CollectorId, HeldWeapon Type, ulong ExpiresAtMs);
+  private readonly List <PendingGrant> _pendingGrants = new();
+  private const float PendingGrantTimeoutSeconds = 3.0f;
   private readonly RandomNumberGenerator _rng = new();
   private readonly List <Vector3> _laserPoints = new();
   private PackedScene _pickupScene = null!;
@@ -50,7 +58,11 @@ public partial class WeaponSpawner : Node3D
   private static bool IsFree (Vector3 point, IEnumerable <WeaponPickup> pickups) => pickups.All (pickup => pickup.Position.DistanceTo (point) > OccupiedRadius);
   // Escrowed boomerang cargo counts too (issue #98), or a reconcile pass mid-flight
   // would over-spawn the weapon the boomerang is carrying.
-  private int Count (HeldWeapon type, List <WeaponPickup> pickups, List <Player> players) => pickups.Count (pickup => pickup.Weapon == type) + players.Count (player => player.Holds (type)) + _escrow.Count (cargo => cargo.Type == type);
+  private int Count (HeldWeapon type, List <WeaponPickup> pickups, List <Player> players) => pickups.Count (pickup => pickup.Weapon == type) + players.Count (player => player.Holds (type)) + _escrow.Count (cargo => cargo.Type == type) + _pendingGrants.Count (grant => grant.Type == type);
+  private void TrackPendingGrant (int collectorId, HeldWeapon type) => _pendingGrants.Add (new PendingGrant (collectorId, type, Time.GetTicksMsec() + (ulong)(PendingGrantTimeoutSeconds * 1000.0f))); // Issue #154.
+  // A pending grant ends when the collector's replicated HeldWeapon shows the weapon
+  // (it counts as held from then on) or the timeout passes (issue #154).
+  private void PrunePendingGrants (List <Player> players) => _pendingGrants.RemoveAll (grant => Time.GetTicksMsec() > grant.ExpiresAtMs || players.Any (player => player.NetworkId == grant.CollectorId && player.Holds (grant.Type)));
   private void GrantToSelf (int type, string previousOwner) => (GetParent() as World)?.SelfPlayer?.GrantWeapon ((HeldWeapon)type, previousOwner);
   [Rpc] private void ConfirmPickup (int type, string previousOwner) => GrantToSelf (type, previousOwner);
   // A direct (non-RPC) call means the host itself sent it, so there's no remote sender.
@@ -108,6 +120,7 @@ public partial class WeaponSpawner : Node3D
     var players = Players().ToList();
     // Cargo whose thrower vanished mid-flight goes back to the spawn pool via the caps (issue #98).
     _escrow.RemoveAll (cargo => players.All (player => player.NetworkId != cargo.OwnerId));
+    PrunePendingGrants (players); // Delivered or expired award bridges stop counting (issue #154).
     var freePoints = _laserPoints.Where (point => IsFree (point, pickups)).ToList();
     var laserCount = Count (HeldWeapon.Laser, pickups, players);
 
@@ -191,10 +204,11 @@ public partial class WeaponSpawner : Node3D
 
     if (collectorId == Multiplayer.GetUniqueId())
     {
-      GrantToSelf ((int)type, previousOwner);
+      GrantToSelf ((int)type, previousOwner); // Synchronous: the server's own HeldWeapon shows it immediately.
       return;
     }
 
+    TrackPendingGrant (collectorId, type); // Bridge until the collector's HeldWeapon replicates back (issue #154).
     RpcId (collectorId, MethodName.ConfirmPickup, (int)type, previousOwner);
   }
 
@@ -328,10 +342,11 @@ public partial class WeaponSpawner : Node3D
 
     if (throwerId == Multiplayer.GetUniqueId())
     {
-      GrantToSelf ((int)cargo.Type, cargo.PreviousOwner);
+      GrantToSelf ((int)cargo.Type, cargo.PreviousOwner); // Synchronous: the server's own HeldWeapon shows it immediately.
       return;
     }
 
+    TrackPendingGrant (throwerId, cargo.Type); // Bridge until the thrower's HeldWeapon replicates back (issue #154).
     RpcId (throwerId, MethodName.ConfirmPickup, (int)cargo.Type, cargo.PreviousOwner);
   }
 
@@ -358,14 +373,20 @@ public partial class WeaponSpawner : Node3D
 
   // Level geometry only (collision layer 1): another player below isn't a shelf.
   private const uint WorldLayer = 1;
+  // The kill boundary under the arena (y=-100) shares the world layer, & the ground
+  // ray was treating it as a floor - spawning unreachable pickups at y=-99 (issue
+  // #172). No real level surface sits below this, so anything deeper is the void.
+  private const float MinGroundY = -50.0f;
 
   // Finds the first level surface beneath the point (hover height above it); false
-  // over the void, where there's nothing for a pickup to rest on (issue #151).
+  // over the void, where there's nothing for a pickup to rest on (issue #151) - the
+  // kill boundary below the arena doesn't count (issue #172).
   private bool TryFindGround (Vector3 position, out Vector3 spot)
   {
     var query = PhysicsRayQueryParameters3D.Create (position, position + Vector3.Down * 100.0f, collisionMask: WorldLayer);
     var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
-    spot = hit.Count == 0 ? position : (Vector3)hit["position"] + Vector3.Up * PickupHoverHeight;
-    return hit.Count > 0;
+    var grounded = hit.Count > 0 && ((Vector3)hit["position"]).Y >= MinGroundY;
+    spot = grounded ? (Vector3)hit["position"] + Vector3.Up * PickupHoverHeight : position;
+    return grounded;
   }
 }

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -193,6 +193,15 @@ public partial class WeaponSpawner : Node3D
   private void RequestPickup (string pickupName, int collectorId)
   {
     if (!Multiplayer.IsServer()) return;
+
+    // Claims are always filed by the collecting player's own peer (CodeRabbit on
+    // #184): a forged collectorId can't award (or deny) weapons to someone else.
+    if (collectorId != SenderOrSelf())
+    {
+      ServerLog.Event (SenderOrSelf(), $"weapon deny: claim for another peer [{collectorId}]");
+      return;
+    }
+
     var pickup = GetParent().GetNodeOrNull <WeaponPickup> (pickupName);
     ServerLog.Event (collectorId, $"weapon claim: pickup [{pickupName}]");
 
@@ -291,6 +300,17 @@ public partial class WeaponSpawner : Node3D
   {
     if (!Multiplayer.IsServer()) return;
     var throwerId = SenderOrSelf();
+    var thrower = Players().FirstOrDefault (player => player.NetworkId == throwerId);
+
+    // Server-side state check (CodeRabbit on #184, the #145/#167 convention): only a
+    // boomerang carrier can have one out flying to scoop with (the flag stays set
+    // through the whole flight).
+    if (thrower == null || (thrower.HeldOrRecentlyHeld & HeldWeapon.Boomerang) == 0)
+    {
+      ServerLog.Event (throwerId, "boomerang scoop deny: sender does not hold a boomerang");
+      return;
+    }
+
     var pickup = GetParent().GetNodeOrNull <WeaponPickup> (pickupName);
 
     if (pickup == null || pickup.IsQueuedForDeletion())
@@ -307,14 +327,35 @@ public partial class WeaponSpawner : Node3D
   // A boomerang hit stole the victim's held weapon. The victim reports its own loss
   // (it owns its replicated HeldWeapon), so the theft attribution for the revenge
   // messages (issue #84) comes from the RPC sender - never client-supplied text.
+  // The surrendered type is validated the same way (CodeRabbit on #184, the
+  // #145/#167 convention): it must show in the victim's replicated state (current
+  // or drop-grace), reduced to a single flag so a forged multi-flag mask can't
+  // conjure weapons into escrow.
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
   private void RequestBoomerangEscrow (int throwerId, int type)
   {
     if (!Multiplayer.IsServer()) return;
     var victimId = SenderOrSelf();
-    var victimName = Players().FirstOrDefault (player => player.NetworkId == victimId)?.DisplayName ?? string.Empty;
-    _escrow.Add (new BoomerangCargo (throwerId, (HeldWeapon)type, victimName));
-    ServerLog.Event (victimId, $"boomerang steal: {(HeldWeapon)type} taken from [{victimName}] for peer {throwerId}");
+    var victim = Players().FirstOrDefault (player => player.NetworkId == victimId);
+    var surrendered = FirstFlag ((HeldWeapon)type & (victim?.HeldOrRecentlyHeld ?? HeldWeapon.None));
+
+    if (surrendered == HeldWeapon.None)
+    {
+      ServerLog.Event (victimId, $"boomerang steal deny: mask [{(HeldWeapon)type}] not held by sender");
+      return;
+    }
+
+    var victimName = victim!.DisplayName; // Non-null: the mask intersection above proved the sender exists.
+    _escrow.Add (new BoomerangCargo (throwerId, surrendered, victimName));
+    ServerLog.Event (victimId, $"boomerang steal: {surrendered} taken from [{victimName}] for peer {throwerId}");
+  }
+
+  // Escrow & pickups carry exactly one weapon each: reduce a validated mask to its
+  // first flag so downstream Spawn/Deliver never see a multi-flag type (issue #184).
+  private static HeldWeapon FirstFlag (HeldWeapon mask)
+  {
+    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot }) { if ((mask & flag) != 0) return flag; }
+    return HeldWeapon.None;
   }
 
   // The thrower caught the boomerang: deliver all escrowed cargo. Grants reuse the
@@ -365,17 +406,30 @@ public partial class WeaponSpawner : Node3D
   {
     if (!Multiplayer.IsServer()) return;
     var throwerId = SenderOrSelf();
-    var spot = GroundedSpot (position);
+    var thrower = Players().FirstOrDefault (player => player.NetworkId == throwerId);
+    // Server-side state check (CodeRabbit on #184, the #145/#167 convention): only a
+    // sender whose replicated HeldWeapon shows a boomerang (current or drop-grace)
+    // can release one - a forged request can't conjure pickups.
+    if (thrower == null || (thrower.HeldOrRecentlyHeld & HeldWeapon.Boomerang) == 0)
+    {
+      ServerLog.Event (throwerId, "boomerang release deny: sender does not hold a boomerang");
+      return;
+    }
+
+    // No ground beneath the release point (CodeRabbit on #184): skip the spawns like
+    // RequestDrop does - draining the escrow lets the caps respawn boomerang & cargo
+    // at spawn points instead of leaving unreachable floating pickups.
+    if (!TryFindGround (position, out var spot))
+    {
+      TakeEscrowFor (throwerId);
+      ServerLog.Event (throwerId, $"boomerang release skip: no ground beneath {position}; boomerang & cargo return via the caps");
+      return;
+    }
+
     ServerLog.Event (throwerId, $"boomerang release: dropped at {spot}");
     Spawn (HeldWeapon.Boomerang, spot, expires: true);
     var offset = 0;
     foreach (var cargo in TakeEscrowFor (throwerId)) Spawn (cargo.Type, spot + Vector3.Right * (0.8f * ++offset), expires: true, cargo.PreviousOwner);
-  }
-
-  private Vector3 GroundedSpot (Vector3 position)
-  {
-    TryFindGround (position, out var spot);
-    return spot; // Over the void this keeps the raw position; the pickup expires & the caps respawn it.
   }
 
   // Level geometry only (collision layer 1): another player below isn't a shelf.

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -1,0 +1,36 @@
+# Controls
+
+Every weapon uses the same primary button: **left mouse** acts with whatever slot is selected (issue #164).
+
+| Input | Action |
+|---|---|
+| W A S D | Move |
+| Mouse | Look |
+| Left mouse | Use the selected weapon (see below) |
+| Right mouse | Unbound (reserved) |
+| 1 | Select fists (always available) |
+| 2 | Select laser (while held) |
+| 3 | Select banana launcher (while held) |
+| 4 | Select boomerang (while held) |
+| 5 | Select slingshot (while held) |
+| F | Full-auto ability (3 s burst, 15 s cooldown; requires the laser) |
+| Space | Jump |
+| Shift | Slide |
+| C | Crouch |
+| G | Dance |
+| B | Eat bread (one full heal per life) |
+| V | Toggle first-/third-person view |
+| Tab | Message history |
+| . | Music: thumbs up the current track |
+| , | Music: thumbs down (enough votes skip the track) |
+| Esc | Quit dialog |
+
+## Left mouse, per weapon
+
+| Selected weapon | Left mouse does |
+|---|---|
+| Fists (slot 1) | Punch |
+| Laser (slot 2) | Hold to charge, release to fire — the longer the charge, the stronger the bolt |
+| Banana launcher (slot 3) | Fire an arcing banana |
+| Boomerang (slot 4) | Throw; it curves back for the catch |
+| Slingshot (slot 5) | Hold to draw the band, release to sling a stone — drawn longer flies flatter, faster, & harder; a quick tap just relaxes the band |

--- a/project.godot
+++ b/project.godot
@@ -75,7 +75,7 @@ shoot={
 }
 punch={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":2,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":true,"double_click":false,"script":null)
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 ]
 }
 weapon_1={

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -31,6 +31,10 @@ public partial class PlaytestDriver : Node
   private int _boltsSpawned;
   private int _boomerangsSpawned;
   private int _stonesSpawned;
+  // The most recent stone & how far along +Z it got, sampled every frame (issue
+  // #163): the wall-block assert needs the flight path, not just the spawn count.
+  private SlingshotStone? _lastStone;
+  private float _lastStoneMaxZ = float.MinValue;
   private Player? _self;
   private Player Self => _self ??= _world.GetPlayers().First (player => player.IsMultiplayerAuthority());
   private MusicManager Music => _world.GetNode <MusicManager> ("MusicManager");
@@ -45,6 +49,7 @@ public partial class PlaytestDriver : Node
     _world.ChildEnteredTree += node => _boltsSpawned += node is LaserBolt ? 1 : 0;
     _world.ChildEnteredTree += node => _boomerangsSpawned += node is BoomerangProjectile ? 1 : 0;
     _world.ChildEnteredTree += node => _stonesSpawned += node is SlingshotStone ? 1 : 0;
+    _world.ChildEnteredTree += node => { if (node is SlingshotStone stone) TrackStone (stone); };
     var args = OS.GetCmdlineUserArgs();
     _role = ArgValue (args, "--playtest") ?? string.Empty;
     _address = ArgValue (args, "--address") ?? "127.0.0.1";
@@ -181,12 +186,14 @@ public partial class PlaytestDriver : Node
     var healthBeforePunch = victim.Health;
     await WaitUntil (() => ApproachedVictim (victim), 30, "walked into punch range of victim");
 
+    // Punch on LEFT click (issue #164): injected as real mouse-button events so the
+    // binding itself is under test, not just the action.
     for (var attempt = 0; attempt < 10 && victim.Health >= healthBeforePunch; ++attempt)
     {
       AimAt (victim.GlobalPosition + Vector3.Up);
-      PressAction ("punch");
+      PressLeftClick();
       await Task.Delay (80);
-      ReleaseAction ("punch");
+      ReleaseLeftClick();
       await Task.Delay (700);
     }
 
@@ -370,12 +377,45 @@ public partial class PlaytestDriver : Node
     for (var attempt = 0; attempt < 10 && _stonesSpawned == stonesBefore; ++attempt)
     {
       PressAction ("shoot");
-      await Task.Delay (600); // Hold to draw (#99); release slings the stone.
+      await Task.Delay (900); // Hold to draw (#99), past the minimum draw (#163); release slings the stone.
       ReleaseAction ("shoot");
       await Task.Delay (300);
     }
 
     Assert (_stonesSpawned > stonesBefore, "slingshot draw & release fired a stone (#99)");
+
+    // Fire-rate cap (#163): sub-minimum taps just relax the band - no stones.
+    await Task.Delay (800); // Let the previous shot's cooldown lapse so only the taps are under test.
+    var stonesBeforeSpam = _stonesSpawned;
+
+    for (var i = 0; i < 4; ++i)
+    {
+      PressAction ("shoot");
+      await Task.Delay (80);
+      ReleaseAction ("shoot");
+      await Task.Delay (120);
+    }
+
+    Assert (_stonesSpawned == stonesBeforeSpam, $"sub-minimum taps released no stones (#163), got {_stonesSpawned - stonesBeforeSpam}");
+
+    // Wall blocking (#163): point-blank into the spawn-room wall (the wall face is
+    // about as close as the muzzle offset from here), so the first-frame camera
+    // sweep is what stops the stone - it must never travel past the wall at z=6.
+    AimAt (new Vector3 (Self.GlobalPosition.X, 31.0f, 6.0f)); // Mid-height of the wall ahead.
+    var wallStone = await SlingAStone (drawMs: 1500, "wall-test stone (#163)");
+    await TryWaitUntil (() => !IsInstanceValid (wallStone) || !wallStone.IsInsideTree(), 5);
+    Assert (!IsInstanceValid (wallStone) || !wallStone.IsInsideTree(), "the wall stopped the stone (#163)");
+    Assert (_lastStoneMaxZ < 6.5f, $"stone never passed the wall at z=6 (#163), max z {_lastStoneMaxZ:0.00}");
+
+    // Long flight (#163): a full-draw stone lobbed high over the walls must still be
+    // flying seconds later & have covered real distance - no premature despawn.
+    var launchPosition = Self.GlobalPosition;
+    AimAt (Self.GetNode <Camera3D> ("Camera3D").GlobalPosition + new Vector3 (0.0f, 30.0f, 30.0f)); // ~45 degrees up, over the wall, away from everyone.
+    var flightStone = await SlingAStone (drawMs: 3000, "long-flight stone (#163)");
+    await Task.Delay (4000);
+    Assert (IsInstanceValid (flightStone) && flightStone.IsInsideTree(), "full-draw stone still flying after 4s (#163)");
+    var flightDistance = new Vector2 (flightStone.GlobalPosition.X - launchPosition.X, flightStone.GlobalPosition.Z - launchPosition.Z).Length();
+    Assert (flightDistance > 40.0f, $"full-draw stone covered real range (#163), got {flightDistance:0.0}m");
 
     // The toggle persists to the shared user settings (#119); restore the starting
     // view so a playtest run never flips the developer's real preference.
@@ -514,6 +554,43 @@ public partial class PlaytestDriver : Node
 
   private static void PressAction (string action) => Input.ParseInputEvent (new InputEventAction { Action = action, Pressed = true });
   private static void ReleaseAction (string action) => Input.ParseInputEvent (new InputEventAction { Action = action, Pressed = false });
+  // Real left-mouse events, not action injections (issue #164): punching must work
+  // through the actual left-click binding while fists are the selected weapon.
+  private static void PressLeftClick() => Input.ParseInputEvent (new InputEventMouseButton { ButtonIndex = MouseButton.Left, Pressed = true });
+  private static void ReleaseLeftClick() => Input.ParseInputEvent (new InputEventMouseButton { ButtonIndex = MouseButton.Left, Pressed = false });
+
+  // Draws (holding well past the minimum draw time, #163) & releases until a stone
+  // spawns; retries absorb CI physics-time dilation eating into the cooldown & draw.
+  private async Task <SlingshotStone> SlingAStone (int drawMs, string description)
+  {
+    for (var attempt = 0; attempt < 5; ++attempt)
+    {
+      _lastStone = null;
+      PressAction ("shoot");
+      await Task.Delay (drawMs);
+      ReleaseAction ("shoot");
+      await TryWaitUntil (() => _lastStone != null, 2);
+      if (_lastStone != null) return _lastStone;
+    }
+
+    throw new Exception ($"no stone spawned: {description}");
+  }
+
+  // Samples the newest stone's +Z progress every frame until it despawns (issue
+  // #163): flight paths outlive any 100ms poll, so the wall assert needs per-frame data.
+  private async void TrackStone (SlingshotStone stone)
+  {
+    _lastStone = stone;
+    _lastStoneMaxZ = float.MinValue;
+
+    // Stop sampling once a newer stone takes over, so an earlier stone still in
+    // flight can't pollute the newer stone's measurements.
+    while (_lastStone == stone && IsInstanceValid (stone) && stone.IsInsideTree() && IsInsideTree())
+    {
+      _lastStoneMaxZ = Mathf.Max (_lastStoneMaxZ, stone.GlobalPosition.Z);
+      await ToSignal (GetTree(), SceneTree.SignalName.ProcessFrame);
+    }
+  }
 
   private static void Assert (bool condition, string description)
   {


### PR DESCRIPTION
Weapons batch covering six issues.

## Slingshot rework (#163) — all seven items
1. **Fire-rate cap**: a new minimum draw time (0.2s) means a sub-minimum release just relaxes the band — no stone — & a 0.5s cooldown gates the next draw, so tap-spam does nothing.
2. **Range**: max draw speed raised 60 → 90, & stone gravity now scales down with draw (24 → 10 at full draw), so a full draw is a genuinely long, flat shot while taps stay lobbed.
3. **Lifetime**: stone lifetime doubled 6s → 12s — stones fly their full arc & only despawn on impact or well past relevance.
4. **Nocked stone**: the shared slingshot visual now carries a stone in a pouch, pulled back toward the eye with the draw.
5. **Band animation**: the band is now two halves running from the prong tips to the pouch; they stretch back with the draw & snap forward on release (draw pose 0). Pickups show the relaxed rest pose.
6. **Knockback**: audit confirmed the up-pop compounded — `ApplyKnockback`'s 0.3 vertical factor multiplied `KnockbackStrength * energy * scale` *and* stacked additively across rapid hits. Knockback is now a mostly-horizontal shove: it can never push upward speed past a modest cap (default 6 m/s), while an already-faster ascent (jump, rocket boost) keeps its own speed.
7. **Wall collision**: stones already swept per-frame, but the first sweep started at the muzzle — point-blank shots could spawn past thin geometry. The first frame now sweeps from the camera, the exact #112 laser-bolt pattern, verified at max draw speed in the playtest.

## Charge-cancel on weapon switch (#156)
Leaving the laser slot cancels the charge via `EnergyWeapon.ResetCharge()`: instant spin-down, energy reset, charging sound stopped, & the full-charge lock-in (#113) cleared; the x-ray reveal (#105) keys off `IsFullyCharged` & clears on its next poll. Implemented as a per-frame poll (mirroring the slingshot's `CancelSlingshotDraw` self-heal), so weapon switches, drops, boomerang theft, death, & respawn all cancel through one path.

## Punch on left click (#164)
Fists are slot 1, so primary fire now punches while fists are selected — consistent with every other slot's left-click-to-use. Right click is unbound (the `punch` action remains, now bound to left mouse; selection gates decide whether a click punches, charges the laser, slings, throws, or launches). `docs/CONTROLS.md` added with the full table & the README controls table updated.

## Grounded drops (#172)
`TryFindGround` treated the kill-boundary collider at y=-100 as a floor (it shares collision layer 1), leaving unreachable expiring pickups at y=-99. Hits below a sane minimum ground height (-50) now count as the void: the drop is skipped & the weapons return via the caps, as designed.

## Banana duplication audit (#154)
The audit found two real windows where the server's weapon count could dip & a reconcile pass could spawn a duplicate (full write-up on the issue):
- `SurrenderWeaponToBoomerang` & `OnBoomerangLost` cleared the replicated `HeldWeapon` *before* sending their escrow/release RPC — the flag-clear delta could beat the RPC to the server, briefly making the weapon neither held, nor a pickup, nor escrowed. Both now request before clearing, matching `DropHeldWeapon`'s documented order.
- Remote pickup awards & escrow deliveries weren't counted between the server's despawn/deliver & the collector's replicated `HeldWeapon` landing a round-trip later. The server now bridges that gap with pending-grant entries that count toward the caps until the flag shows (or a 3s timeout covers a mid-grant disconnect).

## Sfx polyphony (#182)
Rapid-retrigger combat sounds no longer cut their own tails: `MaxPolyphony` raised on punch hit/whiff/thud, hitmarker, damage, pickup chime, jump, & through-wall zap (6), the laser shot for full-auto bursts (6), the banana launcher thump (4), & the code-built slingshot stretch creak (4). Per-event one-shot 3D players (slingshot thwack, boomerang whoosh, banana explosion) spawn a fresh node per play & can't self-cut, so they're unchanged.

## Validation
- `dotnet build`: 0 errors, 0 warnings.
- Full multiplayer playtest (host + shooter + victim) passed, including the new phases: punch lands through the real left-click binding (injected `InputEventMouseButton`), sub-minimum slingshot taps release no stones, a point-blank stone is stopped by the spawn-room wall (never crosses it), & a full-draw stone is still flying after 4s having covered 264m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slingshots now support charged shots with draw-based speed and gravity, improved visuals, minimum draw time, and shot cooldowns.
  - Audio effects can overlap more naturally during rapid firing and stretching.
- **Bug Fixes**
  - Improved weapon pickup and boomerang delivery reliability.
  - Prevented projectiles from passing through nearby walls.
  - Stabilized laser charging and knockback behavior.
  - Prevented invalid ground pickups near arena boundaries.
- **Controls & Documentation**
  - Punching now uses left-click; right-click is reserved.
  - Updated controls documentation with slingshot timing and cooldown details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #154
Fixes #156
Fixes #163
Fixes #164
Fixes #172
Fixes #182