### PR TITLE
Crouch un-stick & hold setting, longer chainable slides, & the 5s death sequence

### DIFF
--- a/core/players/Player.Banana.cs
+++ b/core/players/Player.Banana.cs
@@ -120,6 +120,7 @@ public partial class Player
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
+    if (Fallen) return; // A body mid-death-sequence is scenery (issue #152).
     GD.Print ($"{DisplayName}: I was blasted by {firedByPlayerName}'s banana!");
     LastDamageKind = DamageKind.Banana; // Message context (issue #84).
     ApplyBananaStun(); // Flat 5s stun synced with the splatter overlay (issue #70).
@@ -191,6 +192,7 @@ public partial class Player
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
+    if (Fallen) return; // A body mid-death-sequence can't be launched (issue #152); a pre-death sticky still detonates on it harmlessly.
     var attackerId = Multiplayer.GetRemoteSenderId(); // Captured now - the RPC context is gone after the fuse.
     GD.Print ($"{DisplayName}: {firedByPlayerName}'s banana stuck to me!");
     ApplyBananaStun();

--- a/core/players/Player.Boomerang.cs
+++ b/core/players/Player.Boomerang.cs
@@ -94,6 +94,7 @@ public partial class Player
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
+    if (Fallen) return; // A body mid-death-sequence is scenery: nothing left to steal or hurt (issue #152).
     var throwerId = Multiplayer.GetRemoteSenderId();
     GD.Print ($"{DisplayName}: I was clipped by {thrownByPlayerName}'s boomerang!");
     LastDamageKind = DamageKind.Boomerang; // Message context (issue #84).

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -256,6 +256,7 @@ public partial class Player
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
+    if (Fallen) return; // A body mid-death-sequence is scenery (issue #152).
     GD.Print ($"{DisplayName}: I was hit by {shotByPlayerName}{(throughBarrier ? " through a barrier" : "")}!");
     // The fire mode travels with the hit (CodeRabbit on #96): a weak quick-tap
     // discharge must not be misread as full-auto by an energy threshold.
@@ -270,6 +271,7 @@ public partial class Player
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
+    if (Fallen) return; // A body mid-death-sequence is scenery (issue #152).
     GD.Print ($"{DisplayName}: I was punched by {punchedByPlayerName}!");
     LastDamageKind = DamageKind.Punch; // Message context (issue #84).
     // No punch sfx here (issue #82): the victim hears the damage sound via ApplyDamage.
@@ -313,6 +315,9 @@ public partial class Player
   // attacker id captured while the RPC context still existed (issue #83).
   private void ApplyDamageFrom (int attackerId, float energy, string attackerName, float knockbackScale, bool isSurvivableAtFullHealth = false, bool throughBarrier = false)
   {
+    // Already zapped out (issue #152): a body lying through its death sequence takes
+    // no further damage - late stickies, blasts, & punches land on scenery.
+    if (Fallen) return;
     // Difficulty damage handicap: lower-skill attackers hit higher-skill targets harder
     // (+50% per tier gap: Beginner->Intermediate 1.5x, Beginner->Expert 2x,
     // Intermediate->Expert 1.5x). Attacking downward is unchanged - the bigger health

--- a/core/players/Player.Death.cs
+++ b/core/players/Player.Death.cs
@@ -1,0 +1,75 @@
+using System.Threading.Tasks;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Death sequence (issue #152): a zapped-out body tips over (non-gory, lights-out
+// robot style) & lies at the death spot for DeathSequenceSeconds while the victim's
+// camera pulls back & up (Player.View.cs) & the HUD shows the death message with a
+// countdown (Hud.cs); then the usual auto-respawn (spawn armor included) runs.
+public partial class Player
+{
+  private const float FallOverSeconds = 0.7f;
+  private bool _fallen;
+  private Tween? _fallTween;
+
+  // Replicated like Sliding so every peer sees the fallen body at the death spot;
+  // synced ALWAYS for the same self-healing reason (issue #131), so ApplyFallen must
+  // stay idempotent per state.
+  [Export]
+  public bool Fallen
+  {
+    get => _fallen;
+    set
+    {
+      _fallen = value;
+      ApplyFallen();
+    }
+  }
+
+  // The authority's side of the sequence: lock input, drop the pose flags so every
+  // peer's restore helpers agree, & lie there until the respawn timer fires.
+  private async Task LieFallen()
+  {
+    Sliding = false;
+    Crouching = false;
+    Dancing = false;
+    Fallen = true;
+    SetInputEnabled (isEnabled: false);
+    EnterDeathView(); // Watch the aftermath from above (issue #152).
+    GD.Print ($"{DisplayName}: I'm down for {DeathSequenceSeconds}s...");
+    await ToSignal (GetTree().CreateTimer (DeathSequenceSeconds), SceneTreeTimer.SignalName.Timeout);
+    Fallen = false;
+    ExitDeathView();
+  }
+
+  // Runs on every peer via the replicated Fallen property; ALWAYS-mode sync re-fires
+  // the setter every tick, so start/stop exactly once per state flip (like Dancing).
+  private void ApplyFallen()
+  {
+    if (_mesh == null) return; // Pre-_Ready sync; the next ALWAYS tick re-applies.
+    if (_fallen && _fallTween == null) { StartFallAnimation(); return; }
+    if (!_fallen && _fallTween != null) StopFallAnimation();
+  }
+
+  // A powered-down robot tipping over: the mesh eases to its side at the death spot.
+  // Mesh only - no hitbox changes, the body is scenery until the respawn.
+  private void StartFallAnimation()
+  {
+    _danceTween?.Kill(); // A mid-dance death releases the mesh to the fall.
+    _danceTween = null;
+    _fallTween = CreateTween().SetParallel();
+    _fallTween.TweenProperty (_mesh, "rotation_degrees", new Vector3 (0.0f, 0.0f, 90.0f), FallOverSeconds).SetTrans (Tween.TransitionType.Quad).SetEase (Tween.EaseType.In);
+    _fallTween.TweenProperty (_mesh, "position", new Vector3 (0.0f, 0.5f, 0.0f), FallOverSeconds).SetTrans (Tween.TransitionType.Quad).SetEase (Tween.EaseType.In);
+    _fallTween.TweenProperty (_mesh, "scale", Vector3.One, FallOverSeconds);
+  }
+
+  // Same canonical restore helpers the dance & respawn reset audits rely on (issue #103).
+  private void StopFallAnimation()
+  {
+    _fallTween?.Kill();
+    _fallTween = null;
+    ApplySlidePose();
+    ApplyCrouchScale();
+  }
+}

--- a/core/players/Player.Death.cs
+++ b/core/players/Player.Death.cs
@@ -35,10 +35,14 @@ public partial class Player
     Crouching = false;
     Dancing = false;
     Fallen = true;
+    _slideJumpCarrying = false; // A corpse (& the next life) inherits no slide-jump momentum (issue #149).
     SetInputEnabled (isEnabled: false);
     EnterDeathView(); // Watch the aftermath from above (issue #152).
     GD.Print ($"{DisplayName}: I'm down for {DeathSequenceSeconds}s...");
     await ToSignal (GetTree().CreateTimer (DeathSequenceSeconds), SceneTreeTimer.SignalName.Timeout);
+    // A disconnect can free this node mid-wait (CodeRabbit on #185): never touch
+    // disposed children after the await, same as the sticky-banana fuse.
+    if (!IsInstanceValid (this) || !IsInsideTree()) return;
     Fallen = false;
     ExitDeathView();
   }

--- a/core/players/Player.Death.cs.uid
+++ b/core/players/Player.Death.cs.uid
@@ -1,0 +1,1 @@
+uid://ck080ubhh20u2

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -160,12 +160,17 @@ public partial class Player
     if (Dancing) return;
     if (Fallen) return; // Same for the death tip-over tween (issue #152).
     var rotation = Sliding ? new Vector3 (-90.0f, 0.0f, 0.0f) : Vector3.Zero;
-    var position = new Vector3 (0.0f, Sliding ? 0.5f : _crouching ? CrouchHeightScale : 1.0f, 0.0f);
+    var position = BodyPoseOffset();
     _mesh.RotationDegrees = rotation;
     _mesh.Position = position;
     _collisionShape.RotationDegrees = rotation;
     _collisionShape.Position = position;
   }
+
+  // Where the mesh & collision nodes sit for the current stance: slide-height while
+  // sliding, dropped to keep the FEET planted while crouched (issue #171), standing
+  // center otherwise. Shared by both pose helpers so they can never disagree.
+  private Vector3 BodyPoseOffset() => new(0.0f, Sliding ? 0.5f : _crouching ? CrouchHeightScale : 1.0f, 0.0f);
 
   // Runs on every peer via the replicated Crouching property. The shape scales about
   // its center, so the node also drops to keep the FEET planted (issue #171): the old
@@ -177,7 +182,7 @@ public partial class Player
     if (Dancing) return; // Same ALWAYS-sync reason as ApplySlidePose (issue #103).
     if (Fallen) return; // The death tip-over tween owns the mesh (issue #152).
     var scale = new Vector3 (1.0f, _crouching ? CrouchHeightScale : 1.0f, 1.0f);
-    var position = new Vector3 (0.0f, Sliding ? 0.5f : _crouching ? CrouchHeightScale : 1.0f, 0.0f);
+    var position = BodyPoseOffset();
     _mesh.Scale = scale;
     _mesh.Position = position;
     _collisionShape.Scale = scale;
@@ -237,6 +242,9 @@ public partial class Player
     DropAllHeldWeapons(); // Death drops everything carried at the death spot (issue #72).
     EmitSignal (SignalName.RespawnedShot, DisplayName, shotByPlayerName); // Message shows during the wait (issue #152).
     await LieFallen();
+    // A disconnect can free this node mid-lie-down (CodeRabbit on #185): a freed
+    // node has nothing left to respawn.
+    if (!IsInstanceValid (this) || !IsInsideTree()) return;
     Respawn();
   }
 
@@ -306,6 +314,7 @@ public partial class Player
     _respawnSound.Play();
     GD.Print ($"{DisplayName}: I respawned!");
     await ToSignal (GetTree().CreateTimer (RespawnInputLockSeconds), SceneTreeTimer.SignalName.Timeout);
+    if (!IsInstanceValid (this) || !IsInsideTree()) return; // Same disconnect guard as the death sequence (CodeRabbit on #185).
     SetInputEnabled (isEnabled: true);
   }
 

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -19,6 +19,8 @@ public partial class Player
   // 0..1 for the HUD's slide cooldown bar, like PunchReadyFraction (issue #127).
   // Non-positive cooldown = always ready; clamped so the HUD bar never sees NaN or overshoot.
   public float SlideReadyFraction => SlideCooldownSeconds <= 0.0f ? 1.0f : Mathf.Clamp (1.0f - _slideCooldownLeft / SlideCooldownSeconds, 0.0f, 1.0f);
+  // Playtest-observable (issue #149): the current slide's speed - base, or higher when chained.
+  public float CurrentSlideSpeed => _currentSlideSpeed;
   private bool IsFalling() => !IsOnFloor();
   // Stun blocks jumping & sliding (issues #70 & #71).
   private bool IsJumping() => _isInputEnabled && !IsStunned && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
@@ -27,22 +29,29 @@ public partial class Player
   // Edge-triggered start (issue #131): a wedged pressed key state (e.g. a swallowed
   // Shift release on focus loss) can't auto-restart slides after every cooldown.
   private bool StartsSlide() => _isInputEnabled && !IsStunned && Input.IsActionJustPressed ("slide");
-  // Escape hatches (issue #131): while sliding, a fresh slide press always cancels, &
-  // a jump press cancels when there's room to stand; crouch cancels in UpdateCrouch.
-  private bool CanceledSlide() => _isInputEnabled && (Input.IsActionJustPressed ("slide") || (Input.IsActionJustPressed ("jump") && !IsOverheadBlocked()));
+  // Escape hatch (issue #131): while sliding, a fresh slide press always cancels;
+  // crouch cancels in UpdateCrouch & jump chains via SlideJump (issue #149).
+  private bool CanceledSlide() => _isInputEnabled && Input.IsActionJustPressed ("slide");
+  // Mirrors IsJumping plus the room-to-stand check (issue #149): the same press that
+  // makes Jump() fire this frame also ends the slide with its momentum & no cooldown.
+  private bool StartsSlideJump() => _isInputEnabled && !IsStunned && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor() && !IsOverheadBlocked();
   private bool ToggledCrouch() => _isInputEnabled && Input.IsActionJustPressed ("crouch");
-  private float MoveSpeed() => (Sliding ? Speed * SlideSpeedMultiplier : _crouching ? Speed * CrouchSpeedMultiplier : Speed) * StunSpeedMultiplier();
+  private float MoveSpeed() => (Sliding ? _currentSlideSpeed : _crouching ? Speed * CrouchSpeedMultiplier : Speed) * StunSpeedMultiplier();
 
   // Press to slide, hold to sustain: double speed & a horizontal pose, capped at
   // SlideDurationSeconds, then a cooldown before the next slide (see issue #41).
-  // Slide, crouch, & jump presses all cancel a slide mid-way (issue #131).
+  // Slide & crouch presses cancel a slide mid-way (issue #131); a jump press
+  // slide-jumps out with momentum & no cooldown (issue #149).
   private void UpdateSlide (double delta)
   {
     _slideCooldownLeft = Mathf.Max (0.0f, _slideCooldownLeft - (float)delta);
+    _slideChainWindowLeft = Mathf.Max (0.0f, _slideChainWindowLeft - (float)delta);
+    if (_slideJumpCarrying && IsOnFloor() && Velocity.Y <= 0.0f) LandSlideJump();
 
     if (Sliding)
     {
       _slideSecondsLeft -= (float)delta;
+      if (StartsSlideJump()) { SlideJump(); return; }
       if (WantsSlide() && !CanceledSlide() && _slideSecondsLeft > 0.0f) return;
       StopSlide();
       return;
@@ -55,25 +64,57 @@ public partial class Player
   private void StartSlide()
   {
     _slideSecondsLeft = SlideDurationSeconds;
+    _currentSlideSpeed = ChainedSlideSpeed();
     Sliding = true; // Setter re-poses the body; replicated so every peer sees it.
     ApplyCameraHeight();
+  }
+
+  // A slide chained within the landing window continues from the carried speed with
+  // a small boost (issue #149), capped so back-to-back chains can't diverge. The
+  // window counts physics time, immune to CI wall-clock dilation.
+  private float ChainedSlideSpeed()
+  {
+    var baseSpeed = Speed * SlideSpeedMultiplier;
+    if (_slideChainWindowLeft <= 0.0f) return baseSpeed;
+    return Mathf.Clamp (_slideChainLandingSpeed * SlideChainBoostMultiplier, baseSpeed, baseSpeed * MaxChainedSlideSpeedScale);
+  }
+
+  // Jumping out of a slide (issue #149): the air keeps the slide's momentum (see
+  // Move) & the cooldown is skipped entirely, so landing into another slide chains.
+  private void SlideJump()
+  {
+    Sliding = false;
+    _slideJumpCarrying = true;
+    ApplyCameraHeight();
+  }
+
+  // Touchdown ends the momentum carry & opens the chain window (issue #149).
+  private void LandSlideJump()
+  {
+    _slideJumpCarrying = false;
+    _slideChainWindowLeft = SlideChainWindowSeconds;
+    _slideChainLandingSpeed = new Vector3 (Velocity.X, 0.0f, Velocity.Z).Length();
   }
 
   private void StopSlide()
   {
     _slideCooldownLeft = SlideCooldownSeconds;
     Sliding = false;
-    if (IsOverheadBlocked()) Crouching = true; // Slid under something low: come up into a crouch, not the ceiling.
+    // Timer expiry & cancels end STANDING when there's room (issue #150); only a low
+    // ceiling forces the crouch so the head can't come up into it.
+    if (IsOverheadBlocked()) Crouching = true;
     ApplyCameraHeight();
   }
 
-  // Press C to crouch, press again to stand (issue #85): shorter profile & slower
-  // speed (see issue #51). Sliding cancels a crouch; a crouch press mid-slide cancels
-  // the slide into a crouch (issue #131); standing needs overhead clearance so the
-  // head can't clip into geometry above.
+  // Press C to crouch, press again to stand (issue #85) - or hold-to-crouch when the
+  // persisted setting says so (issue #147): shorter profile & slower speed (see issue
+  // #51). Sliding cancels a crouch; a crouch press mid-slide cancels the slide into a
+  // crouch (issue #131); standing needs overhead clearance so the head can't clip
+  // into geometry above.
   private void UpdateCrouch()
   {
     if (Sliding && _crouching) { Crouching = false; ApplyCameraHeight(); return; }
+    if (_holdToCrouch) { UpdateHeldCrouch(); return; }
     if (!ToggledCrouch()) return;
     if (Sliding) { StopSlide(); Crouching = true; ApplyCameraHeight(); return; }
     if (_crouching && IsOverheadBlocked()) return;
@@ -81,10 +122,30 @@ public partial class Player
     ApplyCameraHeight();
   }
 
+  // Hold mode (issue #147): crouched exactly while the key is held. The crouch-press
+  // slide cancel (issue #131) still applies; standing on release re-tries every frame
+  // until there's overhead room, so walking out from under a ledge stands you up.
+  private void UpdateHeldCrouch()
+  {
+    if (Sliding && ToggledCrouch()) { StopSlide(); Crouching = true; ApplyCameraHeight(); return; }
+    if (Sliding) return;
+    var wantsCrouch = _isInputEnabled && Input.IsActionPressed ("crouch");
+    if (wantsCrouch == _crouching) return;
+    if (!wantsCrouch && IsOverheadBlocked()) return;
+    Crouching = wantsCrouch;
+    ApplyCameraHeight();
+  }
+
+  // Root cause of issues #171 & #150: this ray used to start at the body ORIGIN,
+  // which the old crouch scale sank ~0.4m below the floor surface - under the
+  // paper-thin ground slab the upward ray then hit the slab's underside, reporting
+  // "blocked" everywhere, wedging the crouch toggle down & crouching every expired
+  // slide. Starting the probe above any possible floor-clip keeps it honest; real
+  // ceilings that matter sit well above 0.5m.
   private bool IsOverheadBlocked()
   {
-    var from = GlobalPosition;
-    var to = from + Vector3.Up * 2.1f; // Standing capsule head height + margin.
+    var from = GlobalPosition + Vector3.Up * 0.5f;
+    var to = GlobalPosition + Vector3.Up * 2.1f; // Standing capsule head height + margin.
     var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { GetRid() });
     return GetWorld3D().DirectSpaceState.IntersectRay (query).Count > 0;
   }
@@ -97,22 +158,30 @@ public partial class Player
     // The dance owns the mesh (issue #103): Sliding syncs ALWAYS, so this re-runs
     // every tick on puppets & would fight the dance tween; the dance's stop restores.
     if (Dancing) return;
+    if (Fallen) return; // Same for the death tip-over tween (issue #152).
     var rotation = Sliding ? new Vector3 (-90.0f, 0.0f, 0.0f) : Vector3.Zero;
-    var position = new Vector3 (0.0f, Sliding ? 0.5f : 1.0f, 0.0f);
+    var position = new Vector3 (0.0f, Sliding ? 0.5f : _crouching ? CrouchHeightScale : 1.0f, 0.0f);
     _mesh.RotationDegrees = rotation;
     _mesh.Position = position;
     _collisionShape.RotationDegrees = rotation;
     _collisionShape.Position = position;
   }
 
-  // Runs on every peer via the replicated Crouching property.
+  // Runs on every peer via the replicated Crouching property. The shape scales about
+  // its center, so the node also drops to keep the FEET planted (issue #171): the old
+  // center-scale lifted the shape bottom & sank the whole body ~0.4m into the floor,
+  // which broke the overhead probe (see IsOverheadBlocked).
   private void ApplyCrouchScale()
   {
     if (_mesh == null) return;
     if (Dancing) return; // Same ALWAYS-sync reason as ApplySlidePose (issue #103).
+    if (Fallen) return; // The death tip-over tween owns the mesh (issue #152).
     var scale = new Vector3 (1.0f, _crouching ? CrouchHeightScale : 1.0f, 1.0f);
+    var position = new Vector3 (0.0f, Sliding ? 0.5f : _crouching ? CrouchHeightScale : 1.0f, 0.0f);
     _mesh.Scale = scale;
+    _mesh.Position = position;
     _collisionShape.Scale = scale;
+    _collisionShape.Position = position;
   }
 
   private void ApplyCameraHeight()
@@ -131,6 +200,7 @@ public partial class Player
   private void Move (ref Vector3 velocity)
   {
     if (_stickyFlightSecondsLeft > 0.0f) return; // Banana-launched (issue #83): momentum owns the ride.
+    if (_slideJumpCarrying) return; // Slide-jump air (issue #149): the slide's momentum owns the ride until touchdown.
     var speed = MoveSpeed();
     var inputDir = Input.GetVector ("move_left", "move_right", "move_forward", "move_back");
     var inputDirection = (Transform.Basis * new Vector3 (inputDir.X, 0, inputDir.Y)).Normalized();
@@ -158,12 +228,16 @@ public partial class Player
     RespawnFell();
   }
 
-  private void RespawnShot (string shotByPlayerName)
+  // Zap-out deaths run the lie-down sequence (issue #152): weapon drops & the death
+  // message resolve at death time as before, then the body lies at the death spot
+  // for DeathSequenceSeconds before the usual respawn (spawn armor included).
+  private async void RespawnShot (string shotByPlayerName)
   {
     CaptureDeathSnapshot();
     DropAllHeldWeapons(); // Death drops everything carried at the death spot (issue #72).
+    EmitSignal (SignalName.RespawnedShot, DisplayName, shotByPlayerName); // Message shows during the wait (issue #152).
+    await LieFallen();
     Respawn();
-    EmitSignal (SignalName.RespawnedShot, DisplayName, shotByPlayerName);
   }
 
   private void CaptureDeathSnapshot()
@@ -198,6 +272,7 @@ public partial class Player
 
   private void RespawnFell()
   {
+    if (Fallen) return; // A dead body drifting past the boundary mid-lie-down already has a respawn scheduled (issue #152).
     --Score; // Falling off the world costs a point.
     ClearHeldWeapons(); // A drop below the world would be unreachable; the weapons respawn at spawn points instead (issue #72).
     Respawn();
@@ -221,8 +296,11 @@ public partial class Player
     Sliding = false;
     _slideSecondsLeft = 0.0f;
     _slideCooldownLeft = 0.0f;
+    _slideJumpCarrying = false; // No chain carry into a new life (issue #149).
+    _slideChainWindowLeft = 0.0f;
     Crouching = false;
     Dancing = false; // A new life starts with the pose fully restored on every peer (issue #103).
+    Fallen = false; // Belt & braces: the lie-down always ends before this runs (issue #152).
     ApplyCameraHeight();
     SetInputEnabled (isEnabled: false);
     _respawnSound.Play();

--- a/core/players/Player.View.cs
+++ b/core/players/Player.View.cs
@@ -12,14 +12,20 @@ public partial class Player
 {
   [Export] public float ThirdPersonBackMeters = 2.8f;
   [Export] public float ThirdPersonUpMeters = 1.2f;
+  // Death view (issue #152): a wider pull-back over the death spot than the chase view.
+  [Export] public float DeathViewBackMeters = 6.0f;
+  [Export] public float DeathViewUpMeters = 3.0f;
   // The crosshair sprite sits 10m down the aim ray (Player.tscn); the chase camera
   // pitches down just enough to keep it centered on screen.
   private const float CrosshairDistanceMeters = 10.0f;
   private bool _thirdPerson;
+  private bool _deathView;
   private SpringArm3D? _thirdPersonArm;
   private Camera3D? _thirdPersonCamera;
   // The playtest toggles mid-run & asserts bolts still spawn (issue #119).
   public bool IsThirdPerson => _thirdPerson;
+  // The playtest asserts the death camera goes live during the lie-down (issue #152).
+  public bool IsDeathViewActive => _deathView && _thirdPersonCamera is { Current: true };
 
   private void ApplySavedViewPreference()
   {
@@ -53,8 +59,41 @@ public partial class Player
     _thirdPersonArm = new SpringArm3D { Position = new Vector3 (0.0f, ThirdPersonUpMeters, 0.0f), SpringLength = ThirdPersonBackMeters, CollisionMask = 1, Margin = 0.3f };
     _thirdPersonArm.AddExcludedObject (GetRid());
     _camera.AddChild (_thirdPersonArm);
-    var pitch = -Mathf.Atan (ThirdPersonUpMeters / (ThirdPersonBackMeters + CrosshairDistanceMeters));
-    _thirdPersonCamera = new Camera3D { Rotation = new Vector3 (pitch, 0.0f, 0.0f) };
+    _thirdPersonCamera = new Camera3D { Rotation = new Vector3 (ChaseViewPitch(), 0.0f, 0.0f) };
     _thirdPersonArm.AddChild (_thirdPersonCamera);
+  }
+
+  private float ChaseViewPitch() => -Mathf.Atan (ThirdPersonUpMeters / (ThirdPersonBackMeters + CrosshairDistanceMeters));
+
+  // Death view (issue #152): the same spring-arm rig from #119, stretched back & up
+  // over the death spot so the victim can watch their killer emote on the body.
+  private void EnterDeathView()
+  {
+    if (_thirdPersonCamera == null) CreateThirdPersonRig();
+    _deathView = true;
+    _thirdPersonArm!.Position = new Vector3 (0.0f, DeathViewUpMeters, 0.0f);
+    _thirdPersonArm.SpringLength = DeathViewBackMeters;
+    SetFirstPersonOverlayEnabled (enabled: false); // Own weapons must not ghost over the scene from up here.
+    _thirdPersonCamera!.Current = true;
+  }
+
+  // Keeps the fallen body framed however the head was aimed at death; runs only
+  // during the lie-down (issue #152).
+  private void UpdateDeathView()
+  {
+    if (!_deathView) return;
+    var target = GlobalPosition + Vector3.Up * 0.5f;
+    if (target.IsEqualApprox (_thirdPersonCamera!.GlobalPosition)) return;
+    _thirdPersonCamera.LookAt (target, Vector3.Up);
+  }
+
+  // Respawn restores whichever view the player had chosen (issue #119).
+  private void ExitDeathView()
+  {
+    _deathView = false;
+    _thirdPersonArm!.Position = new Vector3 (0.0f, ThirdPersonUpMeters, 0.0f);
+    _thirdPersonArm.SpringLength = ThirdPersonBackMeters;
+    _thirdPersonCamera!.Rotation = new Vector3 (ChaseViewPitch(), 0.0f, 0.0f);
+    SetThirdPerson (_thirdPerson);
   }
 }

--- a/core/players/Player.View.cs
+++ b/core/players/Player.View.cs
@@ -83,7 +83,10 @@ public partial class Player
   {
     if (!_deathView) return;
     var target = GlobalPosition + Vector3.Up * 0.5f;
-    if (target.IsEqualApprox (_thirdPersonCamera!.GlobalPosition)) return;
+    var toTarget = target - _thirdPersonCamera!.GlobalPosition;
+    // A collapsed spring arm can leave the camera directly above the body; a
+    // near-vertical LookAt has no valid up & spams warnings (CodeRabbit on #185).
+    if (toTarget.IsZeroApprox() || toTarget.Cross (Vector3.Up).IsZeroApprox()) return;
     _thirdPersonCamera.LookAt (target, Vector3.Up);
   }
 

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -209,8 +209,18 @@ public partial class Player : CharacterBody3D
   [Export] public float CameraKickRecoverySpeed = 0.4f;
   [Export] public float Speed = 7.0f;
   [Export] public float SlideSpeedMultiplier = 2.0f;
-  [Export] public float SlideDurationSeconds = 5.0f;
+  // 5s -> 7s (issue #148): the duration cap is what actually ends a held slide -
+  // slide speed never decays - so longer simply means farther.
+  [Export] public float SlideDurationSeconds = 7.0f;
   [Export] public float SlideCooldownSeconds = 5.0f;
+  // Slide-jump chaining (issue #149): each slide chained inside the landing window
+  // carries its landing speed boosted by this much, capped at the scale below
+  // (2x base slide speed) so chains build real speed but can't diverge.
+  [Export] public float SlideChainBoostMultiplier = 1.15f;
+  [Export] public float MaxChainedSlideSpeedScale = 2.0f;
+  [Export] public float SlideChainWindowSeconds = 0.5f;
+  // How long a zapped-out body lies at the death spot before auto-respawning (issue #152).
+  [Export] public float DeathSequenceSeconds = 5.0f;
   [Export] public float SlideCameraHeight = 0.6f;
   [Export] public float CrouchHeightScale = 0.6f;
   [Export] public float CrouchSpeedMultiplier = 0.3f;
@@ -251,6 +261,13 @@ public partial class Player : CharacterBody3D
   private OmniLight3D _streakLight = null!;
   private float _slideSecondsLeft;
   private float _slideCooldownLeft;
+  // Current slide's speed (issue #149): base 2x, or higher when chained.
+  private float _currentSlideSpeed;
+  private bool _slideJumpCarrying;
+  private float _slideChainWindowLeft;
+  private float _slideChainLandingSpeed;
+  // Crouch mode (issue #147): cached from Settings so hold mode never reads disk per frame.
+  private bool _holdToCrouch;
   private float _standingCameraHeight;
   private CollisionShape3D _collisionShape = null!;
   private NetworkManager _networkManager = null!;
@@ -295,6 +312,8 @@ public partial class Player : CharacterBody3D
   public static Player? Local => _localPlayer;
   public override void _EnterTree() => SetMultiplayerAuthority (NetworkId);
   public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
+  // Re-reads the persisted crouch mode (issue #147); the pause-dialog toggle calls this.
+  public void RefreshCrouchMode() => _holdToCrouch = Settings.HoldToCrouch;
   // Guards against "The multiplayer instance isn't currently active" error spam from
   // IsMultiplayerAuthority() after the session ends but before player nodes are freed (see issue #22).
   private bool IsMultiplayerActive() => Multiplayer.MultiplayerPeer != null && Multiplayer.MultiplayerPeer.GetConnectionStatus() == MultiplayerPeer.ConnectionStatus.Connected;
@@ -360,6 +379,7 @@ public partial class Player : CharacterBody3D
     _camera.Current = true;
     _standingCameraHeight = _camera.Position.Y;
     _isInputEnabled = true;
+    _holdToCrouch = Settings.HoldToCrouch; // Toggle-vs-hold crouch preference (issue #147).
     Input.MouseMode = Input.MouseModeEnum.Captured;
     Position = CalculateRandomSpawnPosition();
     ActivateSpawnArmor();
@@ -401,6 +421,7 @@ public partial class Player : CharacterBody3D
     UpdateStickyFlight (delta);
     UpdateCameraKick (delta);
     UpdateCameraShake (delta);
+    UpdateDeathView(); // Keeps the fallen body framed during the lie-down (issue #152).
     UpdateStun (delta);
     UpdateSlide (delta);
     UpdateCrouch();

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -111,6 +111,9 @@ properties/17/replication_mode = 2
 properties/18/path = NodePath(".:Dancing")
 properties/18/spawn = true
 properties/18/replication_mode = 1
+properties/19/path = NodePath(".:Fallen")
+properties/19/spawn = true
+properties/19/replication_mode = 1
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using com.forerunnergames.energyshot.core.audio;
 using com.forerunnergames.energyshot.core.world;
 using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.utilities;
 using com.forerunnergames.energyshot.weapons;
 using Godot;
 
@@ -15,7 +16,7 @@ namespace com.forerunnergames.energyshot.playtest;
 // Activated by launching with: godot --headless --path . -- --playtest <role> [--address a] [--port n]
 public partial class PlaytestDriver : Node
 {
-  private const int Port = 55599;
+  private const int DefaultPort = 55599;
   // Fixed, deterministic game password (issue #90): exercises the server-side check.
   private const string Password = "playtest-secret";
   private const string HostName = "Host";
@@ -28,6 +29,8 @@ public partial class PlaytestDriver : Node
   private World _world = null!;
   private string _role = string.Empty;
   private string _address = "127.0.0.1";
+  // Overridable so parallel local runs don't collide on one port (--port n).
+  private int _port = DefaultPort;
   private int _boltsSpawned;
   private int _boomerangsSpawned;
   private int _stonesSpawned;
@@ -48,6 +51,7 @@ public partial class PlaytestDriver : Node
     var args = OS.GetCmdlineUserArgs();
     _role = ArgValue (args, "--playtest") ?? string.Empty;
     _address = ArgValue (args, "--address") ?? "127.0.0.1";
+    _port = int.TryParse (ArgValue (args, "--port"), out var port) ? port : DefaultPort;
     GD.Print ($"PLAYTEST: starting role [{_role}]");
     RunScenario();
   }
@@ -100,7 +104,7 @@ public partial class PlaytestDriver : Node
 
   private async Task RunHost()
   {
-    _world.StartHostSession (HostName, difficulty: 2, Port, Password, HostColor);
+    _world.StartHostSession (HostName, difficulty: 2, _port, Password, HostColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players joined");
     // Chosen body colors (issue #43): own pick stuck & both clients' picks replicate to the host.
     Assert (Self.ColorIndex == HostColor, $"own chosen color is {HostColor}, got {Self.ColorIndex}");
@@ -116,8 +120,8 @@ public partial class PlaytestDriver : Node
     // Shooter kills victim once (plus possibly the host itself in the line of
     // fire); wait to observe the replicated score.
     await WaitUntil (() => FindPlayer (ShooterName)?.Score >= 1, 120, "shooter's kill replicated to host");
-    // Victim respawns with armor visible to the host too.
-    await WaitUntil (() => FindPlayer (VictimName)?.SpawnArmor == true, 30, "victim respawn armor replicated to host");
+    // Victim respawns with armor visible to the host too (~5s later now, #152).
+    await WaitUntil (() => FindPlayer (VictimName)?.SpawnArmor == true, 35, "victim respawn armor replicated to host");
     // The victim's fall at score 0 goes negative & replicates (issue #108).
     await WaitUntil (() => FindPlayer (VictimName)?.Score == -1, 60, "victim's fall penalty (-1) replicated to host");
     // Stay up until both clients have finished & disconnected.
@@ -126,7 +130,7 @@ public partial class PlaytestDriver : Node
 
   private async Task RunShooter()
   {
-    _world.StartClientSession (ShooterName, difficulty: 1, _address, Port, Password, ShooterColor);
+    _world.StartClientSession (ShooterName, difficulty: 1, _address, _port, Password, ShooterColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
     // DisplayName is an on-change sync that can land a beat after the spawn itself
     // under CI load (issue #78): wait for both names before dereferencing the
@@ -180,6 +184,14 @@ public partial class PlaytestDriver : Node
     ReleaseAction ("weapon_1");
     var healthBeforePunch = victim.Health;
     await WaitUntil (() => ApproachedVictim (victim), 30, "walked into punch range of victim");
+
+    // Punch from the side of the victim opposite the idle host: the punch ray hits
+    // the FIRST body, & an unlucky spawn once put the host in front of the victim
+    // for all 10 attempts (same line-of-fire hazard the laser phase guards against).
+    var awayFromHost = victim.GlobalPosition - host.GlobalPosition;
+    var flatAway = new Vector3 (awayFromHost.X, 0.0f, awayFromHost.Z);
+    Self.Position = victim.GlobalPosition + (flatAway.Length() > 0.5f ? flatAway.Normalized() : Vector3.Right) * 1.5f;
+    await Task.Delay (200);
 
     for (var attempt = 0; attempt < 10 && victim.Health >= healthBeforePunch; ++attempt)
     {
@@ -249,8 +261,13 @@ public partial class PlaytestDriver : Node
     // >= 1: an incidental one-hit kill on the host in the line of fire also scores.
     Assert (Self.Score >= 1, $"own replicated Score is >= 1, got {Self.Score}");
 
-    // Victim must come back armored in the spawn room.
-    await WaitUntil (() => respawnArmorSeen, 15, "victim respawned with spawn armor");
+    // Death sequence (#152): the victim's body lies fallen at the death spot &
+    // the replicated Fallen state must render the tip-over on this peer too.
+    await WaitUntil (() => victim.Fallen, 10, "victim's fallen body replicated to shooter (#152)");
+
+    // Victim must come back armored in the spawn room (~5s later now, #152).
+    await WaitUntil (() => respawnArmorSeen, 20, "victim respawned with spawn armor");
+    await WaitUntil (() => !victim.Fallen, 5, "victim's body stood back up on respawn (#152)");
 
     // Streak glow bug (#88): the kill ended the victim's streak; the reset must
     // replicate here so the glow & pulsing leaderboard entry clear.
@@ -330,6 +347,8 @@ public partial class PlaytestDriver : Node
     Input.ActionRelease ("move_forward");
     await WaitUntil (() => !Self.Dancing, 5, "moving canceled the dance (#103)");
 
+    await RunMovementBatchPhases();
+
     // Boomerang (#98): collect the deterministic spawn-room pickup, throw it (aimed
     // away from everyone so no incidental steals), & watch it fly back into the hand.
     await WaitUntil (() => WalkedTo (WeaponSpawner.PlaytestBoomerangPosition), 45, "walked to the playtest boomerang pickup");
@@ -382,6 +401,91 @@ public partial class PlaytestDriver : Node
     await ToggleViewUntil (startedThirdPerson);
   }
 
+  // Movement & death-feel batch (#171/#147/#148/#149/#150): crouch un-stick, the
+  // hold-to-crouch setting, slide-jump chaining, & standing slide expiry. Runs on
+  // the open arena ground - the paper-thin slab is the exact surface the #171
+  // regression wedged on - then returns to the spawn room for the pickup phases
+  // (teleport precedent: the victim's fall-penalty phase).
+  private async Task RunMovementBatchPhases()
+  {
+    Self.Position = new Vector3 (40.0f, 1.0f, -40.0f); // Open corner: no buildings, pillars, or platforms nearby.
+    await Task.Delay (300); // Settle onto the ground.
+
+    // Crouch un-stick (#171): a plain toggle on the thin arena ground must go down
+    // AND back up, with the feet staying planted - the old center-scale sank the
+    // body ~0.4m, so the overhead probe started under the slab, saw its underside,
+    // & wedged the toggle down.
+    var yBeforeCrouch = Self.GlobalPosition.Y;
+    PressAction ("crouch");
+    await Task.Delay (100);
+    ReleaseAction ("crouch");
+    await WaitUntil (() => Self.Crouching, 5, "crouch toggled down (#171)");
+    await Task.Delay (400); // Give any (wrongly) sinking body time to sink before probing.
+    Assert (Mathf.Abs (Self.GlobalPosition.Y - yBeforeCrouch) < 0.2f, $"crouch kept the feet planted (#171), drifted {Self.GlobalPosition.Y - yBeforeCrouch:0.00}m");
+    PressAction ("crouch");
+    await Task.Delay (100);
+    ReleaseAction ("crouch");
+    await WaitUntil (() => !Self.Crouching, 5, "crouch toggled back up (#171)");
+
+    // Hold-to-crouch (#147): flip the persisted setting, hold = crouch, release =
+    // stand; the developer's real preference is restored afterward.
+    var startedHoldToCrouch = Settings.HoldToCrouch;
+    Settings.HoldToCrouch = true;
+    Self.RefreshCrouchMode();
+    PressAction ("crouch");
+    await WaitUntil (() => Self.Crouching, 5, "hold mode: crouched while held (#147)");
+    ReleaseAction ("crouch");
+    await WaitUntil (() => !Self.Crouching, 5, "hold mode: stood up on release (#147)");
+    Settings.HoldToCrouch = startedHoldToCrouch;
+    Self.RefreshCrouchMode();
+
+    // Slide-jump chaining (#149): jumping out of a slide keeps its momentum in the
+    // air & cancels the cooldown, so a slide pressed right after landing chains
+    // faster than base - capped so it can't diverge. Aimed down the open -X lane at
+    // z=-40: ~15m of travel with nothing to hit.
+    await WaitUntil (() => Self.SlideReadyFraction >= 1.0f, 15, "slide cooldown ready for the chain test (#149)");
+    AimAt (Self.GlobalPosition + new Vector3 (-20.0f, 0.0f, 0.0f));
+    Input.ActionPress ("move_forward"); // The carry needs real momentum.
+    PressAction ("slide");
+    await WaitUntil (() => Self.Sliding, 5, "slide started for the chain (#149)");
+    await Task.Delay (200);
+    PressAction ("jump");
+    await Task.Delay (100);
+    ReleaseAction ("jump");
+    await WaitUntil (() => !Self.Sliding, 2, "jump ended the slide (#149)");
+    ReleaseAction ("slide");
+    Assert (Self.SlideReadyFraction >= 1.0f, "slide-jump canceled the slide cooldown (#149)");
+    var airSpeed = new Vector3 (Self.Velocity.X, 0.0f, Self.Velocity.Z).Length();
+    Assert (airSpeed >= Self.Speed * Self.SlideSpeedMultiplier - 0.5f, $"slide momentum carried into the air (#149), speed {airSpeed:0.0}");
+    await WaitUntil (() => Self.IsOnFloor(), 5, "landed from the slide-jump (#149)");
+    PressAction ("slide");
+    await WaitUntil (() => Self.Sliding, 2, "chained slide started with no cooldown (#149)");
+    Assert (Self.CurrentSlideSpeed > Self.Speed * Self.SlideSpeedMultiplier + 0.1f, $"chained slide runs faster than base (#149), speed {Self.CurrentSlideSpeed:0.0}");
+    Assert (Self.CurrentSlideSpeed <= Self.Speed * Self.SlideSpeedMultiplier * Self.MaxChainedSlideSpeedScale + 0.01f, $"chained slide speed capped (#149), speed {Self.CurrentSlideSpeed:0.0}");
+    ReleaseAction ("slide");
+    Input.ActionRelease ("move_forward");
+    await WaitUntil (() => !Self.Sliding, 2, "chained slide released");
+
+    // Slide TIMER expiry (#148/#150): the lengthened slide runs its full duration &
+    // ends STANDING in the open - no more forced crouch on expiry. Stationary (no
+    // movement input): the timer & end pose don't need travel, & 7s at slide speed
+    // would cross most of the arena.
+    Assert (Self.SlideDurationSeconds >= 7.0f, $"slide duration lengthened (#148), got {Self.SlideDurationSeconds}s");
+    await WaitUntil (() => Self.SlideReadyFraction >= 1.0f, 15, "slide cooldown recovered for the expiry test (#150)");
+    PressAction ("slide");
+    await WaitUntil (() => Self.Sliding, 5, "slide started for the expiry test (#150)");
+    var slideStartMs = Time.GetTicksMsec();
+    await WaitUntil (() => !Self.Sliding, Self.SlideDurationSeconds + 5, "slide timer expired on its own (#148)");
+    var slideMs = Time.GetTicksMsec() - slideStartMs;
+    ReleaseAction ("slide");
+    Assert (slideMs >= 6000, $"slide lasted the lengthened duration (#148), got {slideMs}ms");
+    Assert (!Self.Crouching, "expired slide ended standing, not crouched (#150)");
+
+    // Back to the spawn room for the boomerang & slingshot pickup phases.
+    Self.Position = new Vector3 (0.0f, 31.0f, 0.0f);
+    await Task.Delay (300);
+  }
+
   // Presses V until the view matches; the toggle only persists on a real key press,
   // so this exercises the exact input path a player uses (#119).
   private async Task ToggleViewUntil (bool thirdPerson)
@@ -400,7 +504,7 @@ public partial class PlaytestDriver : Node
     // Password enforcement (issue #109): a wrong password must get kicked with
     // "Wrong password." before the real join succeeds.
     await AssertWrongPasswordIsKicked();
-    _world.StartClientSession (VictimName, difficulty: 0, _address, Port, Password, VictimColor);
+    _world.StartClientSession (VictimName, difficulty: 0, _address, _port, Password, VictimColor);
     await WaitUntil (() => _world.GetPlayers().Count() == 3, 60, "all 3 players visible");
     Assert (Self.MaxHealth == 400, $"own MaxHealth is Beginner 400, got {Self.MaxHealth}");
     // Chosen body colors (issue #43): own pick stuck & both peers' picks replicate to the victim.
@@ -430,7 +534,15 @@ public partial class PlaytestDriver : Node
     var partialLaserHits = 0;
     var healthAfterPunch = Self.Health;
     Self.HealthChanged += value => partialLaserHits += value > 0 && value < healthAfterPunch ? 1 : 0;
+    // Death sequence (#152): the kill drops us where we stand for ~DeathSequenceSeconds
+    // with the pulled-back death camera live, & only then the usual armored respawn.
+    await WaitUntil (() => Self.Fallen, 120, "own death started the lie-down (#152)");
+    var fallenStartMs = Time.GetTicksMsec();
+    Assert (Self.IsDeathViewActive, "death camera pulled back over the death spot (#152)");
     await WaitUntil (() => Self.SpawnArmor && Self.Health == Self.MaxHealth, 120, "died & respawned with armor & full health");
+    var lieDownMs = Time.GetTicksMsec() - fallenStartMs;
+    Assert (lieDownMs >= (ulong)(Self.DeathSequenceSeconds * 1000.0f) - 500, $"lay at the death spot ~{Self.DeathSequenceSeconds}s before respawning (#152), got {lieDownMs}ms");
+    Assert (!Self.Fallen && !Self.IsDeathViewActive, "respawn ended the lie-down & restored the normal view (#152)");
     Assert (partialLaserHits == 0, $"full-charge kill took exactly one hit (#93), saw {partialLaserHits} partial-damage hits");
     Assert (Self.GlobalPosition.Y > 20.0f, $"respawned up in the spawn room, y={Self.GlobalPosition.Y}");
     // >= 1: an incidental one-hit kill on the host in the line of fire also counts.
@@ -453,7 +565,7 @@ public partial class PlaytestDriver : Node
   {
     var kickReason = string.Empty;
     _world.KickedFromServer += reason => kickReason = reason;
-    _world.StartClientSession (VictimName, difficulty: 0, _address, Port, "wrong-" + Password);
+    _world.StartClientSession (VictimName, difficulty: 0, _address, _port, "wrong-" + Password);
     await WaitUntil (() => kickReason.Length > 0, 30, "wrong-password join was kicked");
     Assert (kickReason == "Wrong password.", $"kick reason is \"Wrong password.\", got \"{kickReason}\"");
     await WaitUntil (() => Multiplayer.MultiplayerPeer.GetConnectionStatus() != MultiplayerPeer.ConnectionStatus.Connected, 15, "kicked connection fully closed");

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -58,7 +58,9 @@ public partial class PlaytestDriver : Node
     var args = OS.GetCmdlineUserArgs();
     _role = ArgValue (args, "--playtest") ?? string.Empty;
     _address = ArgValue (args, "--address") ?? "127.0.0.1";
-    _port = int.TryParse (ArgValue (args, "--port"), out var port) ? port : DefaultPort;
+    // Sanity-check the override (CodeRabbit on #185): anything outside the sane
+    // unprivileged range falls back to the default instead of failing the bind.
+    _port = int.TryParse (ArgValue (args, "--port"), out var port) && port is >= 1024 and <= 65535 ? port : DefaultPort;
     GD.Print ($"PLAYTEST: starting role [{_role}]");
     RunScenario();
   }
@@ -441,6 +443,13 @@ public partial class PlaytestDriver : Node
     Self.Position = new Vector3 (40.0f, 1.0f, -40.0f); // Open corner: no buildings, pillars, or platforms nearby.
     await Task.Delay (300); // Settle onto the ground.
 
+    // The crouch phases must not depend on whatever crouch mode the developer's
+    // real settings.cfg persists (CodeRabbit on #185): force each mode explicitly
+    // & restore the real preference at the end.
+    var startedHoldToCrouch = Settings.HoldToCrouch;
+    Settings.HoldToCrouch = false;
+    Self.RefreshCrouchMode();
+
     // Crouch un-stick (#171): a plain toggle on the thin arena ground must go down
     // AND back up, with the feet staying planted - the old center-scale sank the
     // body ~0.4m, so the overhead probe started under the slab, saw its underside,
@@ -457,16 +466,14 @@ public partial class PlaytestDriver : Node
     ReleaseAction ("crouch");
     await WaitUntil (() => !Self.Crouching, 5, "crouch toggled back up (#171)");
 
-    // Hold-to-crouch (#147): flip the persisted setting, hold = crouch, release =
-    // stand; the developer's real preference is restored afterward.
-    var startedHoldToCrouch = Settings.HoldToCrouch;
+    // Hold-to-crouch (#147): switch to hold mode - hold = crouch, release = stand.
     Settings.HoldToCrouch = true;
     Self.RefreshCrouchMode();
     PressAction ("crouch");
     await WaitUntil (() => Self.Crouching, 5, "hold mode: crouched while held (#147)");
     ReleaseAction ("crouch");
     await WaitUntil (() => !Self.Crouching, 5, "hold mode: stood up on release (#147)");
-    Settings.HoldToCrouch = startedHoldToCrouch;
+    Settings.HoldToCrouch = startedHoldToCrouch; // The developer's real preference survives the run.
     Self.RefreshCrouchMode();
 
     // Slide-jump chaining (#149): jumping out of a slide keeps its momentum in the
@@ -495,6 +502,28 @@ public partial class PlaytestDriver : Node
     ReleaseAction ("slide");
     Input.ActionRelease ("move_forward");
     await WaitUntil (() => !Self.Sliding, 2, "chained slide released");
+
+    // Chain window expiry (#149): outliving the landing window forfeits the chain -
+    // the next slide runs at base speed again (CodeRabbit on #185).
+    await WaitUntil (() => Self.SlideReadyFraction >= 1.0f, 15, "slide cooldown ready for the window-expiry test (#149)");
+    AimAt (Self.GlobalPosition + new Vector3 (-20.0f, 0.0f, 0.0f)); // Same clear -X lane.
+    Input.ActionPress ("move_forward");
+    PressAction ("slide");
+    await WaitUntil (() => Self.Sliding, 5, "slide started for the window-expiry test (#149)");
+    await Task.Delay (200);
+    PressAction ("jump");
+    await Task.Delay (100);
+    ReleaseAction ("jump");
+    await WaitUntil (() => !Self.Sliding, 2, "jump ended the window-expiry slide (#149)");
+    ReleaseAction ("slide");
+    await WaitUntil (() => Self.IsOnFloor(), 5, "landed from the window-expiry slide-jump (#149)");
+    Input.ActionRelease ("move_forward");
+    await Task.Delay (2000); // Far past the 0.5s window; generous because it counts (slower) physics time.
+    PressAction ("slide");
+    await WaitUntil (() => Self.Sliding, 2, "post-window slide started (#149)");
+    Assert (Self.CurrentSlideSpeed <= Self.Speed * Self.SlideSpeedMultiplier + 0.01f, $"expired chain window: slide back at base speed (#149), speed {Self.CurrentSlideSpeed:0.0}");
+    ReleaseAction ("slide");
+    await WaitUntil (() => !Self.Sliding, 2, "post-window slide released");
 
     // Slide TIMER expiry (#148/#150): the lengthened slide runs its full duration &
     // ends STANDING in the open - no more forced crouch on expiry. Stationary (no

--- a/tests/playtest/run-playtest.sh
+++ b/tests/playtest/run-playtest.sh
@@ -7,6 +7,8 @@ set -u
 GODOT_BIN="${GODOT_BIN:?Set GODOT_BIN to the Godot .NET binary}"
 DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 LOGS="$DIR/reports/playtest"
+# Overridable so parallel local runs don't collide on one port.
+PORT="${PLAYTEST_PORT:-55599}"
 mkdir -p "$LOGS"
 
 echo "== Importing & building =="
@@ -14,13 +16,13 @@ echo "== Importing & building =="
 dotnet build "$DIR" > "$LOGS/build.log" 2>&1 || { echo "BUILD FAILED"; tail -20 "$LOGS/build.log"; exit 1; }
 
 echo "== Launching host + 2 clients =="
-"$GODOT_BIN" --headless --path "$DIR" -- --playtest host > "$LOGS/host.log" 2>&1 &
+"$GODOT_BIN" --headless --path "$DIR" -- --playtest host --port "$PORT" > "$LOGS/host.log" 2>&1 &
 HOST=$!
 sleep 5
-"$GODOT_BIN" --headless --path "$DIR" -- --playtest victim > "$LOGS/victim.log" 2>&1 &
+"$GODOT_BIN" --headless --path "$DIR" -- --playtest victim --port "$PORT" > "$LOGS/victim.log" 2>&1 &
 VICTIM=$!
 sleep 3
-"$GODOT_BIN" --headless --path "$DIR" -- --playtest shooter > "$LOGS/shooter.log" 2>&1 &
+"$GODOT_BIN" --headless --path "$DIR" -- --playtest shooter --port "$PORT" > "$LOGS/shooter.log" 2>&1 &
 SHOOTER=$!
 
 # Watchdog: kill everything if the scenario hangs.

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -3,6 +3,7 @@ using com.forerunnergames.energyshot.core.world;
 using com.forerunnergames.energyshot.players;
 using com.forerunnergames.energyshot.ui.dialogs;
 using com.forerunnergames.energyshot.ui.hud.messages;
+using com.forerunnergames.energyshot.utilities;
 using com.forerunnergames.energyshot.weapons;
 using Godot;
 
@@ -28,6 +29,9 @@ public partial class Hud : Control
   private ProgressBar _slideBar = null!;
   private ProgressBar _fullAutoBar = null!;
   private ProgressBar _bananaBar = null!;
+  private ColorRect _deathOverlay = null!;
+  private Label _deathCountdown = null!;
+  private ulong _deathOverlayEndMs;
   private float _blurIntensity;
   private float _splatterSecondsLeft;
   private float _splatterSlide;
@@ -110,6 +114,41 @@ public partial class Hud : Control
     _world.SelfPlayerHealthChanged += OnSelfPlayerHealthChanged;
     _world.KickedFromServer += OnKickedFromServer;
     _world.ServerShutDown += OnServerShutDown;
+    CreateDeathOverlay();
+    AddCrouchModeToggleToPauseDialog();
+  }
+
+  // Death overlay (issue #152): a dim wash + countdown while the body lies at the
+  // death spot; built in code to keep Hud scene edits minimal, like the music
+  // player's pause toggle (issue #137).
+  private void CreateDeathOverlay()
+  {
+    _deathOverlay = new ColorRect { Color = new Color (0.0f, 0.0f, 0.0f, 0.45f), MouseFilter = MouseFilterEnum.Ignore, Visible = false };
+    _deathOverlay.SetAnchorsPreset (LayoutPreset.FullRect);
+    AddChild (_deathOverlay);
+    MoveChild (_deathOverlay, 0); // Under the health bar, messages, & leaderboard.
+    _deathCountdown = new Label { HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center, MouseFilter = MouseFilterEnum.Ignore };
+    _deathCountdown.AddThemeFontSizeOverride ("font_size", 48);
+    _deathCountdown.SetAnchorsPreset (LayoutPreset.FullRect);
+    _deathOverlay.AddChild (_deathCountdown);
+  }
+
+  // Crouch toggle-vs-hold (issue #147), persisted & offered in the pause (quit)
+  // dialog - the only in-game UI with a visible mouse - like the music toggle (#137).
+  private void AddCrouchModeToggleToPauseDialog()
+  {
+    var container = GetNodeOrNull <BoxContainer> ("QuitDialog/VBoxContainer/HBoxContainer");
+    if (container == null) return;
+    var toggle = new CheckButton { Text = "Hold to crouch", ButtonPressed = Settings.HoldToCrouch };
+    toggle.AddThemeFontSizeOverride ("font_size", 40);
+    toggle.Toggled += OnHoldToCrouchToggled;
+    container.AddChild (toggle);
+  }
+
+  private static void OnHoldToCrouchToggled (bool isEnabled)
+  {
+    Settings.HoldToCrouch = isEnabled;
+    Player.Local?.RefreshCrouchMode(); // Applies immediately, not just next launch (issue #147).
   }
 
   public override void _UnhandledInput (InputEvent @event)
@@ -123,6 +162,26 @@ public partial class Hud : Control
     UpdateBlur (delta);
     UpdateSplatter (delta);
     UpdateCooldownBars();
+    UpdateDeathOverlay();
+  }
+
+  private void ShowDeathOverlay()
+  {
+    var seconds = _world.SelfPlayer?.DeathSequenceSeconds ?? 5.0f;
+    _deathOverlayEndMs = Time.GetTicksMsec() + (ulong)(seconds * 1000.0f);
+    _deathOverlay.Visible = true;
+  }
+
+  // Countdown feel (issue #152): whole seconds ticking down to the auto-respawn;
+  // clears once the wait is over & the replicated Fallen state has dropped.
+  private void UpdateDeathOverlay()
+  {
+    if (!_deathOverlay.Visible) return;
+    var now = Time.GetTicksMsec();
+    var secondsLeft = now >= _deathOverlayEndMs ? 0 : (int)Mathf.Ceil ((_deathOverlayEndMs - now) / 1000.0f);
+    _deathCountdown.Text = $"Zapped out!\nBack in {Mathf.Max (1, secondsLeft)}...";
+    if (secondsLeft > 0 || _world.SelfPlayer?.Fallen == true) return;
+    _deathOverlay.Visible = false;
   }
 
   // Punch blur stacks per hit & fades back to sharp; a heavy stack fades slower, so
@@ -174,6 +233,7 @@ public partial class Hud : Control
   {
     _selfPlayerName = selfPlayerName;
     _messageScroller.Reset();
+    _deathOverlay.Visible = false; // No stale countdown from a previous session (issue #152).
     _healthBar.MaxValue = selfMaxHealth;
     _healthBar.Value = selfMaxHealth;
     UpdateVignette (selfMaxHealth);
@@ -209,6 +269,7 @@ public partial class Hud : Control
     if (!IsSelf (playerName)) return;
     // Your own death renders red locally (issue #101); everyone else gets the same text in white.
     Announce (MessageGenerator.OnZapped (playerName, shotByPlayerName, BuildDeathContext (shotByPlayerName)), MessageScroller.MessageImportance.Critical);
+    ShowDeathOverlay(); // The message now lands at death time, opening the lie-down wait (issue #152).
     ++_zappedStreak;
     _zapStreak = 0;
     if (_zappedStreak >= 3) Announce (MessageGenerator.OnZappedStreak (playerName));

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -141,7 +141,7 @@ public partial class Hud : Control
   private void AddCrouchModeToggleToPauseDialog()
   {
     var container = GetNodeOrNull <BoxContainer> ("QuitDialog/VBoxContainer/HBoxContainer");
-    if (container == null) return;
+    if (container == null) { GD.PushWarning ("Pause-dialog container missing: the hold-to-crouch toggle (issue #147) was not added."); return; }
     var toggle = new CheckButton { Text = "Hold to crouch", ButtonPressed = Settings.HoldToCrouch };
     toggle.AddThemeFontSizeOverride ("font_size", 40);
     toggle.Toggled += OnHoldToCrouchToggled;

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -68,6 +68,13 @@ public static class Settings
     set => Set ("third_person_view", value);
   }
 
+  // Crouch as hold-while-pressed instead of the default toggle (issue #147).
+  public static bool HoldToCrouch
+  {
+    get => GetBool ("hold_to_crouch", false);
+    set => Set ("hold_to_crouch", value);
+  }
+
   // Mini music player visibility (issue #137): hiding it never stops the music.
   public static bool ShowMusicPlayer
   {


### PR DESCRIPTION
Movement & death-feel batch: fixes #171, #147, #148, #149, #150, & #152.

## Crouch un-stick (#171) - root cause
`ApplyCrouchScale` scaled the collision shape about its **center** (node at y=1), lifting the shape's bottom ~0.4m - so the whole body sank ~0.4m into the floor while crouched. The `IsOverheadBlocked` ray started at the body origin, i.e. **underneath the paper-thin arena ground slab** (0.002m thick), traveled up, hit the slab's underside front-on, & reported "blocked" everywhere. Result: `C` could never stand you up on the main ground, & `StopSlide`'s low-ceiling check crouched every expired slide (#150 - same root cause). The #131 playtest missed it because that phase runs in the spawn room, whose 0.5m-thick floor swallows the ray start inside the slab (backfaces ignored).

**Fix:** the crouch now keeps the feet planted (the shape node drops to compensate for the center scale - no more body sink, no pop on stand), & the overhead probe starts 0.5m above the origin, above any possible floor clip. The playtest asserts both the toggle round-trip **on the thin arena ground** & that crouching drifts the body < 0.2m (measured 0.01m; ~0.4m before the fix).

## Crouch toggle-vs-hold setting (#147)
- `Settings.HoldToCrouch` persisted in `user://settings.cfg` (default off = toggle, unchanged).
- "Hold to crouch" CheckButton in the pause (quit) dialog next to "Show music player"; applies immediately via `Player.Local.RefreshCrouchMode()` (cached - hold mode never reads disk per frame).
- Hold mode: crouched exactly while held; standing on release re-tries each frame until there's overhead room; the #131 crouch-press slide cancel still applies.

## Longer slides (#148)
`SlideDurationSeconds` 5s -> 7s. Verified the timer cap is what actually ends a held slide (slide speed never decays), so the longer cap directly means farther slides.

## Slide-jump chaining (#149)
- Jumping out of a slide (with room to stand) ends the slide with **no cooldown** & the air **keeps the slide's momentum** (input can't overwrite velocity until touchdown, like the banana launch).
- Landing opens a 0.5s chain window (physics-time, immune to CI clock dilation): a slide started inside it continues from the carried speed +15%, clamped to **2x base slide speed** so chains build speed but can't diverge.
- Playtest: cooldown canceled, 14.0 m/s carried through the air, chained slide at 16.1 m/s, cap respected.

## Slide expiry ends standing (#150)
With the overhead probe fixed, `StopSlide` behaves as originally intended: timer expiry ends standing in the open; only a genuinely low ceiling forces the crouch. The #131 crouch-cancel-into-crouch is untouched (playtest-asserted).

## Death sequence (#152)
- On zap-out: death snapshot & weapon drops resolve at death time as before, the death message broadcasts immediately, then the body lies at the death spot for **5s** (`DeathSequenceSeconds`) before the usual auto-respawn with spawn armor.
- **Fallen** replicated property appended to Player.tscn (index 19, ALWAYS-sync like Sliding) drives a non-gory lights-out tip-over tween on every peer; mesh-only, idempotent per state like Dancing.
- The victim's camera pulls back & up over the death spot (reusing the #119 spring-arm rig, stretched to 6m back / 3m up) & keeps the body framed, so they can watch their killer emote on it; the chosen view is restored on respawn.
- HUD: dim overlay + "Back in N..." countdown (code-built, like the music player's pause toggle), cleared when the replicated Fallen state drops.
- Input locked for the lie-down; a fallen body takes no further hits (guards in the damage RPCs & `ApplyDamageFrom`, covering late stickies/blasts/punches/boomerangs), can't be re-killed, & skips the world-boundary fall penalty. Kill-heal & boomerang mid-flight drops resolve at death time exactly as before.

## Playtest driver
- `--port` override (+ `PLAYTEST_PORT` env in run-playtest.sh) so parallel local runs don't collide on one port.
- Punch phase repositions the shooter on the far side of the victim from the idle host - an unlucky spawn once put the host in the punch ray for all 10 attempts (same line-of-fire hazard the laser phase already guards).
- New assertions: crouch round-trip & planted feet on the thin ground (#171), hold mode (#147), chain speed/cap/cooldown (#149), 7s duration & standing expiry (#148/#150), fallen replication to peers, ~5s lie-down (measured 4986ms), death camera live & restored (#152).
- +5s respawn-wait adjustments where victims die.

## Validation
- `dotnet build`: 0 errors, 0 warnings.
- Full 3-instance playtest: **PASS (host + shooter + victim)**, all phases green including every new assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fallen-player death sequence with replicated animations, a dedicated death camera, and a respawn countdown overlay.
  - Added slide chaining, momentum-preserving slide jumps, configurable crouch hold mode, and longer slide duration.
  - Added persistent hold-to-crouch settings.

- **Bug Fixes**
  - Fallen players no longer take additional damage, receive hits, or get launched during the death sequence.
  - Respawning now reliably restores movement, camera, crouch, and slide states.
  - Improved crouch and slide behavior around overhead clearance and grounded movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #147
Fixes #148
Fixes #149
Fixes #150
Fixes #152
Fixes #171