### PR TITLE
Harden the playtest harness: free ports, no false passes, & death-drop coverage

### DIFF
--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -28,6 +28,14 @@ public partial class WeaponSpawner : Node3D
   public static readonly Vector3 PlaytestBoomerangPosition = new(3.0f, 31.1f, 5.0f);
   // Playtest-only (#99): same idea for the slingshot draw/release phase.
   public static readonly Vector3 PlaytestSlingshotPosition = new(-3.0f, 31.1f, 5.0f);
+  // Playtest-only (#169): the victim arms up here before the kill phase, so the death
+  // drop has something to drop - RequestDrop's death path had no coverage at all,
+  // which is how the #167 vanishing-weapon regression reached players. Down in the
+  // empty arena rather than the spawn room: every spot in that small room is within
+  // claim reach of the +/-4 random spawn scatter (observed: a joining peer grabbed
+  // it seconds after spawning), & a stray banana in someone's hands would make the
+  // death-drop phase's claim assert meaningless.
+  public static readonly Vector3 PlaytestBananaPosition = new(0.0f, 0.9f, -40.0f);
   private const float OccupiedRadius = 1.0f;
   // Cargo riding a boomerang home (issue #98): stolen & scooped weapons live here
   // between the grab & the thrower's catch, so the caps still count them.
@@ -152,13 +160,14 @@ public partial class WeaponSpawner : Node3D
   }
 
   // Playtest-only (#72 & #98): keeps deterministic pickups available in the spawn
-  // room for the driver's collection, shooting, & throw/catch phases.
+  // room for the driver's collection, shooting, throw/catch, & death-drop phases.
   private void EnsurePlaytestPickups (List <WeaponPickup> pickups)
   {
     if (!_isPlaytest) return;
     EnsurePlaytestPickup (HeldWeapon.Laser, PlaytestLaserPosition, pickups);
     EnsurePlaytestPickup (HeldWeapon.Boomerang, PlaytestBoomerangPosition, pickups);
     EnsurePlaytestPickup (HeldWeapon.Slingshot, PlaytestSlingshotPosition, pickups); // Issue #99.
+    EnsurePlaytestPickup (HeldWeapon.Banana, PlaytestBananaPosition, pickups); // Issue #169.
   }
 
   private void EnsurePlaytestPickup (HeldWeapon type, Vector3 position, List <WeaponPickup> pickups)

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -31,6 +31,17 @@ public partial class PlaytestDriver : Node
   // file mid-run; the version must match run-playtest.sh's version file content.
   private const string AdminAnnouncement = "Playtest admin announcement";
   private const string ServerVersion = "v9.9.9-playtest";
+  // Death-drop coverage (issue #169): the victim carries the deterministic playtest
+  // banana to this fixed spot to be zapped, so the drop lands metres clear of every
+  // playtest pickup spot - a drop search next to one of those could match it instead.
+  private static readonly Vector3 KillSpot = new(4.0f, 31.0f, 0.0f);
+  private static readonly Vector3 SpawnRoomCenter = new(0.0f, 31.0f, 0.0f);
+  // The drop grounds straight down from the death spot (#151), so it stays in that
+  // XZ column; the radius only has to cover RequestDrop's per-weapon side offsets.
+  private const float DropSearchRadius = 2.0f;
+  // Matches WeaponSpawner's MinGroundY (#172): anything below is the kill boundary
+  // under the arena, where a "grounded" drop is really an unreachable one.
+  private const float MinDropY = -50.0f;
   private World _world = null!;
   private string _role = string.Empty;
   private string _address = "127.0.0.1";
@@ -327,6 +338,7 @@ public partial class PlaytestDriver : Node
     // Death sequence (#152): the victim's body lies fallen at the death spot &
     // the replicated Fallen state must render the tip-over on this peer too.
     await WaitUntil (() => victim.Fallen, 10, "victim's fallen body replicated to shooter (#152)");
+    await RunDeathDropPhase (victim);
 
     // Victim must come back armored in the spawn room (~5s later now, #152).
     await WaitUntil (() => respawnArmorSeen, 20, "victim respawned with spawn armor");
@@ -506,6 +518,40 @@ public partial class PlaytestDriver : Node
     Assert (_adminMessages.All (message => !message.Contains ("FORGED")), "forged admin RPC was rejected (#158)");
   }
 
+  // Death-drop coverage (issue #169): the victim died holding the deterministic
+  // playtest banana, so RequestDrop's death path must have left a real, claimable
+  // pickup on the floor under the body. That path had zero playtest coverage until
+  // now - which is how the #167 regression (killed players' weapons vanishing into
+  // nothing) reached players.
+  private async Task RunDeathDropPhase (Player victim)
+  {
+    var deathSpot = victim.GlobalPosition;
+    await WaitUntil (() => DroppedBananaNear (deathSpot) != null, 15, "victim's banana dropped in the death spot's column (#169)");
+    var drop = DroppedBananaNear (deathSpot)!;
+    // Ray-grounded (#151/#172): the drop rests on the level below the death spot -
+    // never floating above it, never down on the kill boundary at y=-100.
+    Assert (drop.GlobalPosition.Y > MinDropY && drop.GlobalPosition.Y < deathSpot.Y + 2.0f, $"dropped banana ray-grounded below the death spot (#151/#172), drop y {drop.GlobalPosition.Y:0.00} vs death y {deathSpot.Y:0.00}");
+    // Claimable: take it through the real claim path, before the drop expires. The
+    // only other banana in the level is the playtest one down in the arena, so
+    // starting empty-handed is what makes the wait below mean "the drop was claimed".
+    Assert (!Self.Holds (HeldWeapon.Banana), "reached the death-drop phase with no banana of our own (#169)");
+    Self.Position = drop.GlobalPosition;
+    await WaitUntil (() => Self.Holds (HeldWeapon.Banana), 10, "victim's dropped banana was claimable (#169)");
+    Self.Position = SpawnRoomCenter; // Back where the phases below expect to run.
+    await Task.Delay (300); // Settle onto the floor.
+    // That pickup auto-equipped the banana (#128) & the phases below count laser
+    // bolts, so put the laser back in hand first.
+    PressAction ("weapon_2");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_2");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Laser, "laser re-selected after the death-drop phase (#169)");
+  }
+
+  // The nearest live banana pickup around a spot, measured flat: the drop grounds onto
+  // whatever lies below, so its height is the one thing this search must not assume.
+  private WeaponPickup? DroppedBananaNear (Vector3 spot) => _world.GetChildren().OfType <WeaponPickup>().FirstOrDefault (pickup => pickup.Weapon == HeldWeapon.Banana && !pickup.IsQueuedForDeletion() && FlatDistance (pickup.GlobalPosition, spot) < DropSearchRadius);
+  private static float FlatDistance (Vector3 a, Vector3 b) => new Vector2 (a.X - b.X, a.Z - b.Z).Length();
+
   // Movement & death-feel batch (#171/#147/#148/#149/#150): crouch un-stick, the
   // hold-to-crouch setting, slide-jump chaining, & standing slide expiry. Runs on
   // the open arena ground - the paper-thin slab is the exact surface the #171
@@ -614,7 +660,7 @@ public partial class PlaytestDriver : Node
     Assert (!Self.Crouching, "expired slide ended standing, not crouched (#150)");
 
     // Back to the spawn room for the boomerang & slingshot pickup phases.
-    Self.Position = new Vector3 (0.0f, 31.0f, 0.0f);
+    Self.Position = SpawnRoomCenter;
     await Task.Delay (300);
   }
 
@@ -678,11 +724,21 @@ public partial class PlaytestDriver : Node
     var partialLaserHits = 0;
     var healthAfterPunch = Self.Health;
     Self.HealthChanged += value => partialLaserHits += value > 0 && value < healthAfterPunch ? 1 : 0;
+    // Death-drop coverage (#169): arm up AFTER the punch (a punch has a drop chance of
+    // its own, which would empty our hands again) & carry the banana to the fixed kill
+    // spot, so the kill actually runs RequestDrop's death path. Teleporting to the
+    // pickup & to the kill spot follows the fall-penalty phase's precedent below.
+    Self.Position = WeaponSpawner.PlaytestBananaPosition; // Down in the empty arena, then straight back up.
+    await WaitUntil (() => Self.Holds (HeldWeapon.Banana), 20, "collected the playtest banana before the kill (#169)");
+    Self.Position = KillSpot;
     // Death sequence (#152): the kill drops us where we stand for ~DeathSequenceSeconds
     // with the pulled-back death camera live, & only then the usual armored respawn.
     await WaitUntil (() => Self.Fallen, 120, "own death started the lie-down (#152)");
     var fallenStartMs = Time.GetTicksMsec();
     Assert (Self.IsDeathViewActive, "death camera pulled back over the death spot (#152)");
+    // The death drop runs before the lie-down starts (#169), so our hands are already
+    // empty here - the shooter asserts the pickup itself landed & is claimable.
+    Assert (Self.HeldWeapon == HeldWeapon.None, $"death dropped every carried weapon (#169), still holding {Self.HeldWeapon}");
     await WaitUntil (() => Self.SpawnArmor && Self.Health == Self.MaxHealth, 120, "died & respawned with armor & full health");
     var lieDownMs = Time.GetTicksMsec() - fallenStartMs;
     Assert (lieDownMs >= (ulong)(Self.DeathSequenceSeconds * 1000.0f) - 500, $"lay at the death spot ~{Self.DeathSequenceSeconds}s before respawning (#152), got {lieDownMs}ms");

--- a/tests/playtest/run-playtest.sh
+++ b/tests/playtest/run-playtest.sh
@@ -7,15 +7,62 @@ set -u
 GODOT_BIN="${GODOT_BIN:?Set GODOT_BIN to the Godot .NET binary}"
 DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 LOGS="$DIR/reports/playtest"
-# Overridable so parallel local runs don't collide on one port.
-PORT="${PLAYTEST_PORT:-55599}"
 mkdir -p "$LOGS"
 
+# Is anything already bound to this UDP port? Whichever tool the machine has wins;
+# no tool at all just means every candidate looks free (the PID seed still keeps
+# concurrent runs apart).
+port_in_use() {
+  if command -v lsof > /dev/null 2>&1; then
+    lsof -nP -iUDP:"$1" > /dev/null 2>&1
+    return $?
+  fi
+  if command -v ss > /dev/null 2>&1; then
+    ss -lun 2>/dev/null | grep -qE "[:.]$1([[:space:]]|\$)"
+    return $?
+  fi
+  netstat -an 2>/dev/null | grep -qE "^udp.*[.:]$1([[:space:]]|\$)"
+}
+
+# Issue #144: this used to be one hardcoded port, so two runs on one machine (e.g.
+# parallel agents in separate worktrees) joined each OTHER's host - seen as RPC
+# checksum mismatches & instances landing in the wrong game. 49152-65535 is the
+# dynamic/private range & $$ is unique among live runs, so two runs never start
+# from the same candidate; anything already listening is stepped over.
+pick_port() {
+  candidate=$((49152 + $$ % 16000))
+  attempt=0
+  while port_in_use "$candidate" && [ "$attempt" -lt 200 ]; do
+    candidate=$((49152 + (candidate - 49152 + 1) % 16000))
+    attempt=$((attempt + 1))
+  done
+  echo "$candidate"
+}
+
+# Overridable so a run can be pinned to a known port (firewall rules, tcpdump).
+PORT="${PLAYTEST_PORT:-$(pick_port)}"
+
+# Issue #140: each instance must leave positive evidence that it really ran - it
+# started the scenario, it asserted something, & it finished. A crashed --import
+# step once let instances exit 0 without ever loading the main scene, and a silent
+# log was reported as a PASS.
+verify_log() {
+  role="$1"
+  log="$LOGS/$role.log"
+  [ -s "$log" ] || { echo "$role: log is missing or empty - the instance never ran"; return 1; }
+  grep -q "PLAYTEST: starting role \[$role\]" "$log" || { echo "$role: no 'starting role' line - the main scene never loaded"; return 1; }
+  grep -q "PLAYTEST OK" "$log" || { echo "$role: no 'PLAYTEST OK' assertion - the scenario never ran"; return 1; }
+  grep -q "PLAYTEST PASS \[$role\]" "$log" || { echo "$role: no 'PLAYTEST PASS' marker - the role never finished"; return 1; }
+  return 0
+}
+
 echo "== Importing & building =="
-"$GODOT_BIN" --headless --path "$DIR" --import > "$LOGS/import.log" 2>&1
+# A failed import is a failed run (issue #140): the instances launched afterwards
+# can exit 0 with a half-imported project & nothing would have been tested.
+"$GODOT_BIN" --headless --path "$DIR" --import > "$LOGS/import.log" 2>&1 || { echo "IMPORT FAILED"; tail -20 "$LOGS/import.log"; exit 1; }
 dotnet build "$DIR" > "$LOGS/build.log" 2>&1 || { echo "BUILD FAILED"; tail -20 "$LOGS/build.log"; exit 1; }
 
-echo "== Launching host + 2 clients =="
+echo "== Launching host + 2 clients on port $PORT =="
 # Admin messages (issue #158): the host runs with the operator file channel & a
 # version file; the driver writes an announcement mid-run & every role asserts it.
 ADMIN_FILE="$LOGS/admin-message"
@@ -36,22 +83,28 @@ SHOOTER=$!
 WATCHDOG=$!
 
 FAIL=0
-for role in SHOOTER VICTIM HOST; do
-  pid=${!role}
+for role in shooter victim host; do
+  case "$role" in
+    shooter) pid=$SHOOTER ;;
+    victim) pid=$VICTIM ;;
+    host) pid=$HOST ;;
+  esac
   wait "$pid"
   code=$?
   echo "$role exited with $code"
   [ "$code" -ne 0 ] && FAIL=1
+  # Exit 0 is not proof the role ran (issue #140); the log has to show it did.
+  verify_log "$role" || FAIL=1
 done
 
 kill $WATCHDOG 2>/dev/null
 wait $WATCHDOG 2>/dev/null
 
 if [ "$FAIL" -ne 0 ]; then
-  echo "== PLAYTEST FAILED - logs =="
+  echo "== PLAYTEST FAILED (port $PORT) - logs =="
   for f in host shooter victim; do
     echo "--- $f.log (last 40 lines) ---"
-    tail -40 "$LOGS/$f.log"
+    tail -40 "$LOGS/$f.log" 2>/dev/null
   done
   exit 1
 fi


### PR DESCRIPTION
Playtest harness hardening batch. Test infrastructure only - no gameplay behavior changes.

## #144 - concurrent runs collide on a fixed port

`run-playtest.sh` hardcoded one port, so two runs on the same machine (parallel agents in separate worktrees) bound the same socket and one run's instances joined the OTHER run's host - seen as RPC errors and instances landing in the wrong game.

The script now picks a port per run: a candidate out of the dynamic/private range (49152-65535) seeded by the run's PID, stepped forward past anything already listening (`lsof`, falling back to `ss`, then `netstat`). All three instances get it through the driver's existing `--port` plumbing, and the chosen port is echoed in the launch line and in the failure banner. `PLAYTEST_PORT` still pins the port when you want a fixed one.

**Proof.** Two full playtests run concurrently from two copies of the project - and, as it happens, alongside two *other* agents' playtests already running on this machine:

```
=== run A ===  == Launching host + 2 clients on port 57357 ==
               == PLAYTEST PASSED (host + shooter + victim) ==
=== run B ===  == Launching host + 2 clients on port 57358 ==
               == PLAYTEST PASSED (host + shooter + victim) ==

run A host: 5 peer connections, spawned [Host] [Shooter] [Victim]
run B host: 5 peer connections, spawned [Host] [Shooter] [Victim]
bind errors: none          cross-run "Method not found" RPC errors: 0
```

The same pair of runs on the pre-change script (fixed 55599) collided immediately:

```
A exit 1 / B exit 1
Playtest host failed: CantCreate          (both hosts)
ERROR: RPC - 'CharacterBody3D(Player.cs)::ReceiveStickyBanana': Method not found
PLAYTEST FAIL [victim]: timed out after 30s waiting for: admin announcement received from the server (#158)
```

## #140 - false PASS when the import step crashes

Two holes, both closed:

1. The `--import` step's exit code was ignored. It now fails the run.
2. Exit 0 from an instance was taken as proof it passed. Each role's log must now also show it really ran: the `PLAYTEST: starting role [<role>]` line, at least one `PLAYTEST OK` assertion, and that role's `PLAYTEST PASS` marker. A missing or empty log fails too.

**Proof.** Same simulated crashed import (a fake `GODOT_BIN` whose instances exit 0 without loading the main scene):

```
OLD script: == PLAYTEST PASSED (host + shooter + victim) ==      exit 0   <- the bug
NEW script: shooter: log is missing or empty - the instance never ran
            victim: log is missing or empty - the instance never ran
            host: log is missing or empty - the instance never ran
            == PLAYTEST FAILED (port 56805) - logs ==            exit 1
```

Import step exiting 139 (simulated segfault):

```
== Importing & building ==
IMPORT FAILED
Segmentation fault (simulated)                                   exit 1
```

Instances exiting 0 with a non-empty but evidence-free log (Godot banner only):

```
shooter: no 'starting role' line - the main scene never loaded
victim: no 'starting role' line - the main scene never loaded
host: no 'starting role' line - the main scene never loaded
== PLAYTEST FAILED (port 56866) - logs ==                        exit 1
```

## #169 - the victim death-drop path is never exercised

The playtest victim always died empty-handed, so `RequestDrop`'s death path had zero coverage - the gap that let the v0.8.14 vanishing-weapon regression (#167) ship.

- A deterministic playtest-only banana pickup joins the existing laser/boomerang/slingshot ones in `WeaponSpawner` (`EnsurePlaytestPickups`, same established pattern). It sits down in the empty arena rather than the spawn room: every spot in that small room is within claim reach of the +/-4 random spawn scatter, and a peer grabbing it by accident would make the claim assert below meaningless. That was not hypothetical - the first version of this change put it in the spawn room and a joining peer picked it up seconds after spawning.
- The victim collects it *after* the punch phase (a punch has a drop chance of its own) and carries it to a fixed kill spot, so the drop lands metres clear of every deterministic pickup. On death it asserts its hands were emptied.
- The shooter then asserts the drop landed in the death spot's XZ column, is ray-grounded below the death spot and above the kill boundary (#151/#172), and - starting provably empty-handed - claims it through the real pickup path before the drop expires, then re-selects the laser for the phases that count bolts.

New log lines from a green run:

```
victim:  PLAYTEST OK: collected the playtest banana before the kill (#169)
victim:  PLAYTEST OK: death dropped every carried weapon (#169), still holding None
shooter: PLAYTEST OK: victim's banana dropped in the death spot's column (#169)
shooter: PLAYTEST OK: reached the death-drop phase with no banana of our own (#169)
shooter: PLAYTEST OK: victim's dropped banana was claimable (#169)
shooter: PLAYTEST OK: laser re-selected after the death-drop phase (#169)

server:  [peer 2020576463] weapon drop: Banana at (4, 0.9009994, 0)
server:  [peer 613499133] weapon award: Banana from pickup [WeaponPickup13]
```

## #78 - flake "shooter's score replicated to victim" times out

Audited, no code change. Every `FindPlayer`-by-name call left in the driver is either inside a `WaitUntil` predicate behind `?.` (an unreplicated name reads as "not yet" and the wait keeps polling), or is preceded by the explicit non-null name wait that PR #142 added, or - in the host's one by-name `Assert` - follows several successful waits on that same name. The three count-only `GetPlayers().Count()` waits are each followed only by authority-based `Self` access or by null-safe by-name waits, never by a raw dereference. Details posted on the issue.

## Validation

`dotnet build` clean (0 errors, 0 warnings) and the full playtest green in the foreground, plus the concurrent pair above. All three roles exit 0 with their evidence markers present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
