### PR TITLE
Stop the idle HUD overlays from drawing, & fix the airplane's look

### DIFF
--- a/core/players/Player.AirplaneHazard.cs
+++ b/core/players/Player.AirplaneHazard.cs
@@ -47,6 +47,7 @@ public partial class Player
   private static readonly Color FlameOrange = new(1.0f, 0.55f, 0.12f);
   private bool _burning;
   private OmniLight3D? _burnLight;
+  private CpuParticles3D? _burnFlames;
   private ulong _mineFuseEndMs;
   // Whichever airplane is locked onto us, live or a visual copy - the ring reads its
   // distance. Registered by SpawnAirplane on every peer (issues #102 & #191).
@@ -156,8 +157,9 @@ public partial class Player
     if (!_burning && _burnLight != null) StopBurnEffect();
   }
 
-  // A zappy flame, not a fire: a flickering orange light riding the body, visible to
-  // everyone so the whole arena can see who's about to pop.
+  // Actual flames (issue #207): a flickering light alone just tinted the player
+  // orange, which reads as "hurt", not "on fire". Rising particles give visible
+  // fire on the body, & everyone sees them - the light stays for the glow it casts.
   private void StartBurnEffect()
   {
     _burnLight = new OmniLight3D { LightColor = FlameOrange, LightEnergy = 4.0f, OmniRange = 7.0f, Position = Vector3.Up * 1.2f };
@@ -165,12 +167,56 @@ public partial class Player
     var flicker = _burnLight.CreateTween().SetLoops();
     flicker.TweenProperty (_burnLight, "light_energy", 1.6f, 0.09f);
     flicker.TweenProperty (_burnLight, "light_energy", 4.0f, 0.09f);
+    _burnFlames = CreateFlames();
+    AddChild (_burnFlames);
+  }
+
+  // Code-built so nothing is downloaded: additive billboard quads streaming upward,
+  // fading bright yellow -> orange -> out, spread across the body's height.
+  private static CpuParticles3D CreateFlames()
+  {
+    var gradient = new Gradient();
+    gradient.SetColor (0, new Color (1.0f, 0.95f, 0.45f, 1.0f));
+    gradient.SetColor (1, new Color (1.0f, 0.25f, 0.05f, 0.0f));
+
+    return new CpuParticles3D
+    {
+      Amount = 48,
+      Lifetime = 0.55,
+      Position = Vector3.Up * 0.6f,
+      Mesh = new QuadMesh
+      {
+        Size = new Vector2 (0.42f, 0.42f),
+        Material = new StandardMaterial3D
+        {
+          ShadingMode = BaseMaterial3D.ShadingModeEnum.Unshaded,
+          Transparency = BaseMaterial3D.TransparencyEnum.Alpha,
+          BlendMode = BaseMaterial3D.BlendModeEnum.Add,
+          BillboardMode = BaseMaterial3D.BillboardModeEnum.Particles,
+          VertexColorUseAsAlbedo = true,
+          AlbedoColor = Colors.White
+        }
+      },
+      EmissionShape = CpuParticles3D.EmissionShapeEnum.Box,
+      EmissionBoxExtents = new Vector3 (0.35f, 0.7f, 0.35f),
+      Direction = Vector3.Up,
+      Spread = 18.0f,
+      InitialVelocityMin = 1.4f,
+      InitialVelocityMax = 2.6f,
+      Gravity = Vector3.Up * 1.2f, // Flames rise; they don't fall.
+      ScaleAmountMin = 0.7f,
+      ScaleAmountMax = 1.5f,
+      ColorRamp = gradient,
+      Emitting = true
+    };
   }
 
   private void StopBurnEffect()
   {
     _burnLight?.QueueFree();
     _burnLight = null;
+    _burnFlames?.QueueFree();
+    _burnFlames = null;
   }
 
   // A respawn (or falling off the world) puts the fire out & abandons any burn ticks

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -293,6 +293,10 @@ public partial class Player
   {
     ZapStreakCount = 0; // Any respawn ends the streak.
     Health = MaxHealth;
+    // Announce it (issue #201): the HUD's health bar & the red death-vignette both
+    // follow this signal, so a silent reset left the vignette glowing for the rest
+    // of the life - a permanent red halo after every respawn.
+    EmitSignal (SignalName.HealthChanged, Health);
     Velocity = Vector3.Zero;
     Position = CalculateRandomSpawnPosition();
     SetBreadHeld (isHeld: true); // Fresh bread every life (issues #62 & #190).

--- a/core/players/Player.PaperAirplane.cs
+++ b/core/players/Player.PaperAirplane.cs
@@ -34,6 +34,9 @@ public partial class Player
   // validated on their own peer; this only rejects wildly stale/forged requests.
   [Export] public float AirplaneCatchSlackMeters = 6.0f;
   [Signal] public delegate void AirplaneCaughtEventHandler (string catcherName);
+  // Fired the moment a player enters the lock ring (issue #211): the HUD chirps so
+  // the lock is audible as well as visible, without watching the ring.
+  [Signal] public delegate void AirplaneLockAcquiredEventHandler();
   private PaperAirplaneProjectile? _liveAirplane;
   private PaperAirplaneProjectile? _visualAirplane;
   private Node3D _airplaneHeld = null!;
@@ -66,12 +69,44 @@ public partial class Player
   // Lock-on feedback (issue #205): with the airplane in hand & a player under the
   // crosshair, the throw WILL home on them - the HUD draws a big ring so that's
   // visible before committing, instead of the lock being silent & invisible.
-  public bool HasAirplaneLock { get; private set; }
+  public bool HasAirplaneLock => _lockedTarget != null;
+  // The ring is a big TARGET AREA, not a crosshair (issue #211): anyone inside the
+  // circle when you release is who the glider chases. Measured as a cone off the aim
+  // axis rather than in screen pixels - 27 degrees is what TargetRing's 0.34-of-screen
+  // circle subtends at the default FOV, & unlike a viewport measurement it means the
+  // same thing at any window size (& in a headless playtest, where there is none).
+  private const float LockConeDegrees = 27.0f;
+  private Player? _lockedTarget;
 
   private void UpdateAirplaneLock()
   {
     if (!IsMultiplayerAuthority()) return;
-    HasAirplaneLock = IsPaperAirplaneSelected && HasPaperAirplane && !IsAirplaneOut && FindAimedPlayer (200.0f) != null;
+    var wasLocked = _lockedTarget != null;
+    _lockedTarget = IsPaperAirplaneSelected && HasPaperAirplane && !IsAirplaneOut ? FindPlayerInsideLockRing() : null;
+    if (_lockedTarget != null && !wasLocked) EmitSignal (SignalName.AirplaneLockAcquired); // Chirp on acquisition.
+  }
+
+  // Whoever sits nearest the middle of the ring - screen-space, so a distant player
+  // inside the circle locks just as well as a close one.
+  private Player? FindPlayerInsideLockRing()
+  {
+    var aim = -_camera.GlobalTransform.Basis.Z;
+    var cone = Mathf.DegToRad (LockConeDegrees);
+    Player? best = null;
+    var bestAngle = float.MaxValue;
+
+    foreach (var node in GetParent().GetChildren())
+    {
+      if (node is not Player player || player == this) continue;
+      var toHead = player.GlobalPosition + Vector3.Up - _camera.GlobalPosition;
+      if (toHead.LengthSquared() < 0.001f) continue;
+      var angle = aim.AngleTo (toHead.Normalized());
+      if (angle > cone || angle >= bestAngle) continue; // Nearest the middle of the ring wins.
+      best = player;
+      bestAngle = angle;
+    }
+
+    return best;
   }
 
   // The target locks at throw time (issue #102): whoever is under the crosshair.
@@ -79,7 +114,7 @@ public partial class Player
   private void ThrowPaperAirplane()
   {
     CancelSpawnArmorIfFired();
-    var target = FindAimedPlayer (200.0f);
+    var target = _lockedTarget; // Whoever was inside the ring at release (issue #211).
     var direction = -_camera.GlobalTransform.Basis.Z;
     var origin = _camera.GlobalPosition + direction * MuzzleOffsetMeters;
     // The server registers the flight (CodeRabbit on #180): the single-use record a

--- a/core/players/Player.PaperAirplane.cs
+++ b/core/players/Player.PaperAirplane.cs
@@ -82,7 +82,10 @@ public partial class Player
   {
     if (!IsMultiplayerAuthority()) return;
     var wasLocked = _lockedTarget != null;
-    _lockedTarget = IsPaperAirplaneSelected && HasPaperAirplane && !IsAirplaneOut ? FindPlayerInsideLockRing() : null;
+    // Same gates the throw itself applies (CodeRabbit on #206): showing a lock during
+    // the respawn input lock or a dance promises a throw that won't happen.
+    var canThrow = _isInputEnabled && !Dancing && IsPaperAirplaneSelected && HasPaperAirplane && !IsAirplaneOut;
+    _lockedTarget = canThrow ? FindPlayerInsideLockRing() : null;
     if (_lockedTarget != null && !wasLocked) EmitSignal (SignalName.AirplaneLockAcquired); // Chirp on acquisition.
   }
 

--- a/core/players/Player.PaperAirplane.cs
+++ b/core/players/Player.PaperAirplane.cs
@@ -63,6 +63,17 @@ public partial class Player
     ThrowPaperAirplane();
   }
 
+  // Lock-on feedback (issue #205): with the airplane in hand & a player under the
+  // crosshair, the throw WILL home on them - the HUD draws a big ring so that's
+  // visible before committing, instead of the lock being silent & invisible.
+  public bool HasAirplaneLock { get; private set; }
+
+  private void UpdateAirplaneLock()
+  {
+    if (!IsMultiplayerAuthority()) return;
+    HasAirplaneLock = IsPaperAirplaneSelected && HasPaperAirplane && !IsAirplaneOut && FindAimedPlayer (200.0f) != null;
+  }
+
   // The target locks at throw time (issue #102): whoever is under the crosshair.
   // With nobody aimed, the airplane just glides straight & lands as a pickup.
   private void ThrowPaperAirplane()

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -431,8 +431,8 @@ public partial class Player : CharacterBody3D
     UpdateBananaLauncher();
     UpdateBoomerang();
     UpdateSlingshot (delta); // Draw-&-release stones (issue #99).
+    UpdateAirplaneLock(); // Resolve the lock BEFORE the throw reads it (issues #205 & #211).
     UpdateAirplane(); // Homing glider throws (issue #102).
-    UpdateAirplaneLock(); // Lock-on ring while one's in hand (issue #205).
     UpdateAirplaneCatchWindow(); // An open swing keeps grabbing briefly (issue #102).
     UpdateBread();
     UpdateFullAuto (delta);

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -432,6 +432,7 @@ public partial class Player : CharacterBody3D
     UpdateBoomerang();
     UpdateSlingshot (delta); // Draw-&-release stones (issue #99).
     UpdateAirplane(); // Homing glider throws (issue #102).
+    UpdateAirplaneLock(); // Lock-on ring while one's in hand (issue #205).
     UpdateAirplaneCatchWindow(); // An open swing keeps grabbing briefly (issue #102).
     UpdateBread();
     UpdateFullAuto (delta);

--- a/core/weapons/BananaDebris.cs
+++ b/core/weapons/BananaDebris.cs
@@ -38,6 +38,10 @@ public partial class BananaDebris : MeshInstance3D
     }
   }
 
+  // Paper scraps are cosmetic only (CodeRabbit on #206): a slingshot must not scoop
+  // one up & fire it as a banana chunk.
+  private bool _isPaper;
+
   private static BananaDebris CreateChunk (Color color, bool isPaper = false)
   {
     var size = Rng.RandfRange (0.08f, 0.2f);
@@ -49,6 +53,7 @@ public partial class BananaDebris : MeshInstance3D
     {
       Mesh = new BoxMesh { Size = shape },
       _color = color,
+      _isPaper = isPaper,
       _velocity = RandomLaunchVelocity(),
       _spinRadiansPerSecond = new Vector3 (Rng.RandfRange (-6.0f, 6.0f), Rng.RandfRange (-6.0f, 6.0f), Rng.RandfRange (-6.0f, 6.0f))
     };
@@ -101,6 +106,7 @@ public partial class BananaDebris : MeshInstance3D
   // chunk each peer sees simply fades out on its own timer.
   private void TryLoadIntoSlingshot()
   {
+    if (_isPaper) return; // Paper scraps aren't ammo (CodeRabbit on #206).
     var local = players.Player.Local;
     if (local == null || !local.IsLoadingAmmo) return;
     if (local.GlobalPosition.DistanceTo (GlobalPosition) > ScoopRangeMeters) return;

--- a/core/weapons/BananaDebris.cs
+++ b/core/weapons/BananaDebris.cs
@@ -25,24 +25,29 @@ public partial class BananaDebris : MeshInstance3D
 
   public static void Scatter (Node parent, Vector3 origin) => Scatter (parent, origin, BananaYellow);
 
-  // Recolored bursts reuse the same chunks (issue #191): the paper airplane's pop
-  // scatters white paper scraps instead of banana pieces - non-gory either way.
-  public static void Scatter (Node parent, Vector3 origin, Color color)
+  // Recoloring alone wasn't enough (issue #203): the paper airplane's pop was
+  // throwing banana-shaped chunks around, just painted white. Paper scraps are flat
+  // & wide, so the burst reads as shredded paper instead of fruit.
+  public static void Scatter (Node parent, Vector3 origin, Color color, bool isPaper = false)
   {
     for (var i = 0; i < ChunkCount; ++i)
     {
-      var chunk = CreateChunk (color);
+      var chunk = CreateChunk (color, isPaper);
       parent.AddChild (chunk);
       chunk.GlobalPosition = origin;
     }
   }
 
-  private static BananaDebris CreateChunk (Color color)
+  private static BananaDebris CreateChunk (Color color, bool isPaper = false)
   {
     var size = Rng.RandfRange (0.08f, 0.2f);
+    var shape = isPaper
+      ? new Vector3 (size * 1.7f, size * 0.06f, size * 1.3f) // Flat, wide scraps.
+      : new Vector3 (size, size * 0.6f, size * 1.6f);        // Chunky banana pieces.
+
     return new BananaDebris
     {
-      Mesh = new BoxMesh { Size = new Vector3 (size, size * 0.6f, size * 1.6f) },
+      Mesh = new BoxMesh { Size = shape },
       _color = color,
       _velocity = RandomLaunchVelocity(),
       _spinRadiansPerSecond = new Vector3 (Rng.RandfRange (-6.0f, 6.0f), Rng.RandfRange (-6.0f, 6.0f), Rng.RandfRange (-6.0f, 6.0f))

--- a/core/weapons/PaperAirplane.cs
+++ b/core/weapons/PaperAirplane.cs
@@ -26,7 +26,7 @@ public static class PaperAirplane
     var fade = flash.CreateTween();
     fade.TweenProperty (flash, "light_energy", 0.0f, 0.35f);
     fade.Finished += flash.QueueFree;
-    BananaDebris.Scatter (parent, origin, PaperWhite);
+    BananaDebris.Scatter (parent, origin, PaperWhite, isPaper: true); // Paper scraps, not fruit (issue #203).
     // The banana blast replayed short & bright reads as a paper pop - reusing an
     // existing sound instead of downloading one.
     PlayAt (parent, origin, "res://assets/sounds/banana-explode.mp3", pitch: 1.9f, volumeDb: -4.0f);

--- a/core/weapons/PaperAirplane.cs
+++ b/core/weapons/PaperAirplane.cs
@@ -1,3 +1,4 @@
+using com.forerunnergames.energyshot.ui.hud;
 using Godot;
 
 namespace com.forerunnergames.energyshot.weapons;
@@ -14,7 +15,7 @@ public static class PaperAirplane
   // The mine going live under somebody's foot (issue #191): a quick, dry tick
   // everyone nearby can hear, so a triggered mine is never silent to bystanders -
   // they get the beat they need to back away from the player who set it off.
-  public static void Arm (Node parent, Vector3 origin) => PlayAt (parent, origin, "res://assets/sounds/punch-thud.wav", pitch: 2.4f, volumeDb: -6.0f);
+  public static void Arm (Node parent, Vector3 origin) => PlayAt (parent, origin, ResourceLoader.Load <AudioStream> ("res://assets/sounds/punch-thud.wav"), pitch: 2.4f, volumeDb: -6.0f);
 
   // The pop (issue #191): a brief warm flash & a burst of paper scraps, played
   // locally on every peer. No blast radius - the damage is strictly single-target.
@@ -27,17 +28,14 @@ public static class PaperAirplane
     fade.TweenProperty (flash, "light_energy", 0.0f, 0.35f);
     fade.Finished += flash.QueueFree;
     BananaDebris.Scatter (parent, origin, PaperWhite, isPaper: true); // Paper scraps, not fruit (issue #203).
-    // The banana blast replayed short & bright reads as a paper pop - reusing an
-    // existing sound instead of downloading one.
-    PlayAt (parent, origin, "res://assets/sounds/banana-explode.mp3", pitch: 1.9f, volumeDb: -4.0f);
+    // A code-generated papery burst (issue #206): the pitched-up banana blast still
+    // sounded like fruit going off, which is not what a paper airplane does.
+    PlayAt (parent, origin, ProceduralSounds.Pop(), pitch: 1.0f, volumeDb: -3.0f);
   }
 
-  // Load first (CodeRabbit): a stream that fails to load would leave a player that
-  // never plays, never emits Finished, & so never frees itself.
-  private static void PlayAt (Node parent, Vector3 origin, string streamPath, float pitch, float volumeDb)
+  private static void PlayAt (Node parent, Vector3 origin, AudioStream? stream, float pitch, float volumeDb)
   {
-    var stream = ResourceLoader.Load <AudioStream> (streamPath);
-    if (stream == null) { GD.PushWarning ($"Paper airplane sound [{streamPath}] failed to load; skipping it."); return; }
+    if (stream == null) { GD.PushWarning ("Paper airplane sound missing; skipping it."); return; }
     var sound = new AudioStreamPlayer3D { Stream = stream, PitchScale = pitch, VolumeDb = volumeDb };
     parent.AddChild (sound);
     sound.GlobalPosition = origin;

--- a/core/weapons/PaperAirplaneProjectile.cs
+++ b/core/weapons/PaperAirplaneProjectile.cs
@@ -14,7 +14,12 @@ namespace com.forerunnergames.energyshot.weapons;
 public partial class PaperAirplaneProjectile : Node3D
 {
   [Export] public float Speed = 10.5f;
-  [Export] public float TurnDegreesPerSecond = 65.0f;
+  // Fast enough to actually hold a turn: at 10.5 m/s, 65 deg/s couldn't sustain a
+  // circle inside ~10m, so the glider physically could not follow anyone who moved
+  // (issue #210). Still well short of a missile - sprinting away breaks it.
+  [Export] public float TurnDegreesPerSecond = 115.0f;
+  // How far ahead of a moving target the glider aims (issue #210).
+  [Export] public float MaxLeadSeconds = 1.2f;
   [Export] public float MaxGlideSeconds = 10.0f;
   [Export] public float FlutterSpeed = 4.5f;
   [Export] public float MaxLifetimeSeconds = 16.0f;
@@ -48,7 +53,17 @@ public partial class PaperAirplaneProjectile : Node3D
   }
   private bool IsFluttering => _age > MaxGlideSeconds;
   private bool HasLiveTarget => _target != null && IsInstanceValid (_target) && _target.IsInsideTree();
-  private Vector3 TargetPoint() => _target!.GlobalPosition + Vector3.Up;
+  // Aim where they're GOING, not where they are (issue #210): pure pursuit trails a
+  // moving player & needs an ever-tighter turn as it closes, so the glider swung wide
+  // & sailed past. Leading keeps it dodgeable - CHANGING direction still breaks the
+  // intercept - while a player who just runs in a straight line gets found.
+  private Vector3 TargetPoint()
+  {
+    var body = _target!.GlobalPosition + Vector3.Up;
+    var secondsToImpact = Mathf.Min (GlobalPosition.DistanceTo (body) / Speed, MaxLeadSeconds);
+    var drift = new Vector3 (_target.Velocity.X, 0.0f, _target.Velocity.Z) * secondsToImpact;
+    return body + drift;
+  }
 
   // Shared look for the projectile, the world pickup, & the held model (issue #102):
   // a folded paper dart - a flat delta wing in two dihedral halves over a thin keel,

--- a/core/weapons/WeaponPickup.cs
+++ b/core/weapons/WeaponPickup.cs
@@ -112,6 +112,17 @@ public partial class WeaponPickup : Area3D
   public override void _Process (double delta)
   {
     _ageSeconds += (float)delta;
+
+    // An armed mine LIES on the ground (issue #204): it spawns at the standard
+    // pickup hover like every other pickup, which left the airplane bobbing in
+    // mid-air instead of sitting where it came down, waiting to be stepped on.
+    if (IsArmedMine)
+    {
+      _visual.Position = Vector3.Down * MineRestDrop;
+      if (_armedLight != null) _armedLight.Visible = Mathf.PosMod (_ageSeconds * ArmedBlinksPerSecond, 1.0f) < 0.5f;
+      return;
+    }
+
     _visual.RotateY (Mathf.Tau * RotationsPerSecond * (float)delta);
     _visual.Position = Vector3.Up * (BobHeight * Mathf.Sin (Mathf.Tau * BobsPerSecond * _ageSeconds));
     // An armed airplane winks at everyone while it waits (issue #191).
@@ -158,6 +169,9 @@ public partial class WeaponPickup : Area3D
   // An airplane that came down from flight (issue #191). Anything else - including a
   // fresh spawn-point airplane - is an ordinary pickup you can put in slot 6 (#102).
   private bool IsArmedMine => Weapon == HeldWeapon.PaperAirplane && Armed;
+  // Pickups spawn a hover height up so they're reachable; a mine drops back to the
+  // surface it landed on (issue #204).
+  private const float MineRestDrop = 0.85f;
 
   // Sphere radius (1.2) + the player capsule's reach, against the player's center.
   private const float ClaimRangeMeters = 1.7f;

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -19,6 +19,8 @@ public partial class World : Node3D
   [Signal] public delegate void SelfPlayerSplatteredEventHandler();
   // Someone caught our own thrown paper airplane (issue #102); the thrower's HUD announces it.
   [Signal] public delegate void SelfPlayerAirplaneCaughtEventHandler (string catcherName, string throwerName);
+  // Our own airplane lock landing on somebody (issue #211); the HUD chirps.
+  [Signal] public delegate void SelfPlayerAirplaneLockAcquiredEventHandler();
   // Bread feedback (issue #160): eaten + soft denied cues, forwarded to the HUD.
   [Signal] public delegate void SelfPlayerAteBreadEventHandler();
   [Signal] public delegate void SelfPlayerBreadDeniedEventHandler (bool isOut);
@@ -430,6 +432,7 @@ public partial class World : Node3D
     // Fired only from the server-confirmed handoff now (CodeRabbit on #198), never
     // from the thrower's own prediction - a denied catch used to announce anyway.
     selfPlayer.AirplaneCaught += catcherName => EmitSignal (SignalName.SelfPlayerAirplaneCaught, catcherName, selfPlayer.DisplayName); // Issue #102.
+    selfPlayer.AirplaneLockAcquired += () => EmitSignal (SignalName.SelfPlayerAirplaneLockAcquired); // Issue #211.
     selfPlayer.BreadEaten += _ => EmitSignal (SignalName.SelfPlayerAteBread); // Bread feedback (issue #160).
     selfPlayer.BreadDenied += isOut => EmitSignal (SignalName.SelfPlayerBreadDenied, isOut);
     selfPlayer.Scored += (playerName, shotPlayerName) => EmitSignal (SignalName.PlayerScored, ++_score, playerName, shotPlayerName);

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -117,6 +117,7 @@ public partial class Hud : Control
     _splatter = (ShaderMaterial)_splatterRect.Material;
     _blurRect.Visible = false;
     _splatterRect.Visible = false;
+    _vignetteRect.Visible = false; // Shown by UpdateVignette once health drops (issue #200).
     _shotMeter = GetNode <CooldownMeter> ("CooldownMeters/Shot");
     _slideMeter = GetNode <CooldownMeter> ("CooldownMeters/Slide");
     _fullAutoMeter = GetNode <CooldownMeter> ("CooldownMeters/FullAuto");
@@ -268,7 +269,7 @@ public partial class Hud : Control
     _splatterSlide += SplatterSlidePerSecond * (float)delta;
     _splatter.SetShaderParameter ("slide", _splatterSlide);
     _splatter.SetShaderParameter ("intensity", _splatterSecondsLeft / SplatterSeconds);
-    // 48 wobbling goo chunks per pixel is a real cost, & it was being paid every
+    // 24 wobbling goo chunks per pixel is a real cost, & it was being paid every
     // frame of every match - the node only stays up while goo is on screen (#200).
     _splatterRect.Visible = _splatterSecondsLeft > 0.0f;
   }

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -37,6 +37,7 @@ public partial class Hud : Control
   private CooldownMeter _bananaMeter = null!;
   private TextureRect _breadIcon = null!;
   private AudioStreamPlayer _munchSound = null!;
+  private AudioStreamPlayer _lockOnSound = null!;
   private AudioStreamPlayer _breadDeniedSound = null!;
   private ColorRect _deathOverlay = null!;
   private Label _deathCountdown = null!;
@@ -122,9 +123,12 @@ public partial class Hud : Control
     _bananaMeter = GetNode <CooldownMeter> ("CooldownMeters/Banana");
     _breadIcon = GetNode <TextureRect> ("VBoxContainer/Bread/Icon");
     CreateBreadSounds();
+    _lockOnSound = new AudioStreamPlayer { Stream = ProceduralSounds.LockOn(), MaxPolyphony = 2 }; // Issue #211.
+    AddChild (_lockOnSound);
     _world.SelfPlayerPunched += OnSelfPlayerPunched;
     _world.SelfPlayerSplattered += OnSelfPlayerSplattered;
     _world.SelfPlayerAirplaneCaught += OnSelfPlayerAirplaneCaught;
+    _world.SelfPlayerAirplaneLockAcquired += () => _lockOnSound.Play(); // Issue #211.
     _world.SelfPlayerAteBread += OnSelfPlayerAteBread;
     _world.SelfPlayerBreadDenied += OnSelfPlayerBreadDenied;
     GetNode <Timer> ("LeaderboardTimer").Timeout += UpdateLeaderboard;

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -25,6 +25,12 @@ public partial class Hud : Control
   private ShaderMaterial _vignette = null!;
   private ShaderMaterial _blur = null!;
   private ShaderMaterial _splatter = null!;
+  // The overlay nodes themselves, so they can be hidden while idle (issue #200):
+  // a visible full-screen ColorRect runs its fragment shader over every pixel of
+  // every frame even when it draws nothing at all.
+  private ColorRect _blurRect = null!;
+  private ColorRect _splatterRect = null!;
+  private ColorRect _vignetteRect = null!;
   private CooldownMeter _shotMeter = null!;
   private CooldownMeter _slideMeter = null!;
   private CooldownMeter _fullAutoMeter = null!;
@@ -59,7 +65,11 @@ public partial class Hud : Control
   private void UpdateVignette (int health)
   {
     var threshold = 0.4f * (float)_healthBar.MaxValue;
-    _vignette.SetShaderParameter ("intensity", Mathf.Clamp (1.0f - health / threshold, 0.0f, 1.0f));
+    var intensity = Mathf.Clamp (1.0f - health / threshold, 0.0f, 1.0f);
+    _vignette.SetShaderParameter ("intensity", intensity);
+    // Above the threshold it draws nothing, so stop drawing it: three full-screen
+    // blended quads per frame is real fill-rate at retina resolutions (issue #200).
+    _vignetteRect.Visible = intensity > 0.0f;
   }
 
   private void UpdateLeaderboard()
@@ -99,8 +109,13 @@ public partial class Hud : Control
     _scoreLabel = GetNode <Label> ("VBoxContainer/Score/Label");
     _leaderboardEntries = GetNode <RichTextLabel> ("Leaderboard/MarginContainer/VBoxContainer/Entries");
     _vignette = (ShaderMaterial)GetNode <ColorRect> ("Vignette").Material;
-    _blur = (ShaderMaterial)GetNode <ColorRect> ("Blur").Material;
-    _splatter = (ShaderMaterial)GetNode <ColorRect> ("Splatter").Material;
+    _vignetteRect = GetNode <ColorRect> ("Vignette");
+    _blurRect = GetNode <ColorRect> ("Blur");
+    _splatterRect = GetNode <ColorRect> ("Splatter");
+    _blur = (ShaderMaterial)_blurRect.Material;
+    _splatter = (ShaderMaterial)_splatterRect.Material;
+    _blurRect.Visible = false;
+    _splatterRect.Visible = false;
     _shotMeter = GetNode <CooldownMeter> ("CooldownMeters/Shot");
     _slideMeter = GetNode <CooldownMeter> ("CooldownMeters/Slide");
     _fullAutoMeter = GetNode <CooldownMeter> ("CooldownMeters/FullAuto");
@@ -193,7 +208,12 @@ public partial class Hud : Control
 
   // The ring only ever reads OUR own incoming-airplane threat (issue #191), so no
   // other player's screen can be lit up by somebody else's hazard.
-  private void UpdateTargetRing() => _targetRing.SetThreat (Visible ? _world.SelfPlayer?.AirplaneThreatFraction ?? 0.0f : 0.0f);
+  private void UpdateTargetRing()
+  {
+    var self = Visible ? _world.SelfPlayer : null;
+    _targetRing.SetThreat (self?.AirplaneThreatFraction ?? 0.0f);
+    _targetRing.SetLocked (self?.HasAirplaneLock ?? false); // Thrower's lock-on (issue #205).
+  }
 
   // Bread munch & soft denied cues are code-generated (issue #160): no downloaded assets.
   private void CreateBreadSounds()
@@ -231,6 +251,9 @@ public partial class Hud : Control
     var fadePerSecond = Mathf.Lerp (0.25f, 0.1f, _blurIntensity);
     _blurIntensity = Mathf.Max (0.0f, _blurIntensity - fadePerSecond * (float)delta);
     _blur.SetShaderParameter ("intensity", _blurIntensity);
+    // Sampling the screen texture forces a back-buffer copy, so the node only
+    // stays up while there's actually blur to draw (issue #200).
+    _blurRect.Visible = _blurIntensity > 0.0f;
   }
 
   // The splat slides slowly down the screen & fades out with the banana stun (issue #70).
@@ -241,6 +264,9 @@ public partial class Hud : Control
     _splatterSlide += SplatterSlidePerSecond * (float)delta;
     _splatter.SetShaderParameter ("slide", _splatterSlide);
     _splatter.SetShaderParameter ("intensity", _splatterSecondsLeft / SplatterSeconds);
+    // 48 wobbling goo chunks per pixel is a real cost, & it was being paid every
+    // frame of every match - the node only stays up while goo is on screen (#200).
+    _splatterRect.Visible = _splatterSecondsLeft > 0.0f;
   }
 
   // Tiny center-screen meters near the crosshair (issue #177), each visible only
@@ -281,6 +307,7 @@ public partial class Hud : Control
   private void OnSelfPlayerPunched()
   {
     _blurIntensity = Mathf.Min (1.0f, _blurIntensity + 0.4f);
+    _blurRect.Visible = true; // Idle-hidden until something actually blurs (issue #200).
     _blur.SetShaderParameter ("intensity", _blurIntensity);
   }
 
@@ -291,6 +318,7 @@ public partial class Hud : Control
   private void OnSelfPlayerSplattered()
   {
     _splatterSecondsLeft = SplatterSeconds;
+    _splatterRect.Visible = true; // Idle-hidden until there's goo to draw (issue #200).
     _splatterSlide = 0.0f;
     _splatter.SetShaderParameter ("slide", 0.0f);
     _splatter.SetShaderParameter ("intensity", 1.0f);

--- a/ui/hud/ProceduralSounds.cs
+++ b/ui/hud/ProceduralSounds.cs
@@ -49,6 +49,16 @@ public static class ProceduralSounds
     return FromSamples (samples);
   }
 
+  // Lock acquired (issue #211): two quick ascending blips - clearly "got them",
+  // and distinct from the target warning's single flat beep.
+  public static AudioStreamWav LockOn()
+  {
+    var samples = new float[(int)(SampleRate * 0.16f)];
+    AddChime (samples, startSeconds: 0.0f, fromHz: 880.0f, toHz: 880.0f, seconds: 0.05f, amplitude: 0.24f);
+    AddChime (samples, startSeconds: 0.07f, fromHz: 1320.0f, toHz: 1400.0f, seconds: 0.07f, amplitude: 0.26f);
+    return FromSamples (samples);
+  }
+
   // A short burst of low-passed noise with an exponential decay reads as a bread crunch.
   private static void AddCrunch (float[] samples, float startSeconds, float brightness)
   {

--- a/ui/hud/ProceduralSounds.cs
+++ b/ui/hud/ProceduralSounds.cs
@@ -37,6 +37,18 @@ public static class ProceduralSounds
     return FromSamples (samples);
   }
 
+  // The paper airplane's pop (issue #206): a dry papery burst - a bright noise crack
+  // that decays fast, with a short low thump under it. Deliberately NOT the banana
+  // blast: this is paper letting go, not fruit.
+  public static AudioStreamWav Pop()
+  {
+    var samples = new float[(int)(SampleRate * 0.4f)];
+    AddCrunch (samples, startSeconds: 0.0f, brightness: 0.75f);
+    AddCrunch (samples, startSeconds: 0.03f, brightness: 0.45f);
+    AddChime (samples, startSeconds: 0.0f, fromHz: 180.0f, toHz: 60.0f, seconds: 0.22f, amplitude: 0.35f);
+    return FromSamples (samples);
+  }
+
   // A short burst of low-passed noise with an exponential decay reads as a bread crunch.
   private static void AddCrunch (float[] samples, float startSeconds, float brightness)
   {

--- a/ui/hud/TargetRing.cs
+++ b/ui/hud/TargetRing.cs
@@ -44,8 +44,13 @@ public partial class TargetRing : Control
   // 0 = nothing incoming, 1 = impact. Called every frame by the HUD.
   public void SetThreat (float threat)
   {
+    var was = _threat;
     _threat = Mathf.Clamp (threat, 0.0f, 1.0f);
     if (_threat > 0.0f) { Visible = true; return; }
+    // The warning just ended (CodeRabbit on #206): with a lock still held the ring
+    // stays up, so it has to redraw as the steady lock ring instead of the last
+    // warning frame - nothing else will ask it to while the threat is zero.
+    if (was > 0.0f) QueueRedraw();
     Reset();
   }
 

--- a/ui/hud/TargetRing.cs
+++ b/ui/hud/TargetRing.cs
@@ -18,6 +18,13 @@ public partial class TargetRing : Control
   private const float MinBlinksPerSecond = 3.0f;
   private const float MaxBlinksPerSecond = 14.0f;
   private static readonly Color WarningRed = new(1.0f, 0.15f, 0.12f);
+  // Lock-on (issue #205): the THROWER's confirmation that the airplane will home
+  // on whoever is under the crosshair. Same ring, steady & thinner, so the two
+  // readings can't be confused: a lock is something you chose, a threat is not.
+  private static readonly Color LockRed = new(1.0f, 0.25f, 0.2f);
+  private const float LockThickness = 8.0f;
+  private const float LockAlpha = 0.75f;
+  private bool _locked;
   private float _threat;
   private float _blinkPhase;
   private bool _blinkOn = true;
@@ -42,9 +49,19 @@ public partial class TargetRing : Control
     Reset();
   }
 
+  // An incoming airplane always outranks a lock: being hunted matters more than
+  // what you're aiming at.
+  public void SetLocked (bool locked)
+  {
+    if (_locked == locked) return;
+    _locked = locked;
+    if (_threat <= 0.0f) Visible = locked;
+    QueueRedraw();
+  }
+
   private void Reset()
   {
-    Visible = false;
+    Visible = _locked;
     _blinkPhase = 0.0f;
     _blinkOn = true;
   }
@@ -52,6 +69,7 @@ public partial class TargetRing : Control
   public override void _Process (double delta)
   {
     if (!Visible) return;
+    if (_threat <= 0.0f) return; // A steady lock ring needs no per-frame work.
     UpdateBlink ((float)delta);
     QueueRedraw();
   }
@@ -70,9 +88,16 @@ public partial class TargetRing : Control
 
   public override void _Draw()
   {
-    if (!_blinkOn) return;
     var size = Size;
     var radius = Mathf.Min (size.X, size.Y) * RadiusScreenFraction;
+
+    if (_threat <= 0.0f)
+    {
+      if (_locked) DrawArc (size * 0.5f, radius, 0.0f, Mathf.Tau, 96, new Color (LockRed, LockAlpha), LockThickness, antialiased: true);
+      return;
+    }
+
+    if (!_blinkOn) return;
     var thickness = Mathf.Lerp (MinThickness, MaxThickness, _threat);
     var color = new Color (WarningRed, Mathf.Lerp (MinAlpha, 1.0f, _threat));
     DrawArc (size * 0.5f, radius, 0.0f, Mathf.Tau, 96, color, thickness, antialiased: true);

--- a/ui/hud/splatter.gdshader
+++ b/ui/hud/splatter.gdshader
@@ -9,6 +9,8 @@ uniform float intensity : hint_range(0.0, 1.0) = 0.0;
 uniform float slide = 0.0;
 uniform float seed = 0.0;
 
+const int CHUNKS = 24;
+
 float hash(float n) {
 	return fract(sin(n * 91.17 + seed * 13.73) * 43758.5453);
 }
@@ -26,13 +28,20 @@ float splat(vec2 uv, vec2 center, float radius, float wobble) {
 }
 
 void fragment() {
+	// Nothing on screen: bail before the chunk loop (issue #200). The node is also
+	// hidden while idle, so this is belt-and-braces for the fade edges.
+	if (intensity <= 0.0) {
+		COLOR = vec4(0.0);
+	} else {
 	float goo = 0.0;
 	float shade = 0.0;
-	for (int i = 0; i < 48; i++) {
+	// 24 chunks, not 48: this loop runs per pixel, & at retina resolution the old
+	// count cost over a billion sin/atan calls a frame while the goo was up (#200).
+	for (int i = 0; i < CHUNKS; i++) {
 		float fi = float(i);
 		vec2 rnd = hash2(fi * 7.31);
 		float sizeRnd = hash(fi * 3.77);
-		float radius = mix(0.03, 0.17, sizeRnd * sizeRnd); // Lots of small bits, a few huge ones.
+		float radius = mix(0.10, 0.34, sizeRnd * sizeRnd); // Big gobs with a few enormous ones (issue #202).
 		float fall = 0.5 + 1.0 * hash(fi * 5.13); // Heavier goo slides at its own pace.
 		vec2 center = vec2(rnd.x * 1.15 - 0.075, rnd.y * 1.15 - 0.075 + slide * fall);
 		// Chunks let go one at a time through the stun instead of one uniform fade.
@@ -48,4 +57,5 @@ void fragment() {
 	vec3 color = mix(bright, dark, shade);
 	float alpha = smoothstep(0.05, 0.6, goo) * 0.96 * smoothstep(0.0, 0.22, intensity);
 	COLOR = vec4(color, alpha);
+	}
 }


### PR DESCRIPTION
**Framerate (#200)** — the reported cause of 'extremely low framerate even with one player'. Splatter, Blur, and Vignette are full-screen ColorRects that were always visible, so their fragment shaders ran over every pixel of every frame regardless of whether they drew anything. The splatter loop walked **48 goo chunks per pixel**, each with several `sin`/`atan` calls — on the order of a billion transcendental ops per frame at retina resolution, permanently. Blur additionally sampled `hint_screen_texture`, forcing a back-buffer copy every frame. All three now hide while idle, the splatter shader early-outs at zero intensity, and the chunk count is halved.

**Splat size (#202)** — with fewer chunks the old radius range read tiny, so gobs are now much bigger (and fewer-but-bigger is cheaper than many-small for the same coverage).

**Red halo after respawn (#201)** — `Respawn()` reset health without emitting `HealthChanged`, and both the HUD health bar and the red vignette follow that signal, so the vignette stayed lit for the rest of the life.

**Airplane (#203/#204/#205)** — the pop threw banana-shaped debris merely painted white (paper bursts now get flat scraps); an armed mine floated at pickup hover height instead of lying where it came down; and the throw's target lock worked but was invisible, so it now draws a large steady ring while a player is under the crosshair. An incoming airplane's warning ring always outranks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added paper-airplane target lock-on indicators, HUD support, and distinct lock-on audio.
  - Added burning flame effects and a new papery pop sound.
  - Paper airplanes now lead moving targets and turn more quickly for accurate throws.

- **Bug Fixes**
  - Health-dependent HUD elements now refresh correctly after respawning.
  - Paper-airplane debris uses a flatter shape and is excluded from slingshot pickup.

- **Improvements**
  - Armed paper-airplane mines remain on the ground with warning flashes.
  - Reduced and enlarged splatter effects for clearer visuals and improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->