### PR TITLE
Give bread its own slot & a three-second eating ritual

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 - **Spawn room**: you respawn in a room above the arena & drop back in when you're ready.
 - **Slingshot universal ammo**: with the slingshot out & empty, walking onto any world item *loads* it instead of collecting it — a dropped laser, the boomerang, someone's bread, even the paper airplane. Slung items fly the slingshot's draw-scaled arc & become ordinary pickups again wherever they land.
 - **The paper airplane**: exactly one in the arena, in slot 6. Thrown, it locks onto whoever was under your crosshair & glides after them — *their* screen fills with a red ring beeping faster & faster, then they catch fire & pop, strictly single-target, nobody near them harmed. Punch it out of the air to catch it & throw it back. A glide that never lands its target comes down **armed**: a landmine that picks whoever steps on it, or slingshot ammo for anyone with a slingshot out.
+- **The bread ritual**: your one-per-life loaf is slot 7. Left-click to eat & you're healed to full — after standing perfectly still for three seconds, rooted, with a reverse meter draining on your screen, the loaf raised to your face, crumbs falling, & a tag over your name telling the whole arena what you're doing. You can't cancel it; anyone who lands a hit on you can, & the loaf is wasted.
 - **Death drops everything**: weapons, your uneaten bread, & whatever's nocked in your slingshot all land where you fell.
 - **Leaderboard**, streak & zap messages with appropriately dry humor, low-health vignette, & more.
 
@@ -24,9 +25,9 @@ Full reference: [docs/CONTROLS.md](docs/CONTROLS.md) (movement, all 6 weapon slo
 | W A S D / Mouse / Space | Move, look, jump |
 | Left mouse | Use selected weapon — punch with fists, hold to charge laser / draw slingshot (fires whatever the slingshot is loaded with) |
 | Right mouse | Unbound (reserved) |
-| 1-6 | Fists, laser, banana, boomerang, slingshot, paper airplane |
+| 1-7 | Fists, laser, banana, boomerang, slingshot, paper airplane, bread |
 | Shift / C / V | Slide, crouch, first-/third-person |
-| F / B / G | Full-auto burst, eat bread, dance |
+| F / G | Full-auto burst, dance |
 | Tab | Message history |
 | . / , | Music vote up / down |
 | Esc | Quit dialog |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A fast, friendly multiplayer laser-tag arena FPS built with Godot 4 (.NET/C#). N
 
 ## Controls
 
-Full reference: [docs/CONTROLS.md](docs/CONTROLS.md) (movement, all 6 weapon slots, abilities, music voting, & hidden mechanics).
+Full reference: [docs/CONTROLS.md](docs/CONTROLS.md) (movement, all 7 weapon slots, abilities, music voting, & hidden mechanics).
 
 | Input | Action |
 |---|---|

--- a/core/items/Bread.cs
+++ b/core/items/Bread.cs
@@ -3,9 +3,11 @@ using Godot;
 namespace com.forerunnergames.energyshot.items;
 
 // One-per-life healing snack (issue #62): every (re)spawn restocks it, & eating it
-// (the eat_bread action) restores the player to full health. Since issue #190 the
-// loaf also rides the HeldWeapon mask, so dying drops it as a world pickup & a
-// slingshot can load it as ammo; Player owns that projection (Player.Weapons.cs).
+// restores the player to full health. Since issue #190 the loaf also rides the
+// HeldWeapon mask, so dying drops it as a world pickup & a slingshot can load it as
+// ammo; since issue #209 it also owns weapon slot 7, & primary fire starts the 3s
+// eating ritual (issue #192). Player owns both projections (Player.Weapons.cs &
+// Player.Bread.cs); this class only owns the one-per-life rule.
 public class Bread
 {
   private static readonly Color CrustBrown = new(0.62f, 0.42f, 0.18f);

--- a/core/players/Player.Bread.cs
+++ b/core/players/Player.Bread.cs
@@ -1,0 +1,267 @@
+using com.forerunnergames.energyshot.items;
+using com.forerunnergames.energyshot.ui.hud;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Bread (issues #62, #190, #209 & #192): the one-per-life healing loaf is slot 7 - a
+// real weapon slot you spawn carrying, equip like any other item, & use with primary
+// fire. It still drops on death & still loads into a slingshot; it just has a key now.
+//
+// Eating is a RITUAL, not the old instant B-key heal (issue #192): three seconds
+// rooted in place, drained on a reverse center-screen meter. You must be STATIONARY
+// to start - moving, sliding, or airborne is refused with an error cue & a line above
+// the meter - & for the duration you can't walk, jump, slide, crouch, uncrouch, or
+// switch slots. Looking around is all you get, & whatever stance you started in is
+// locked in. YOU can't cancel it; an attacker can: any hit ends the ritual & WASTES
+// the loaf, so eating in the open is a genuine gamble.
+//
+// Everyone can see it coming (issue #192): Eating replicates like Sliding, Dancing, &
+// Fallen, so every peer renders the loaf raised to the face, the munch bob, tumbling
+// crumbs, & a tag above the name tag - & hears the munching positionally. A rooted,
+// defenceless player is only interesting if opponents can spot one & punish it.
+public partial class Player
+{
+  // Replicated like Dancing so every peer sees (& can punish) the eater; synced
+  // ALWAYS for the same self-healing reason (issue #131), so ApplyEating must stay
+  // idempotent per state.
+  [Export]
+  public bool Eating
+  {
+    get => _eating;
+    set
+    {
+      _eating = value;
+      ApplyEating();
+    }
+  }
+
+  [Export] public float BreadEatSeconds = 3.0f;
+  [Export] public float EatBobScale = 0.12f;
+  // Bites per ritual: the loop period is BreadEatSeconds / this, so the munch rate
+  // follows the duration instead of drifting out of step with it.
+  private const int EatMunchCount = 3;
+  // Anything slower than this counts as standing still (issue #192); a knockback
+  // shove or a stray step is enough to refuse the ritual.
+  private const float EatStillSpeed = 0.5f;
+  private const int CrumbsPerMunch = 4;
+  private const float CrumbSizeMeters = 0.05f;
+  private const float CrumbFallMeters = 1.4f;
+  private const float CrumbSeconds = 0.8f;
+  private const float EatTagNameTagSpacing = 1.2f;
+  private static readonly Color CrumbTan = new(0.85f, 0.68f, 0.36f);
+  private static readonly Vector3 BreadRestPosition = new(0.45f, -0.45f, -0.85f);
+  // Raised into view & tilted toward the mouth at the peak of each bite.
+  private static readonly Vector3 BreadBitePosition = new(0.12f, -0.22f, -0.55f);
+  private static readonly Vector3 BreadRestRotation = new(0.0f, 25.0f, -12.0f);
+  private bool _eating;
+  private float _eatSecondsLeft;
+  // Death-message context (issue #192): whether the hit that just landed caught us
+  // mid-ritual, captured before the interrupt clears it.
+  private bool _wasEatingWhenHit;
+  private Node3D _breadHeld = null!;
+  private AudioStreamPlayer3D _munchSound = null!;
+  private Label3D? _eatTag;
+  private Tween? _eatTween;
+  // 0..1 of the ritual still to run (issue #192): the HUD's reverse meter drains it.
+  public float BreadEatRemainingFraction => BreadEatSeconds <= 0.0f ? 0.0f : Mathf.Clamp (_eatSecondsLeft / BreadEatSeconds, 0.0f, 1.0f);
+
+  // Held model: the same loaf as the world pickup & a slingshot's nocked ammo (issue
+  // #190), resting in the hand - bread looks like bread everywhere - built in code
+  // alongside the boomerang, slingshot, & airplane held models (issue #209).
+  private void CreateBreadHeld()
+  {
+    _breadHeld = Bread.CreateVisual();
+    _breadHeld.Position = BreadRestPosition;
+    _breadHeld.RotationDegrees = BreadRestRotation;
+    GetNode <Node3D> ("Camera3D").AddChild (_breadHeld);
+    // Positional munching (issue #192): the crunch plays on the EATER's node on every
+    // peer, so anyone nearby hears the snacking. Reuses the code-generated munch from
+    // issue #160 - no downloaded audio - & extra voices let bites overlap (issue #182).
+    _munchSound = new AudioStreamPlayer3D { Stream = ProceduralSounds.Munch(), MaxPolyphony = 3, UnitSize = 12.0f };
+    AddChild (_munchSound);
+  }
+
+  // Primary fire with the loaf out starts the ritual (issue #192), replacing the old
+  // eat-bread keypress entirely. Nothing but the timer or a hit ends it.
+  private void UpdateBread (double delta)
+  {
+    if (Eating) { ContinueEating (delta); return; }
+    if (!StartsEating()) return;
+    TryStartEating();
+  }
+
+  private bool StartsEating() => _isInputEnabled && !Fallen && !Dancing && IsBreadSelected && HasBread && Input.IsActionJustPressed ("shoot");
+
+  // Every refusal is spoken (issue #160's rule, kept): an error cue plus a short line
+  // centered above the bread meter.
+  private void TryStartEating()
+  {
+    if (Health >= MaxHealth) { DenyEat ("Already at full health"); return; }
+    if (IsTooBusyToEat()) { DenyEat ("Stand still to eat"); return; }
+    StartEating();
+  }
+
+  // Stationary means stationary (issue #192): no walking, no slide, & never mid-air -
+  // you may EQUIP the loaf mid-slide or mid-jump, but the ritual waits for the slide
+  // to end & for your feet to be back on the ground & still.
+  private bool IsTooBusyToEat() =>
+    !IsOnFloor()
+    || Sliding
+    || _slideJumpCarrying
+    || Input.GetVector ("move_left", "move_right", "move_forward", "move_back") != Vector2.Zero
+    || new Vector2 (Velocity.X, Velocity.Z).Length() > EatStillSpeed;
+
+  private void DenyEat (string reason)
+  {
+    GD.Print ($"{DisplayName}: I can't eat right now: {reason.ToLower()}");
+    EmitSignal (SignalName.BreadDenied, reason);
+  }
+
+  private void StartEating()
+  {
+    _eatSecondsLeft = BreadEatSeconds;
+    Eating = true; // Setter starts the animation on every peer.
+    ReportToServer ($"bread: {DisplayName} started eating");
+    GD.Print ($"{DisplayName}: Chomp. Nobody bother me for {BreadEatSeconds}s...");
+  }
+
+  // No input escapes the three seconds (issue #192): the movement, stance, & slot
+  // gates elsewhere swallow everything, so only the timer finishes the loaf.
+  private void ContinueEating (double delta)
+  {
+    _eatSecondsLeft -= (float)delta;
+    if (_eatSecondsLeft > 0.0f) return;
+    FinishEating();
+  }
+
+  private void FinishEating()
+  {
+    Eating = false;
+    _eatSecondsLeft = 0.0f;
+    SetBreadHeld (isHeld: false); // Consumes the loaf & falls slot 7 back to fists (issues #190 & #209).
+    Health = MaxHealth;
+    ReportToServer ($"bread: {DisplayName} finished the loaf & healed to full");
+    GD.Print ($"{DisplayName}: I ate my bread & feel brand new!");
+    EmitSignal (SignalName.BreadEaten, DisplayName);
+    EmitSignal (SignalName.HealthChanged, Health);
+  }
+
+  // Taking a hit cancels the eat (owner's addition to issue #192). The loaf is
+  // WASTED - no heal, no second loaf this life - which is what makes snacking in the
+  // open a gamble. Called from ApplyDamage on the victim's OWN authority, from a hit
+  // that peer already validated (spawn armor, fallen), so no client can ever claim
+  // "stop eating" at somebody else.
+  private void InterruptEating()
+  {
+    if (!Eating) return;
+    Eating = false;
+    _eatSecondsLeft = 0.0f;
+    SetBreadHeld (isHeld: false);
+    ReportToServer ($"bread: {DisplayName} was interrupted mid-bite & wasted the loaf");
+    GD.Print ($"{DisplayName}: My bread! I dropped my bread!");
+    EmitSignal (SignalName.BreadInterrupted);
+  }
+
+  // Runs on every peer via the replicated Eating property; ALWAYS-mode sync re-fires
+  // the setter every tick, so start/stop exactly once per state flip (like Dancing).
+  private void ApplyEating()
+  {
+    if (_mesh == null || _breadHeld == null) return; // Pre-_Ready sync; the next ALWAYS tick re-applies.
+    if (_eating && _eatTween == null) { StartEatAnimation(); return; }
+    if (!_eating && _eatTween != null) StopEatAnimation();
+  }
+
+  // Mechanically Minecraft-like, simplified & original (issue #192): the loaf swings
+  // up to the face, the body munches on a bob, & crumbs tumble off every bite. One
+  // looping method tween drives the lot from a single 0..pi phase, procedurally on
+  // existing nodes - no animation assets, exactly like the dance (issue #103).
+  private void StartEatAnimation()
+  {
+    _eatTween = CreateTween().SetLoops();
+    _eatTween.TweenCallback (Callable.From (Munch));
+    _eatTween.TweenMethod (Callable.From <float> (ApplyEatPose), 0.0f, Mathf.Pi, BreadEatSeconds / EatMunchCount);
+    ShowEatTag (isVisible: true);
+  }
+
+  // Full restore on every peer, through the same canonical helpers the dance & death
+  // sequence use (issue #103), so no pose ever survives the ritual.
+  private void StopEatAnimation()
+  {
+    _eatTween?.Kill();
+    _eatTween = null;
+    _breadHeld.Position = BreadRestPosition;
+    _breadHeld.RotationDegrees = BreadRestRotation;
+    ShowEatTag (isVisible: false);
+    ApplySlidePose();
+    ApplyCrouchScale();
+  }
+
+  // phase runs 0..pi per bite: sin phi lifts the loaf into the mouth & squashes the
+  // body once. Only the mesh squashes - the hitbox stays honest while you're a
+  // sitting duck, same as the dance.
+  private void ApplyEatPose (float phase)
+  {
+    var munch = Mathf.Sin (phase);
+    var stance = _crouching ? CrouchHeightScale : 1.0f;
+    _breadHeld.Position = BreadRestPosition.Lerp (BreadBitePosition, munch);
+    _breadHeld.RotationDegrees = BreadRestRotation + new Vector3 (-40.0f * munch, 0.0f, 0.0f);
+    _mesh.Scale = new Vector3 (1.0f + EatBobScale * 0.5f * munch, stance * (1.0f - EatBobScale * munch), 1.0f + EatBobScale * 0.5f * munch);
+    _mesh.Position = BodyPoseOffset() - Vector3.Up * (EatBobScale * 0.5f * munch); // Feet stay planted through the squash.
+  }
+
+  private void Munch()
+  {
+    _munchSound.Play();
+    for (var crumb = 0; crumb < CrumbsPerMunch; ++crumb) SpawnCrumb();
+  }
+
+  // Goofy, non-gory garnish (issue #192): tiny code-built crumbs tumble off the loaf
+  // on every bite & fade out. Parented to the world, so they fall where they were
+  // dropped instead of riding the eater around.
+  private void SpawnCrumb()
+  {
+    var material = new StandardMaterial3D { AlbedoColor = CrumbTan, Transparency = BaseMaterial3D.TransparencyEnum.Alpha };
+    var crumb = new MeshInstance3D { Mesh = new BoxMesh { Size = Vector3.One * CrumbSizeMeters }, MaterialOverride = material, CastShadow = GeometryInstance3D.ShadowCastingSetting.Off };
+    GetParent().AddChild (crumb);
+    crumb.GlobalPosition = GlobalPosition + Vector3.Up * NameTagBaseHeight * 0.7f + new Vector3 (_rng.RandfRange (-0.25f, 0.25f), 0.0f, _rng.RandfRange (-0.25f, 0.25f));
+    var tween = crumb.CreateTween().SetParallel();
+    tween.TweenProperty (crumb, "position", crumb.Position + Vector3.Down * CrumbFallMeters, CrumbSeconds).SetTrans (Tween.TransitionType.Quad).SetEase (Tween.EaseType.In);
+    tween.TweenProperty (material, "albedo_color:a", 0.0f, CrumbSeconds);
+    tween.Finished += crumb.QueueFree;
+  }
+
+  // The long-range cue (issue #192): a goofy tag over the name tag, so opponents
+  // across the arena can spot a rooted snacker & come collect. Every peer renders it.
+  private void ShowEatTag (bool isVisible)
+  {
+    _eatTag ??= CreateEatTag();
+    _eatTag.Visible = isVisible;
+  }
+
+  private Label3D CreateEatTag()
+  {
+    var tag = new Label3D
+    {
+      Text = "nom nom nom",
+      Billboard = BaseMaterial3D.BillboardModeEnum.Enabled,
+      Modulate = CrumbTan,
+      OutlineSize = 16,
+      FontSize = 64,
+      Position = Vector3.Up * (NameTagBaseHeight + EatTagNameTagSpacing),
+      Visible = false
+    };
+
+    AddChild (tag);
+    return tag;
+  }
+
+  // Rides above the name tag & scales with it (issue #192), like the crown (issue
+  // #107), so the cue is readable at arena distance. Driven by UpdatePuppetTags.
+  private void UpdateEatTagPlacement (float scaleFactor, float verticalOffset)
+  {
+    if (_eatTag == null) return;
+    _eatTag.Scale = Vector3.One * scaleFactor;
+    _eatTag.Position = new Vector3 (0.0f, NameTagBaseHeight + verticalOffset + EatTagNameTagSpacing * scaleFactor, 0.0f);
+  }
+}

--- a/core/players/Player.Bread.cs.uid
+++ b/core/players/Player.Bread.cs.uid
@@ -1,0 +1,1 @@
+uid://c8g07udp3nvc6

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -347,6 +347,10 @@ public partial class Player
       attacker?.RpcId (attackerId, MethodName.NotifyScored, DisplayName);
       RespawnShot (attackerName);
     }
+    // Survived it (CodeRabbit on #214): the capture is only ever the death snapshot's
+    // context, so a nonlethal interruption must not still read as "died eating" when
+    // a later, unrelated hit finishes the job.
+    else _wasEatingWhenHit = false;
 
     EmitSignal (SignalName.HealthChanged, Health);
   }

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -310,31 +310,6 @@ public partial class Player
     Call ("DropHeldWeapon");
   }
 
-  // One-per-life full heal (issue #62): restocked on every (re)spawn. A press that
-  // can't eat is never silent anymore (issue #160): it emits a soft denied cue.
-  private void UpdateBread()
-  {
-    if (!_isInputEnabled || !Input.IsActionJustPressed ("eat_bread")) return;
-
-    if (!_bread.IsAvailable)
-    {
-      EmitSignal (SignalName.BreadDenied, true); // No bread left this life (issue #160).
-      return;
-    }
-
-    if (Health >= MaxHealth)
-    {
-      EmitSignal (SignalName.BreadDenied, false); // Don't waste the bread at full health.
-      return;
-    }
-
-    SetBreadHeld (isHeld: false); // Eating clears the loaf & its HeldWeapon flag together (issue #190).
-    Health = MaxHealth;
-    GD.Print ($"{DisplayName}: I ate my bread & feel brand new!");
-    EmitSignal (SignalName.BreadEaten, DisplayName);
-    EmitSignal (SignalName.HealthChanged, Health);
-  }
-
   private void ApplyDamage (float energy, string attackerName, float knockbackScale, bool isSurvivableAtFullHealth = false, bool throughBarrier = false)
     => ApplyDamageFrom (Multiplayer.GetRemoteSenderId(), energy, attackerName, knockbackScale, isSurvivableAtFullHealth, throughBarrier);
 
@@ -350,6 +325,8 @@ public partial class Player
     // Intermediate->Expert 1.5x). Attacking downward is unchanged - the bigger health
     // pool already is the handicap.
     Dancing = false; // Getting zapped mid-dance ends the groove on every peer (issue #103).
+    _wasEatingWhenHit = Eating; // Death-message context, captured before the interrupt clears it (issue #192).
+    InterruptEating(); // YOU can't cancel the ritual; an attacker can - & the loaf is wasted (issue #192).
     var attacker = GetParent().GetNodeOrNull <Player> ($"{attackerId}");
     var handicap = 1.0f + 0.5f * Mathf.Max (0, TierOf (MaxHealth) - TierOf (attacker?.MaxHealth ?? MaxHealth));
     var decrease = Mathf.RoundToInt (CalculateHealthDecrease (energy) * handicap);

--- a/core/players/Player.Cosmetics.cs
+++ b/core/players/Player.Cosmetics.cs
@@ -156,6 +156,7 @@ public partial class Player
     _healthTag.Scale = originalHealthTagScale * healthTagScaleFactor;
     _healthTag.Position = new Vector3 (_healthTag.Position.X, NameTagBaseHeight + verticalOffset - tagSpacing, _healthTag.Position.Z);
     UpdateCrownPlacement (scaleFactor, verticalOffset);
+    UpdateEatTagPlacement (scaleFactor, verticalOffset); // The "nom nom nom" cue rides along (issue #192).
   }
 
   // The crown rides clearly above the name tag & scales with it, so the leader is

--- a/core/players/Player.Dance.cs
+++ b/core/players/Player.Dance.cs
@@ -45,7 +45,8 @@ public partial class Player
     StartDance();
   }
 
-  private bool StartsDance() => _isInputEnabled && !IsStunned && !Sliding && Input.IsActionJustPressed ("dance");
+  // The eating ritual blocks the groove too (issue #192): no input escapes the 3s.
+  private bool StartsDance() => _isInputEnabled && !IsStunned && !Sliding && !Eating && Input.IsActionJustPressed ("dance");
 
   private void StartDance()
   {

--- a/core/players/Player.Death.cs
+++ b/core/players/Player.Death.cs
@@ -34,6 +34,7 @@ public partial class Player
     Sliding = false;
     Crouching = false;
     Dancing = false;
+    Eating = false; // A body doesn't finish its sandwich (issue #192).
     Fallen = true;
     _slideJumpCarrying = false; // A corpse (& the next life) inherits no slide-jump momentum (issue #149).
     SetInputEnabled (isEnabled: false);

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -15,6 +15,8 @@ public partial class Player
   public bool DiedSliding { get; private set; }
   public bool DiedArmed { get; private set; }
   public bool DiedHoldingBananaGun { get; private set; }
+  // Zapped out mid-ritual (issue #192): its own scenario, & the funniest one.
+  public bool DiedEating { get; private set; }
   public int LostStreakCount { get; private set; }
   // 0..1 for the HUD's slide cooldown bar, like PunchReadyFraction (issue #127).
   // Non-positive cooldown = always ready; clamped so the HUD bar never sees NaN or overshoot.
@@ -22,13 +24,14 @@ public partial class Player
   // Playtest-observable (issue #149): the current slide's speed - base, or higher when chained.
   public float CurrentSlideSpeed => _currentSlideSpeed;
   private bool IsFalling() => !IsOnFloor();
-  // Stun blocks jumping & sliding (issues #70 & #71).
-  private bool IsJumping() => _isInputEnabled && !IsStunned && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
+  // Stun blocks jumping & sliding (issues #70 & #71); the eating ritual roots you
+  // completely (issue #192) - no walking, jumping, sliding, or crouch changes.
+  private bool IsJumping() => _isInputEnabled && !IsStunned && !Eating && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
   private void Fall (ref Vector3 velocity, double delta) => velocity += Gravity * (float)delta;
   private bool WantsSlide() => _isInputEnabled && !IsStunned && Input.IsActionPressed ("slide");
   // Edge-triggered start (issue #131): a wedged pressed key state (e.g. a swallowed
   // Shift release on focus loss) can't auto-restart slides after every cooldown.
-  private bool StartsSlide() => _isInputEnabled && !IsStunned && Input.IsActionJustPressed ("slide");
+  private bool StartsSlide() => _isInputEnabled && !IsStunned && !Eating && Input.IsActionJustPressed ("slide");
   // Escape hatch (issue #131): while sliding, a fresh slide press always cancels;
   // crouch cancels in UpdateCrouch & jump chains via SlideJump (issue #149).
   private bool CanceledSlide() => _isInputEnabled && Input.IsActionJustPressed ("slide");
@@ -113,6 +116,7 @@ public partial class Player
   // into geometry above.
   private void UpdateCrouch()
   {
+    if (Eating) return; // The stance you started the ritual in is locked in (issue #192).
     if (Sliding && _crouching) { Crouching = false; ApplyCameraHeight(); return; }
     if (_holdToCrouch) { UpdateHeldCrouch(); return; }
     if (!ToggledCrouch()) return;
@@ -158,6 +162,7 @@ public partial class Player
     // The dance owns the mesh (issue #103): Sliding syncs ALWAYS, so this re-runs
     // every tick on puppets & would fight the dance tween; the dance's stop restores.
     if (Dancing) return;
+    if (Eating) return; // Same for the munch bob (issue #192).
     if (Fallen) return; // Same for the death tip-over tween (issue #152).
     var rotation = Sliding ? new Vector3 (-90.0f, 0.0f, 0.0f) : Vector3.Zero;
     var position = BodyPoseOffset();
@@ -180,6 +185,7 @@ public partial class Player
   {
     if (_mesh == null) return;
     if (Dancing) return; // Same ALWAYS-sync reason as ApplySlidePose (issue #103).
+    if (Eating) return; // Same for the munch bob (issue #192).
     if (Fallen) return; // The death tip-over tween owns the mesh (issue #152).
     var scale = new Vector3 (1.0f, _crouching ? CrouchHeightScale : 1.0f, 1.0f);
     var position = BodyPoseOffset();
@@ -204,6 +210,9 @@ public partial class Player
 
   private void Move (ref Vector3 velocity)
   {
+    // Rooted for the ritual (issue #192): movement input produces no motion at all.
+    // Gravity still applies, so a floor vanishing underneath still drops you.
+    if (Eating) { velocity.X = 0.0f; velocity.Z = 0.0f; return; }
     if (_stickyFlightSecondsLeft > 0.0f) return; // Banana-launched (issue #83): momentum owns the ride.
     if (_slideJumpCarrying) return; // Slide-jump air (issue #149): the slide's momentum owns the ride until touchdown.
     var speed = MoveSpeed();
@@ -253,6 +262,8 @@ public partial class Player
     DiedSliding = Sliding;
     DiedArmed = !IsUnarmed; // Carrying bread isn't being armed (issue #190).
     DiedHoldingBananaGun = Holds (HeldWeapon.Banana);
+    // The lethal hit already interrupted the ritual, so read what it captured (issue #192).
+    DiedEating = _wasEatingWhenHit;
     LostStreakCount = ZapStreakCount;
   }
 
@@ -313,6 +324,9 @@ public partial class Player
     _slideChainWindowLeft = 0.0f;
     Crouching = false;
     Dancing = false; // A new life starts with the pose fully restored on every peer (issue #103).
+    Eating = false; // Same for the eating ritual & its munch bob (issue #192).
+    _eatSecondsLeft = 0.0f;
+    _wasEatingWhenHit = false;
     Fallen = false; // Belt & braces: the lie-down always ends before this runs (issue #152).
     ApplyCameraHeight();
     SetInputEnabled (isEnabled: false);

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -7,8 +7,9 @@ namespace com.forerunnergames.energyshot.players;
 // Weapon lifecycle & selection (issues #72 & #82): players spawn with fists only &
 // arm up from world pickups; death drops everything held at the death spot. Slot 1 =
 // fists (always available), slot 2 = laser, slot 3 = banana, slot 4 = boomerang (#98),
-// slot 5 = slingshot (#99); guns are selectable only while held. The server-side
-// WeaponSpawner owns pickup spawning & the weapon caps.
+// slot 5 = slingshot (#99), slot 6 = paper airplane (#102), slot 7 = bread (#209);
+// everything but fists is selectable only while held. The server-side WeaponSpawner
+// owns pickup spawning & the weapon caps.
 public partial class Player
 {
   // Replicated like SpawnArmor so every peer knows what this player carries & renders
@@ -86,6 +87,7 @@ public partial class Player
   private bool HasSlingshot => Holds (HeldWeapon.Slingshot);
   private bool HasPaperAirplane => Holds (HeldWeapon.PaperAirplane);
   private bool IsFistsSelected => _selectedWeapon == SelectedWeapon.Fists;
+  private bool IsBreadSelected => _selectedWeapon == SelectedWeapon.Bread; // Slot 7 (issue #209).
   private bool IsLaserSelected => _selectedWeapon == SelectedWeapon.Laser;
   private bool IsBananaSelected => _selectedWeapon == SelectedWeapon.Banana;
   private bool IsBoomerangSelected => _selectedWeapon == SelectedWeapon.Boomerang;
@@ -121,6 +123,7 @@ public partial class Player
 
     _bread.TryEat();
     HeldWeapon &= ~HeldWeapon.Bread;
+    DeselectUnheldWeapon(); // An eaten, wasted, or dropped loaf can't stay in slot 7 (issue #209).
   }
 
   // Losing the stolen weapon ends the revenge window (CodeRabbit on #96): a fresh
@@ -135,7 +138,8 @@ public partial class Player
   // Runs on every peer via the replicated HeldWeapon & SelectedWeapon properties.
   private void UpdateWeaponVisibility()
   {
-    if (_bananaLauncher == null || _boomerangHeld == null || _slingshotHeld == null || _airplaneHeld == null) return;
+    if (_bananaLauncher == null || _boomerangHeld == null || _slingshotHeld == null || _airplaneHeld == null || _breadHeld == null) return;
+    _breadHeld.Visible = IsBreadSelected && HasBread; // Slot 7 (issue #209): everyone sees the loaf in hand.
     _energyWeapon.Visible = IsLaserSelected && HasLaser;
     _bananaLauncher.Visible = IsBananaSelected && HasBanana;
     _boomerangHeld.Visible = IsBoomerangSelected && HasBoomerang && !IsBoomerangOut; // Empty hand while it's out flying (issue #98).
@@ -149,17 +153,20 @@ public partial class Player
   private void UpdateWeaponSelection()
   {
     if (!_isInputEnabled) return;
+    if (Eating) return; // The eating ritual locks the slot you started it with (issue #192).
     if (Input.IsActionJustPressed ("weapon_1")) SelectedWeapon = SelectedWeapon.Fists;
     if (Input.IsActionJustPressed ("weapon_2") && HasLaser) SelectedWeapon = SelectedWeapon.Laser;
     if (Input.IsActionJustPressed ("weapon_3") && HasBanana) SelectedWeapon = SelectedWeapon.Banana;
     if (Input.IsActionJustPressed ("weapon_4") && HasBoomerang) SelectedWeapon = SelectedWeapon.Boomerang; // Slot 4 (issue #98).
     if (Input.IsActionJustPressed ("weapon_5") && HasSlingshot) SelectedWeapon = SelectedWeapon.Slingshot; // Slot 5 (issue #99).
     if (Input.IsActionJustPressed ("weapon_6") && HasPaperAirplane) SelectedWeapon = SelectedWeapon.PaperAirplane; // Slot 6 (issue #102).
+    if (Input.IsActionJustPressed ("weapon_7") && HasBread) SelectedWeapon = SelectedWeapon.Bread; // Slot 7 (issue #209).
   }
 
   // A dropped or lost gun can't stay selected: fall back to fists (issue #82).
   private void DeselectUnheldWeapon()
   {
+    if (IsBreadSelected && !HasBread) SelectedWeapon = SelectedWeapon.Fists; // An eaten or lost loaf (issue #209).
     if (IsLaserSelected && !HasLaser) SelectedWeapon = SelectedWeapon.Fists;
     if (IsBananaSelected && !HasBanana) SelectedWeapon = SelectedWeapon.Fists;
     if (IsBoomerangSelected && !HasBoomerang) SelectedWeapon = SelectedWeapon.Fists;
@@ -171,8 +178,9 @@ public partial class Player
   // the claimed pickup for everyone.
   public void GrantWeapon (HeldWeapon type, string previousOwner = "")
   {
-    // Bread has no slot & nothing to equip (issue #190): collecting a loaf just
-    // restocks this life's snack, eaten with B like always.
+    // Bread lives in slot 7 now (issue #209), but it's the one pickup that never
+    // auto-equips (issue #128): swapping a gun for a snack mid-fight is the last
+    // thing anyone wants. Press 7 when you actually mean to eat.
     if (type == HeldWeapon.Bread)
     {
       SetBreadHeld (isHeld: true);
@@ -268,6 +276,7 @@ public partial class Player
     ApplyOverlayMaterials (_boomerangHeld);
     ApplyOverlayMaterials (_slingshotHeld); // Slot 5 (issue #99).
     ApplyOverlayMaterials (_airplaneHeld); // Slot 6 (issue #102).
+    ApplyOverlayMaterials (_breadHeld); // Slot 7 (issue #209).
   }
 
   private void ApplyOverlayMaterials (Node node)

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -41,9 +41,12 @@ public partial class Player : CharacterBody3D
 
   [Signal] public delegate void HealthChangedEventHandler (int value);
   [Signal] public delegate void BreadEatenEventHandler (string playerName);
-  // Soft feedback for a bread press that can't eat (issue #160): isOut = the loaf is
-  // gone this life; otherwise the player is already at full health.
-  [Signal] public delegate void BreadDeniedEventHandler (bool isOut);
+  // Soft feedback for an eat attempt that can't start (issue #160), now carrying the
+  // reason itself (issue #192): full health, or not standing still.
+  [Signal] public delegate void BreadDeniedEventHandler (string reason);
+  // A hit ended the ritual & wasted the loaf (issue #192): the HUD makes it
+  // unmistakable - a sound, a message, & the reverse meter visibly dying.
+  [Signal] public delegate void BreadInterruptedEventHandler();
   [Signal] public delegate void PunchedEventHandler();
   [Signal] public delegate void ScoredEventHandler (string playerName, string shotPlayerName);
   [Signal] public delegate void RespawnedShotEventHandler (string playerName, string shotByPlayerName);
@@ -248,8 +251,11 @@ public partial class Player : CharacterBody3D
   [Export] public float HealthTagNameTagMaxSpacing = 3.0f;
   [Export] public float NameTagBaseHeight = 2.3f;
   public int NetworkId => Name.ToString().ToInt();
-  // Whether the one-per-life loaf is still uneaten, for the HUD bread icon (issue #160).
-  public bool HasBread => _bread.IsAvailable;
+  // Whether the one-per-life loaf is still in hand: the HUD bread icon (issue #160) &
+  // the slot-7 selection rules (issue #209). Reads the REPLICATED mask, not the local
+  // Bread item, so puppets render other players' loaves correctly too - SetBreadHeld
+  // keeps the two in lockstep on the owning peer (issue #190).
+  public bool HasBread => Holds (HeldWeapon.Bread);
   public float LastZapEnergy { get; private set; }
   // Whether the last zap this player took came through a pierced barrier (issue #94).
   public bool LastZapThroughBarrier { get; private set; }
@@ -339,6 +345,7 @@ public partial class Player : CharacterBody3D
     CreateBoomerangHeld(); // Code-built held model, no scene asset (issue #98).
     CreateSlingshotHeld(); // Same, for the slot-5 slingshot (issue #99).
     CreateAirplaneHeld(); // Same, for the slot-6 paper airplane (issue #102).
+    CreateBreadHeld(); // Same, for the slot-7 loaf (issue #209).
     UpdateWeaponVisibility();
     // Spawn-state sync runs before _Ready, when the slingshot node was still null,
     // so re-apply or a late joiner never sees an already-nocked item (issue #190).
@@ -434,7 +441,7 @@ public partial class Player : CharacterBody3D
     UpdateAirplaneLock(); // Resolve the lock BEFORE the throw reads it (issues #205 & #211).
     UpdateAirplane(); // Homing glider throws (issue #102).
     UpdateAirplaneCatchWindow(); // An open swing keeps grabbing briefly (issue #102).
-    UpdateBread();
+    UpdateBread (delta); // The slot-7 loaf & its 3s eating ritual (issues #209 & #192).
     UpdateFullAuto (delta);
     UpdatePunch (delta);
     UpdateDance (delta); // After the fire/punch updates, so a canceling press can't also attack (issue #103).

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -123,6 +123,9 @@ properties/21/replication_mode = 2
 properties/22/path = NodePath(".:Burning")
 properties/22/spawn = true
 properties/22/replication_mode = 1
+properties/23/path = NodePath(".:Eating")
+properties/23/spawn = true
+properties/23/replication_mode = 1
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/core/weapons/SelectedWeapon.cs
+++ b/core/weapons/SelectedWeapon.cs
@@ -1,7 +1,8 @@
 namespace com.forerunnergames.energyshot.weapons;
 
 // The weapon slot a player has out (issue #82). Fists are slot 1 & always available;
-// guns are selectable only while carried (see HeldWeapon).
+// guns are selectable only while carried (see HeldWeapon). Bread is slot 7 (issue
+// #209): not a gun, but a real slot you spawn with, equip, & use with primary fire.
 public enum SelectedWeapon
 {
   Fists = 0,
@@ -9,5 +10,6 @@ public enum SelectedWeapon
   Banana = 2,
   Boomerang = 3,
   Slingshot = 4,
-  PaperAirplane = 5
+  PaperAirplane = 5,
+  Bread = 6
 }

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -21,9 +21,10 @@ public partial class World : Node3D
   [Signal] public delegate void SelfPlayerAirplaneCaughtEventHandler (string catcherName, string throwerName);
   // Our own airplane lock landing on somebody (issue #211); the HUD chirps.
   [Signal] public delegate void SelfPlayerAirplaneLockAcquiredEventHandler();
-  // Bread feedback (issue #160): eaten + soft denied cues, forwarded to the HUD.
+  // Bread feedback (issues #160 & #192): eaten, refused, & interrupted cues, forwarded to the HUD.
   [Signal] public delegate void SelfPlayerAteBreadEventHandler();
-  [Signal] public delegate void SelfPlayerBreadDeniedEventHandler (bool isOut);
+  [Signal] public delegate void SelfPlayerBreadDeniedEventHandler (string reason);
+  [Signal] public delegate void SelfPlayerBreadInterruptedEventHandler();
   [Signal] public delegate void RemoteMessageReceivedEventHandler (string message);
   [Signal] public delegate void AdminMessageReceivedEventHandler (string message);
   [Signal] public delegate void KickedFromServerEventHandler (string reason);
@@ -434,7 +435,8 @@ public partial class World : Node3D
     selfPlayer.AirplaneCaught += catcherName => EmitSignal (SignalName.SelfPlayerAirplaneCaught, catcherName, selfPlayer.DisplayName); // Issue #102.
     selfPlayer.AirplaneLockAcquired += () => EmitSignal (SignalName.SelfPlayerAirplaneLockAcquired); // Issue #211.
     selfPlayer.BreadEaten += _ => EmitSignal (SignalName.SelfPlayerAteBread); // Bread feedback (issue #160).
-    selfPlayer.BreadDenied += isOut => EmitSignal (SignalName.SelfPlayerBreadDenied, isOut);
+    selfPlayer.BreadDenied += reason => EmitSignal (SignalName.SelfPlayerBreadDenied, reason);
+    selfPlayer.BreadInterrupted += () => EmitSignal (SignalName.SelfPlayerBreadInterrupted); // A hit ended the ritual (issue #192).
     selfPlayer.Scored += (playerName, shotPlayerName) => EmitSignal (SignalName.PlayerScored, ++_score, playerName, shotPlayerName);
     GD.Print ($"{_selfPlayer.NetworkId}: Registered my player {_selfPlayer.DisplayName}");
     EmitSignal (SignalName.NewGameStarted, _selfPlayer.DisplayName, _selfPlayer.MaxHealth);

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -1,6 +1,6 @@
 # Controls
 
-Current as of v0.8.14.
+Current as of v0.8.15.
 
 ## Movement
 
@@ -15,7 +15,7 @@ Current as of v0.8.14.
 
 ## Weapons
 
-Slot keys select what's in your hands. You spawn with fists only; everything else is picked up in the arena (picking one up auto-equips it). Every weapon uses the same primary button: left click acts with whatever slot is selected; right click is unbound (reserved).
+Slot keys select what's in your hands. You spawn with fists **and bread**; every gun is picked up in the arena (picking one up auto-equips it - bread is the one exception, so a loaf never swaps a weapon out of your hands mid-fight). Every slot uses the same primary button: left click acts with whatever slot is selected; right click is unbound (reserved).
 
 | Key | Weapon | How it works |
 |---|---|---|
@@ -25,6 +25,7 @@ Slot keys select what's in your hands. You spawn with fists only; everything els
 | 4 | Boomerang | Left-click to throw. Curves out & returns; steals weapons from anyone it clips & scoops pickups it passes; auto-catches on return |
 | 5 | Slingshot | Hold left-click to draw, release to fling a stone. Longer draw = faster, flatter, harder (never a one-hit). A quick tap just relaxes the band - stones need a minimum draw, & a short cooldown separates shots. **Universal ammo**: see below |
 | 6 | Paper airplane | Left-click to throw. Locks onto whoever's under your crosshair & glides slowly after them; punch an incoming one (fists out) to catch it & throw it back. Only one exists in the whole game, & it is a personal hazard - see below |
+| 7 | Bread | Left-click to eat: a 3-second rooted ritual that heals you to full. One loaf per life - see below |
 
 ### Slingshot universal ammo
 
@@ -35,12 +36,22 @@ With the slingshot **out and empty**, walking onto any world item **loads it** i
 - Wherever the item lands, it becomes an ordinary world pickup again - nothing is ever destroyed by being fired.
 - Holster the slingshot (or fill it) if you'd rather just pick things up.
 
+### Eating bread
+
+Bread is slot 7 and you spawn carrying one loaf per life. **Left-click with it out to eat**, and then commit:
+
+- It takes **3 seconds**, drained on a reverse meter in the middle of your screen.
+- You must be **standing still** to start. Eating while walking, sliding, or in mid-air is refused with an error cue and a line above the meter. You *can* equip the loaf mid-slide or mid-jump - the ritual just waits until the slide ends and you land and stop.
+- While eating you **cannot move at all**: no walking, jumping, sliding, crouching, uncrouching, or switching slots. Looking around is all you get, and whatever stance you started in is locked in.
+- **You can't cancel it. Anyone else can**: *any* hit ends the ritual, and the loaf is **wasted** - no heal, and no second loaf until you respawn.
+- Finish it and you're healed to full.
+- **Everyone can see you doing it**: the loaf goes up to your face, your body munches, crumbs fall, a tag pops up over your name, and the crunching is audible to anyone nearby. Eating in the open is a gamble.
+
 ## Abilities & extras
 
 | Input | Action |
 |---|---|
 | F | Full-auto laser burst (3s of rapid low-power shots, 15s cooldown; needs the laser) |
-| B | Eat bread - full heal, once per life. Get zapped out before you eat it & the loaf drops with everything else (grab someone else's & you're stocked again) |
 | G | Dance. Blocks your weapons while grooving; any movement or taking a hit cancels it |
 | Shoot the ground beneath you | Rocket boost upward, scaling with charge. Unlimited from the ground; while airborne it works once per airtime, re-armed when you land |
 
@@ -69,6 +80,6 @@ There is exactly **one** paper airplane in the arena. It's a slot-6 weapon like 
 
 - White glow = spawn armor (5s of invulnerability after spawning; firing or punching cancels it).
 - Getting zapped out drops your body at the death spot for ~5s - the camera pulls back so you can watch the aftermath - then you auto-respawn with spawn armor.
-- Getting zapped out also drops **everything** you were carrying - weapons, your uneaten bread, and anything nocked in your slingshot - right where you fell. Dropped items expire after a few seconds.
+- Getting zapped out also drops **everything** you were carrying - weapons, your uneaten bread, and anything nocked in your slingshot - right where you fell. Dropped items expire after a few seconds. (A loaf ruined by an interrupted eat is gone, not dropped.)
 - Kills heal you 50 HP. Falling off the world costs a point - your score can go negative.
 - Difficulty picks your health pool (Beginner 400 / Intermediate 300 / Expert 200), and lower-tier players hit higher-tier players harder.

--- a/project.godot
+++ b/project.godot
@@ -109,9 +109,9 @@ weapon_6={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":54,"key_label":0,"unicode":54,"location":0,"echo":false,"script":null)
 ]
 }
-eat_bread={
+weapon_7={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":55,"location":0,"echo":false,"script":null)
 ]
 }
 ability={

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -327,6 +327,8 @@ public partial class PlaytestDriver : Node
     // riskiest base-color path, since it used to restore a hardcoded default.
     await WaitUntil (() => victimBody.AlbedoColor.IsEqualApprox (PlayerColors.At (VictimColor)), 15, "victim's body returned to its chosen color after the hit flash (#43)");
 
+    await RunBreadEatCompletionPhase(); // Issues #209 & #192.
+
     // Weapon lifecycle (#72): everyone spawns unarmed, so collect the deterministic
     // laser pickup the WeaponSpawner keeps in the spawn room in --playtest mode.
     await WaitUntil (() => WalkedTo (WeaponSpawner.PlaytestLaserPosition), 45, "walked to the playtest laser pickup");
@@ -387,6 +389,8 @@ public partial class PlaytestDriver : Node
     // Streak glow bug (#88): the kill ended the victim's streak; the reset must
     // replicate here so the glow & pulsing leaderboard entry clear.
     await WaitUntil (() => victim.ZapStreakCount == 0, 15, "victim's streak reset replicated to shooter");
+
+    await RunPunchTheEaterPhase (victim); // Issue #192.
 
     // Third-person view (#119): toggle mid-run so the fire-rate & full-auto phases
     // below prove bolts still spawn from the aim ray with the chase camera live.
@@ -620,6 +624,143 @@ public partial class PlaytestDriver : Node
     // Our forged admin RPC from the start of the run was dropped by the server:
     // it never echoed back here through any relay (#158).
     Assert (_adminMessages.All (message => !message.Contains ("FORGED")), "forged admin RPC was rejected (#158)");
+  }
+
+  // The eater's half of the bread ritual (issues #209 & #192): bread is a real weapon
+  // slot you spawn with, left click starts a 3s ritual you can't move during, & the
+  // whole three seconds heals you to full.
+  //
+  // Self-contained on our own spawn loaf: knuckles vs. wall (#122) is the cheapest
+  // way below full health, which the don't-waste-the-loaf rule (#160) requires before
+  // an eat can start at all. Covers the slot key, the moving rejection, the rooting,
+  // & the heal. (The victim's later phase covers the interruption, on ITS loaf: an
+  // interrupted loaf is wasted, so spending this one twice isn't an option.)
+  private async Task RunBreadEatCompletionPhase()
+  {
+    await TakeBreadEatingPosition();
+    Assert (Self.Health < Self.MaxHealth, $"punching the wall dented our own health (#122), health {Self.Health}/{Self.MaxHealth}");
+    Assert (Self.Holds (HeldWeapon.Bread), "still carrying this life's loaf (#190)");
+    await SelectBreadSlot();
+    await AssertEatingOnTheMoveIsRejected();
+    await StartEating ("standing still with bread out");
+    await AssertEatingRootsUsInPlace();
+    await WaitUntil (() => !Self.Eating, 15, "the ritual ran its full three seconds (#192)");
+    Assert (Self.Health == Self.MaxHealth, $"the completed eat healed to full (#62), health {Self.Health}/{Self.MaxHealth}");
+    Assert (!Self.Holds (HeldWeapon.Bread), "the completed eat consumed the loaf (#190)");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Fists, "the emptied bread slot fell back to fists (#209)");
+    Self.Position = SpawnRoomCenter; // Back where the phases below expect to run.
+    await Task.Delay (300);
+  }
+
+  // The attacker's half (#192): a rooted, eating player must be VISIBLE to every peer
+  // - that's the whole risk/reward of the ritual - & a hit must cancel it, wasting
+  // the loaf & healing nothing. The victim's replicated bread slot is our only cue
+  // that it's about to eat, which is exactly what a real opponent has to go on.
+  private async Task RunPunchTheEaterPhase (Player victim)
+  {
+    await WaitUntil (() => victim.SelectedWeapon == SelectedWeapon.Bread, 120, "victim's bread slot replicated to shooter (#209)");
+    Self.Position = victim.GlobalPosition + new Vector3 (0.0f, 0.0f, -2.0f); // Behind it, off the wall it's punching.
+    await Task.Delay (400); // Settle onto the floor.
+    PressAction ("weapon_1"); // Fists, so the swing is a real punch (#82).
+    await Task.Delay (100);
+    ReleaseAction ("weapon_1");
+    // The eating state replicates WHILE the ritual is in progress, not just after it.
+    await WaitUntil (() => victim.Eating, 90, "victim's in-progress eating state replicated to shooter (#192)");
+    await Task.Delay (700); // Leave the victim its own window to prove the ritual roots it.
+
+    // A rooted victim can't dodge (#192), so swing about as fast as the cooldown allows.
+    for (var attempt = 0; attempt < 12 && victim.Eating; ++attempt)
+    {
+      AimAt (victim.GlobalPosition + Vector3.Up);
+      PressLeftClick();
+      await Task.Delay (60);
+      ReleaseLeftClick();
+      await Task.Delay (190);
+    }
+
+    await WaitUntil (() => !victim.Eating, 5, "our punch canceled the victim's eat (#192)");
+    Assert (victim.Health < victim.MaxHealth, $"the canceled eat healed nobody (#192), victim health {victim.Health}/{victim.MaxHealth}");
+    Self.Position = SpawnRoomCenter;
+    await Task.Delay (300);
+    PressAction ("weapon_2"); // The bolt-counting phases below need the laser back.
+    await Task.Delay (100);
+    ReleaseAction ("weapon_2");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Laser, "laser re-selected after the bread interrupt phase (#192)");
+  }
+
+  // The bread mark: the spawn-room corner where the wall at z=6 is point-blank, so a
+  // few fist-fulls of wall get us below full health (#122) without touching anyone.
+  private async Task TakeBreadEatingPosition()
+  {
+    Self.Position = new Vector3 (5.0f, 31.0f, 5.0f);
+    await Task.Delay (400); // Settle onto the floor.
+    PressAction ("weapon_1");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_1");
+    AimAt (new Vector3 (5.0f, 31.0f, 6.0f)); // Mid-height of the wall ahead.
+
+    for (var attempt = 0; attempt < 12 && Self.Health >= Self.MaxHealth; ++attempt)
+    {
+      PressLeftClick();
+      await Task.Delay (80);
+      ReleaseLeftClick();
+      await Task.Delay (350);
+    }
+  }
+
+  private async Task SelectBreadSlot()
+  {
+    PressAction ("weapon_7");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_7");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Bread, "bread is selectable in its own slot (#209)");
+  }
+
+  // Moving rejects the eat (#192): no ritual ever starts while we're walking, & the
+  // refused attempt costs nothing.
+  private async Task AssertEatingOnTheMoveIsRejected()
+  {
+    var mark = Self.Position;
+    Input.ActionPress ("move_back"); // Away from the wall we've been punching.
+    await Task.Delay (350);
+    PressLeftClick();
+    await Task.Delay (200);
+    ReleaseLeftClick();
+    Assert (!Self.Eating, "eating while moving was rejected (#192)");
+    Assert (Self.Holds (HeldWeapon.Bread), "the rejected attempt cost us nothing (#192)");
+    Input.ActionRelease ("move_back");
+    Self.Position = mark; // Back on the mark, so an attacker's rendezvous still holds.
+    await WaitUntil (() => new Vector2 (Self.Velocity.X, Self.Velocity.Z).Length() < 0.5f, 10, "came to a full stop before eating (#192)");
+  }
+
+  // Rooted (#192): movement & jump input produce no motion at all, & neither escapes
+  // the ritual.
+  private async Task AssertEatingRootsUsInPlace()
+  {
+    var rootedFrom = Self.GlobalPosition;
+    Input.ActionPress ("move_forward");
+    PressAction ("jump");
+    await Task.Delay (400);
+    ReleaseAction ("jump");
+    Input.ActionRelease ("move_forward");
+    Assert (Self.Eating, "no movement or jump input escaped the ritual (#192)");
+    Assert (Self.GlobalPosition.DistanceTo (rootedFrom) < 0.3f, $"eating rooted us in place (#192), drifted {Self.GlobalPosition.DistanceTo (rootedFrom):0.00}m");
+  }
+
+  // Left click with the loaf out starts the ritual (#192), retried until it takes:
+  // the stationary check is honest about settling velocity & knockback shoves, so a
+  // rejected press just means "not quite still yet".
+  private async Task StartEating (string description)
+  {
+    for (var attempt = 0; attempt < 15 && !Self.Eating; ++attempt)
+    {
+      PressLeftClick();
+      await Task.Delay (60);
+      ReleaseLeftClick();
+      await Task.Delay (200);
+    }
+
+    Assert (Self.Eating, $"left click started the eating ritual (#192): {description}");
   }
 
   // Death-drop coverage (issue #169): the victim died holding the deterministic
@@ -921,6 +1062,10 @@ public partial class PlaytestDriver : Node
     // Streak glow (#77/#88): the shooter's kill streak must replicate to the victim's
     // copy of the shooter node, since that drives the glow & leaderboard pulsing here.
     await WaitUntil (() => FindPlayer (ShooterName)?.ZapStreakCount >= 1, 15, "shooter's streak replicated to victim");
+    // The bread ritual (#192) runs on THIS life's fresh loaf, after the death-drop
+    // phase has already proved the previous one landed as a pickup: an interrupted
+    // eat wastes the loaf, so it can't be the one the death drop is counting on.
+    await RunBreadInterruptedPhase();
     // Fall penalty goes negative (issue #108): step off the world at score 0 & verify -1.
     Assert (Self.Score == 0, $"own score is 0 before the fall, got {Self.Score}");
     Self.Position = new Vector3 (120.0f, 5.0f, 120.0f); // Beyond the arena: nothing below but the kill boundary.
@@ -928,6 +1073,8 @@ public partial class PlaytestDriver : Node
     // Respawned from the fall; the shooter's paper airplane phase needs us standing
     // in the spawn room (#102).
     await WaitUntil (() => Self.GlobalPosition.Y > 20.0f, 30, "respawned in the spawn room after the fall");
+    await WaitForTheShooterToClearTheCatchMark();
+    await DitchStraySlingshot(); // Before leaving the spawn room, so the drop stays here.
     // Take up a fixed mark out in the empty arena for the catch (#102): the three
     // bots milling about the spawn room made this phase a lottery - the idle host
     // kept wandering under the shooter's crosshair & stealing the airplane's target
@@ -962,6 +1109,35 @@ public partial class PlaytestDriver : Node
     // The shooter's forged admin RPC must never have been relayed to us: the
     // server drops admin messages from any sender but peer 1 (#158).
     Assert (_adminMessages.All (message => !message.Contains ("FORGED")), "forged admin RPC never relayed to the victim (#158)");
+  }
+
+  // The interrupted half of the bread ritual (issue #192): YOU can't cancel the three
+  // seconds, but an attacker can. The shooter watches our replicated bread slot &
+  // eating state - the same cues a real opponent gets - & swings; the hit must end
+  // the ritual, WASTE the loaf, heal nothing, & drop the empty slot back to fists.
+  //
+  // Runs at the bread mark (the spawn-room corner with the wall at z=6 point-blank):
+  // a fresh life starts at full health, & the don't-waste-the-loaf rule (#160) refuses
+  // an eat there, so a few knuckles vs. wall (#122) open the ritual up.
+  private async Task RunBreadInterruptedPhase()
+  {
+    Assert (Self.Holds (HeldWeapon.Bread), "this life restocked the loaf (#62/#190)");
+    await WaitUntil (() => !Self.SpawnArmor, 20, "spawn armor expired before the bread ritual (#192)");
+    await TakeBreadEatingPosition();
+    Assert (Self.Health < Self.MaxHealth, $"punching the wall dented our own health (#122), health {Self.Health}/{Self.MaxHealth}");
+    await SelectBreadSlot(); // The shooter watches for this before coming over.
+    await AssertEatingOnTheMoveIsRejected();
+    // Only start once the shooter has taken its punching position: the loaf is
+    // one-per-life, so a ritual nobody can reach would just be wasted.
+    await WaitUntil (() => FindPlayer (ShooterName)?.GlobalPosition.DistanceTo (Self.GlobalPosition) < 3.5f, 120, "shooter took punching position (#192)");
+    await StartEating ("standing still with bread out");
+    await AssertEatingRootsUsInPlace();
+    // The shooter is swinging now: the hit must end it. A completed eat would have
+    // healed us to full instead, which is exactly what the health assert catches.
+    await WaitUntil (() => !Self.Eating, 25, "the incoming punch canceled the eat (#192)");
+    Assert (Self.Health < Self.MaxHealth, $"the canceled eat granted no heal (#192), health {Self.Health}/{Self.MaxHealth}");
+    Assert (!Self.Holds (HeldWeapon.Bread), "the interrupted loaf was wasted (#192)");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Fists, "the emptied bread slot fell back to fists (#209)");
   }
 
   // Landing & landmine (#102 & #191): the caught airplane is thrown into the floor
@@ -1005,6 +1181,44 @@ public partial class PlaytestDriver : Node
     Assert (!Self.Burning, "a fresh life never inherits the fire (#191)");
     // Exactly one airplane, always (#102/#191): the caps fold a new one straight away.
     await WaitUntil (() => AirplaneCount() == 1, 25, "exactly one paper airplane back in the level (#102/#191)");
+  }
+
+  // The shooter's movement batch (#148/#149/#150) teleports onto the very corner we
+  // park on for the airplane catch (#102), & a body already standing there is
+  // something to ride up & off: its slide leaves the floor, so the slide-jump that
+  // ends it is swallowed (#149 needs IsOnFloor) & the chain phase wedges. Its trip
+  // DOWN into the arena & back UP to the spawn room afterwards is the all-clear.
+  // Waited out from a quiet spot away from the spawn room's pickups, so idling here
+  // can't auto-claim one (#128).
+  private async Task WaitForTheShooterToClearTheCatchMark()
+  {
+    Self.Position = new Vector3 (5.0f, 31.0f, -3.0f); // Clear of all four deterministic pickup spots.
+    await Task.Delay (300); // Settle onto the floor.
+    var wentDown = false;
+
+    await WaitUntil (() =>
+    {
+      var shooter = FindPlayer (ShooterName);
+      if (shooter == null) return false;
+      wentDown |= shooter.GlobalPosition.Y < 20.0f;
+      return wentDown && shooter.GlobalPosition.Y > 20.0f;
+    }, 240, "shooter finished its arena phases & cleared the catch mark (#149)");
+  }
+
+  // The spawn room's deterministic pickups (#72) sit inside the +/-4 random spawn
+  // scatter, so a respawn can land right on one & auto-claim it (#128) - the same
+  // hazard the shooter's spawn snapshot guards against. A stray slingshot is the one
+  // that breaks the landmine phase below: an equipped slingshot LOADS an armed
+  // airplane as ammo instead of setting it off (#190). Dropped here, in the spawn
+  // room, so the drop is left far behind when we take our mark in the arena.
+  private async Task DitchStraySlingshot()
+  {
+    if (!Self.Holds (HeldWeapon.Slingshot)) return;
+    PressAction ("weapon_5"); // DropHeldWeapon prefers the selected slot (#82).
+    await Task.Delay (100);
+    ReleaseAction ("weapon_5");
+    Self.DropHeldWeapon();
+    await WaitUntil (() => !Self.Holds (HeldWeapon.Slingshot), 10, "ditched a slingshot auto-claimed by an unlucky respawn (#128)");
   }
 
   // Every airplane anywhere: pickups on the ground plus whatever is in someone's

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -12,15 +12,16 @@ public class MessageGeneratorTest
   private static DeathContext Laser (float energy = 0.5f) => new() { Kind = DamageKind.Laser, Energy = energy };
 
   [TestCase]
-  public void ExactlyOneHundredTwentyEightUniqueMessageTemplates()
+  public void ExactlyOneHundredThirtyFourUniqueMessageTemplates()
   {
     // 100 from the content wave (issue #84) + 3 through-wall zaps (issue #94)
     // + 4 boomerang zap-outs (issue #98) + 4 slingshot zap-outs (issue #99)
     // + 6 paper airplane zap-outs & 3 airplane catches (issues #102 & #191)
-    // + 4 slung-item zap-outs (issue #190) + 4 landmines (issue #191).
+    // + 4 slung-item zap-outs (issue #190) + 4 landmines (issue #191)
+    // + 6 zapped-mid-bread-ritual (issue #192).
     var templates = MessagePools.All.SelectMany (pool => pool).ToList();
-    AssertInt (templates.Count).IsEqual (128);
-    AssertInt (templates.Distinct().Count()).IsEqual (128);
+    AssertInt (templates.Count).IsEqual (134);
+    AssertInt (templates.Distinct().Count()).IsEqual (134);
   }
 
   [TestCase]
@@ -35,8 +36,8 @@ public class MessageGeneratorTest
   [TestCase]
   public void EveryPoolIsInTheRegistry()
   {
-    // 29 scenario pools registered, none empty.
-    AssertInt (MessagePools.All.Count).IsEqual (29);
+    // 30 scenario pools registered, none empty.
+    AssertInt (MessagePools.All.Count).IsEqual (30);
     foreach (var pool in MessagePools.All) AssertBool (pool.Count > 0).IsTrue();
   }
 
@@ -115,6 +116,24 @@ public class MessageGeneratorTest
     var message = MessageGenerator.OnAirplaneCatch ("Alice", "Bob");
     AssertBool (message.Contains ("Alice")).IsTrue();
     AssertBool (message.Contains ("Bob")).IsTrue();
+  }
+
+  [TestCase]
+  public void EatingPoolSelectedWhenZappedMidRitual()
+  {
+    // Standing rooted for three seconds is the whole story of that death (issue #192),
+    // so it beats the stance & carried-weapon flavors below it...
+    var eating = Laser() with { VictimEating = true };
+    AssertObject (MessageGenerator.SelectZappedPool (eating)).IsSame (MessagePools.ZappedEating);
+    AssertObject (MessageGenerator.SelectZappedPool (eating with { VictimHeldBananaGun = true })).IsSame (MessagePools.ZappedEating);
+    AssertObject (MessageGenerator.SelectZappedPool (eating with { KillerSliding = true, KillerAirborne = true })).IsSame (MessagePools.ZappedEating);
+    // ...but never the scenarios above it, so a future reorder can't quietly promote it.
+    AssertObject (MessageGenerator.SelectZappedPool (eating with { VictimLostStreak = 5 })).IsSame (MessagePools.StreakEnded);
+    AssertObject (MessageGenerator.SelectZappedPool (eating with { SplatterActive = true, BlurActive = true })).IsSame (MessagePools.ComboSplatterPunch);
+    AssertObject (MessageGenerator.SelectZappedPool (eating with { Kind = DamageKind.Punch })).IsSame (MessagePools.Punch);
+    AssertObject (MessageGenerator.SelectZappedPool (eating with { Kind = DamageKind.Boomerang })).IsSame (MessagePools.Boomerang);
+    // Not eating: nothing changes.
+    AssertObject (MessageGenerator.SelectZappedPool (Laser())).IsSame (MessagePools.Zapped);
   }
 
   [TestCase]

--- a/ui/hud/CooldownMeter.cs
+++ b/ui/hud/CooldownMeter.cs
@@ -5,16 +5,24 @@ namespace com.forerunnergames.energyshot.ui.hud;
 // A tiny center-screen cooldown indicator (issue #177): visible only while its
 // cooldown is actually recovering, fading in & out fast, with a brief green flash
 // the moment it comes back ready. Replaces the old permanent bar row.
+//
+// The same meter also runs in REVERSE for timed rituals (issue #192): the bar starts
+// full & drains to empty, stays visible the whole way, & dies on a red flash if the
+// ritual is interrupted. Same node, same fade family, so every meter matches.
 public partial class CooldownMeter : HBoxContainer
 {
   private const float FadeInPerSecond = 10.0f;
   private const float FadeOutPerSecond = 5.0f;
   private const float ReadyFlashSeconds = 0.35f;
+  private const float InterruptFlashSeconds = 0.5f;
   private static readonly Color ReadyFlashColor = new(0.55f, 1.0f, 0.55f);
+  private static readonly Color InterruptFlashColor = new(1.0f, 0.35f, 0.3f);
   private ProgressBar _bar = null!;
   private float _alpha;
   private float _flashSecondsLeft;
+  private float _interruptSecondsLeft;
   private bool _isRecovering;
+  private bool _isDraining;
 
   public override void _Ready()
   {
@@ -31,13 +39,39 @@ public partial class CooldownMeter : HBoxContainer
     _isRecovering = recovering;
   }
 
+  // Reverse mode (issue #192): remaining runs 1 -> 0 while isActive holds the meter
+  // on screen. A drain that reaches its end gets the same green flash a recovered
+  // cooldown does; an interrupted one is claimed by Interrupt() instead.
+  public void SetDraining (float remaining, bool isActive)
+  {
+    _bar.Value = remaining;
+    if (_isDraining && !isActive && _interruptSecondsLeft <= 0.0f) _flashSecondsLeft = ReadyFlashSeconds;
+    _isDraining = isActive;
+  }
+
+  // The meter visibly dies (issue #192): a red flash instead of the green one, the
+  // bar slammed to empty, & then the usual fade out.
+  public void Interrupt()
+  {
+    _interruptSecondsLeft = InterruptFlashSeconds;
+    _flashSecondsLeft = 0.0f;
+    _isDraining = false;
+    _bar.Value = 0.0f;
+  }
+
   public override void _Process (double delta)
   {
     var dt = (float)delta;
     _flashSecondsLeft = Mathf.Max (0.0f, _flashSecondsLeft - dt);
-    var isRelevant = _isRecovering || _flashSecondsLeft > 0.0f;
+    _interruptSecondsLeft = Mathf.Max (0.0f, _interruptSecondsLeft - dt);
+    var isRelevant = _isRecovering || _isDraining || _flashSecondsLeft > 0.0f || _interruptSecondsLeft > 0.0f;
     _alpha = Mathf.Clamp (_alpha + (isRelevant ? FadeInPerSecond : -FadeOutPerSecond) * dt, 0.0f, 1.0f);
-    var color = _flashSecondsLeft > 0.0f ? ReadyFlashColor : Colors.White;
-    Modulate = color with { A = _alpha };
+    Modulate = FlashColor() with { A = _alpha };
+  }
+
+  private Color FlashColor()
+  {
+    if (_interruptSecondsLeft > 0.0f) return InterruptFlashColor;
+    return _flashSecondsLeft > 0.0f ? ReadyFlashColor : Colors.White;
   }
 }

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -35,10 +35,14 @@ public partial class Hud : Control
   private CooldownMeter _slideMeter = null!;
   private CooldownMeter _fullAutoMeter = null!;
   private CooldownMeter _bananaMeter = null!;
+  // Runs in reverse (issue #192): the eating ritual drains it instead of filling it.
+  private CooldownMeter _eatMeter = null!;
   private TextureRect _breadIcon = null!;
-  private AudioStreamPlayer _munchSound = null!;
+  private Label _breadNotice = null!;
+  private ulong _breadNoticeEndMs;
   private AudioStreamPlayer _lockOnSound = null!;
   private AudioStreamPlayer _breadDeniedSound = null!;
+  private AudioStreamPlayer _breadInterruptedSound = null!;
   private ColorRect _deathOverlay = null!;
   private Label _deathCountdown = null!;
   private TargetRing _targetRing = null!;
@@ -48,6 +52,9 @@ public partial class Hud : Control
   private float _splatterSlide;
   private const float SplatterSeconds = 5.0f; // Matches the banana stun window (issue #70).
   private const float SplatterSlidePerSecond = 0.06f;
+  private const float BreadNoticeSeconds = 2.0f; // How long a bread refusal/interruption line lingers (issue #192).
+  private static readonly Color BreadNoticeColor = new(1.0f, 0.85f, 0.5f);
+  private static readonly Color BreadInterruptColor = new(1.0f, 0.4f, 0.35f);
   private int _zapStreak;
   private int _zappedStreak;
   private int _fallStreak;
@@ -122,8 +129,10 @@ public partial class Hud : Control
     _slideMeter = GetNode <CooldownMeter> ("CooldownMeters/Slide");
     _fullAutoMeter = GetNode <CooldownMeter> ("CooldownMeters/FullAuto");
     _bananaMeter = GetNode <CooldownMeter> ("CooldownMeters/Banana");
+    _eatMeter = GetNode <CooldownMeter> ("CooldownMeters/Eat"); // Reverse meter (issue #192).
     _breadIcon = GetNode <TextureRect> ("VBoxContainer/Bread/Icon");
     CreateBreadSounds();
+    CreateBreadNotice();
     _lockOnSound = new AudioStreamPlayer { Stream = ProceduralSounds.LockOn(), MaxPolyphony = 2 }; // Issue #211.
     AddChild (_lockOnSound);
     _world.SelfPlayerPunched += OnSelfPlayerPunched;
@@ -132,6 +141,7 @@ public partial class Hud : Control
     _world.SelfPlayerAirplaneLockAcquired += () => _lockOnSound.Play(); // Issue #211.
     _world.SelfPlayerAteBread += OnSelfPlayerAteBread;
     _world.SelfPlayerBreadDenied += OnSelfPlayerBreadDenied;
+    _world.SelfPlayerBreadInterrupted += OnSelfPlayerBreadInterrupted;
     GetNode <Timer> ("LeaderboardTimer").Timeout += UpdateLeaderboard;
     _quitDialog = GetNode <ConfirmationDialog2> ("QuitDialog");
     _quitDialog.Confirmed += () => EmitSignal (SignalName.GameQuit);
@@ -207,6 +217,7 @@ public partial class Hud : Control
     UpdateSplatter (delta);
     UpdateCooldownMeters();
     UpdateBreadIcon();
+    UpdateBreadNotice();
     UpdateDeathOverlay();
     UpdateTargetRing();
   }
@@ -220,13 +231,46 @@ public partial class Hud : Control
     _targetRing.SetLocked (self?.HasAirplaneLock ?? false); // Thrower's lock-on (issue #205).
   }
 
-  // Bread munch & soft denied cues are code-generated (issue #160): no downloaded assets.
+  // Bread cues are code-generated (issue #160): no downloaded assets. The munching
+  // itself is positional now & lives on the eater (issue #192), so only the refusal
+  // & the interruption are HUD-local.
   private void CreateBreadSounds()
   {
-    _munchSound = new AudioStreamPlayer { Stream = ProceduralSounds.Munch() };
     _breadDeniedSound = new AudioStreamPlayer { Stream = ProceduralSounds.Denied() };
-    AddChild (_munchSound);
+    _breadInterruptedSound = new AudioStreamPlayer { Stream = ProceduralSounds.Interrupted() };
     AddChild (_breadDeniedSound);
+    AddChild (_breadInterruptedSound);
+  }
+
+  // A short line centered just above the cooldown meters (issue #192): why the eat
+  // was refused, or that a hit just cost you the loaf. Built in code like the death
+  // overlay & target ring, to keep Hud scene edits minimal.
+  private void CreateBreadNotice()
+  {
+    _breadNotice = new Label { HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Bottom, MouseFilter = MouseFilterEnum.Ignore, Visible = false };
+    _breadNotice.AddThemeFontSizeOverride ("font_size", 22);
+    _breadNotice.AddThemeColorOverride ("font_outline_color", Colors.Black);
+    _breadNotice.AddThemeConstantOverride ("outline_size", 4);
+    _breadNotice.SetAnchorsPreset (LayoutPreset.Center);
+    _breadNotice.OffsetLeft = -240.0f;
+    _breadNotice.OffsetRight = 240.0f;
+    _breadNotice.OffsetTop = 4.0f;
+    _breadNotice.OffsetBottom = 32.0f;
+    AddChild (_breadNotice);
+  }
+
+  private void ShowBreadNotice (string text, Color color)
+  {
+    _breadNotice.Text = text;
+    _breadNotice.Modulate = color;
+    _breadNotice.Visible = true;
+    _breadNoticeEndMs = Time.GetTicksMsec() + (ulong)(BreadNoticeSeconds * 1000.0f);
+  }
+
+  private void UpdateBreadNotice()
+  {
+    if (!_breadNotice.Visible || Time.GetTicksMsec() < _breadNoticeEndMs) return;
+    _breadNotice.Visible = false;
   }
 
   private void ShowDeathOverlay()
@@ -284,6 +328,7 @@ public partial class Hud : Control
     _slideMeter.SetFraction (self.SlideReadyFraction); // The slide meter replaced the punch bar (issue #127).
     _fullAutoMeter.SetFraction (self.FullAutoReadyFraction);
     _bananaMeter.SetFraction (self.BananaReadyFraction);
+    _eatMeter.SetDraining (self.BreadEatRemainingFraction, self.Eating); // Reverse: it drains to empty (issue #192).
   }
 
   // The bread icon dims once the loaf is eaten & brightens when a respawn restocks
@@ -295,17 +340,27 @@ public partial class Hud : Control
     _breadIcon.Modulate = self.HasBread ? Colors.White : new Color (0.4f, 0.4f, 0.4f, 0.35f);
   }
 
-  private void OnSelfPlayerAteBread()
-  {
-    _munchSound.Play();
-    PrintMessage ("You scarf your bread & feel brand new!", MessageScroller.MessageImportance.High);
-  }
+  // The munching itself was heard positionally during the ritual (issue #192); this
+  // is the payoff line for finishing the whole three seconds.
+  private void OnSelfPlayerAteBread() => PrintMessage ("You scarf your bread & feel brand new!", MessageScroller.MessageImportance.High);
 
-  // Soft denied cues (issue #160): a pressed B that can't eat is never silent.
-  private void OnSelfPlayerBreadDenied (bool isOut)
+  // Soft denied cues (issue #160): an eat attempt that can't start is never silent,
+  // & the reason now lands centered above the meter (issue #192).
+  private void OnSelfPlayerBreadDenied (string reason)
   {
     _breadDeniedSound.Play();
-    PrintMessage (isOut ? "No bread left this life" : "Already at full health");
+    ShowBreadNotice (reason, BreadNoticeColor);
+    PrintMessage (reason);
+  }
+
+  // Unmistakable interruption (issue #192): a sour cue, a red line above the meter,
+  // & the reverse meter visibly dying - the loaf is gone & you were not healed.
+  private void OnSelfPlayerBreadInterrupted()
+  {
+    _breadInterruptedSound.Play();
+    _eatMeter.Interrupt();
+    ShowBreadNotice ("Your bread!", BreadInterruptColor);
+    PrintMessage ("That hit cost you your bread!", MessageScroller.MessageImportance.High);
   }
 
   // ~3 hits reach max blur (issue #68): the shader's top LOD is a near-whiteout.
@@ -388,6 +443,7 @@ public partial class Hud : Control
       self?.DiedSliding ?? false,
       self?.DiedArmed ?? false,
       self?.DiedHoldingBananaGun ?? false,
+      self?.DiedEating ?? false, // Zapped out mid-ritual (issue #192).
       self?.LostStreakCount ?? 0,
       killer?.Sliding ?? false,
       killer?.IsLikelyAirborne() ?? false,

--- a/ui/hud/Hud.tscn
+++ b/ui/hud/Hud.tscn
@@ -154,7 +154,7 @@ anchor_bottom = 0.5
 offset_left = -78.0
 offset_top = 34.0
 offset_right = 78.0
-offset_bottom = 110.0
+offset_bottom = 131.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 3
@@ -255,6 +255,32 @@ text = "Banana"
 horizontal_alignment = 2
 
 [node name="Bar" type="ProgressBar" parent="CooldownMeters/Banana"]
+custom_minimum_size = Vector2(96, 6)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 1.0
+show_percentage = false
+
+[node name="Eat" type="HBoxContainer" parent="CooldownMeters"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+theme_override_constants/separation = 8
+mouse_filter = 2
+script = ExtResource("1_cldmtr")
+
+[node name="Label" type="Label" parent="CooldownMeters/Eat"]
+custom_minimum_size = Vector2(52, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 13
+text = "Eating"
+horizontal_alignment = 2
+
+[node name="Bar" type="ProgressBar" parent="CooldownMeters/Eat"]
 custom_minimum_size = Vector2(96, 6)
 layout_mode = 2
 size_flags_horizontal = 3

--- a/ui/hud/ProceduralSounds.cs
+++ b/ui/hud/ProceduralSounds.cs
@@ -28,6 +28,17 @@ public static class ProceduralSounds
     return FromSamples (samples);
   }
 
+  // The interrupted-ritual cue (issue #192): a sour falling two-tone "wah-wahh",
+  // unmistakably different from the soft denied blips - somebody just cost you lunch.
+  public static AudioStreamWav Interrupted()
+  {
+    var samples = new float[(int)(SampleRate * 0.5f)];
+    AddChime (samples, startSeconds: 0.0f, fromHz: 420.0f, toHz: 300.0f, seconds: 0.16f, amplitude: 0.34f);
+    AddChime (samples, startSeconds: 0.17f, fromHz: 300.0f, toHz: 120.0f, seconds: 0.3f, amplitude: 0.34f);
+    AddCrunch (samples, startSeconds: 0.0f, brightness: 0.45f); // The loaf hitting the floor.
+    return FromSamples (samples);
+  }
+
   // A soft "uh-uh" denied cue (issue #160): two low, gentle blips - clearly not an error buzzer.
   public static AudioStreamWav Denied()
   {

--- a/ui/hud/messages/DeathContext.cs
+++ b/ui/hud/messages/DeathContext.cs
@@ -11,6 +11,8 @@ public readonly record struct DeathContext (
   bool VictimSliding,
   bool VictimArmed,
   bool VictimHeldBananaGun,
+  // Caught mid-bread-ritual (issue #192): rooted, defenceless, & holding lunch.
+  bool VictimEating,
   int VictimLostStreak,
   bool KillerSliding,
   bool KillerAirborne,

--- a/ui/hud/messages/MessageGenerator.cs
+++ b/ui/hud/messages/MessageGenerator.cs
@@ -60,6 +60,9 @@ public static class MessageGenerator
     if (context.Kind == DamageKind.SlungItem) return MessagePools.SlungItem; // Issue #190.
     if (context.Kind == DamageKind.Slingshot) return MessagePools.Slingshot; // Issue #99.
     if (context.Kind == DamageKind.PaperAirplane) return MessagePools.PaperAirplane; // Issue #102.
+    // Standing stock still for three seconds is the whole story of that death, so it
+    // outranks every stance & carried-weapon flavor below it (issue #192).
+    if (context.VictimEating) return MessagePools.ZappedEating;
     if (context.VictimHeldBananaGun) return MessagePools.HoldingBananaGun;
     if (context.Kind == DamageKind.Laser && context.ThroughBarrier) return MessagePools.ThroughWall; // Pierced a wall/floor first (issue #94).
     if (context.KillerSliding) return MessagePools.SlideShotKiller;

--- a/ui/hud/messages/MessagePools.cs
+++ b/ui/hud/messages/MessagePools.cs
@@ -257,6 +257,18 @@ public static class MessagePools
     "{z} filed {v}'s paper airplane under 'mine now'"
   };
 
+  // Zapped out mid-bread-ritual (issue #192): three rooted seconds is a long time to
+  // stand still, & everyone could see the loaf going up.
+  public static readonly List <string> ZappedEating = new()
+  {
+    "{z} zapped {v} mid-munch. The loaf never stood a chance",
+    "{v} paused for a snack & {z} paused {v}",
+    "{v} will be remembered for almost finishing that loaf, thanks to {z}",
+    "{z} has no respect for lunch, as {v} just found out",
+    "{v} chose bread. {z} chose the trigger",
+    "{v} took three whole seconds off. {z} needed one"
+  };
+
   // {z} zapped {v} with the weapon {v} dropped earlier.
   public static readonly List <string> TheftRevenge = new()
   {
@@ -272,6 +284,7 @@ public static class MessagePools
     Fall, FallStreak, Zapped, ThroughWall, FullCharge, FullAuto, Punch, PunchedOutArmed, FistsVsFists,
     BananaBlast, BananaDirect, HoldingBananaGun, ComboSplatterPunch, JumpShot, SlideShotKiller,
     SlideShotVictim, ZapStreakTier3, ZapStreakTier5, ZapStreakTier7, StreakEnded, StreakLost,
-    ZappedStreak, Boomerang, Slingshot, SlungItem, PaperAirplane, Landmine, AirplaneCatch, TheftRevenge
+    ZappedStreak, Boomerang, Slingshot, SlungItem, PaperAirplane, Landmine, AirplaneCatch, TheftRevenge,
+    ZappedEating
   };
 }


### PR DESCRIPTION
Bread stops being a keypress and becomes an item you carry, equip, and commit three seconds of your life to.

Fixes #209
Fixes #192

## The slot (#209)

Bread is **weapon slot 7**. You spawn carrying a loaf, press `7` to equip it, and every peer sees it in your hands - the same loaf model as the world pickup and a slingshot's nocked ammo, so bread looks like bread everywhere. Selection follows the existing rules: only selectable while held, and an emptied slot falls straight back to fists (eaten, wasted, or dropped on death).

It is the **one pickup that never auto-equips** (#128): walking over a loaf mid-firefight should never swap a gun out of your hands. Press 7 when you actually mean to eat.

## The ritual (#192)

**Left click** with the loaf out starts eating. The `eat_bread` binding and its whole code path are gone.

- **3 seconds**, drained on a **reverse cooldown meter** centre-screen - the #177 `CooldownMeter` family gained a `SetDraining`/`Interrupt` mode, so it fades, flashes, and sits in the same stack as every other meter.
- **You must be stationary to start.** Moving, sliding, or airborne is refused with an error cue plus a short line centred above the meter. You *may* equip bread mid-slide or mid-air - the ritual simply waits for the slide to end and for you to land and stop. Never a pause mid-air.
- **You cannot move while eating**: no walking, jumping, sliding, crouching, uncrouching, or switching slots. Looking around is allowed, and whatever stance you started in is locked for the duration.
- **You can't cancel it. An attacker can.** Any hit ends the ritual.
- **Finishing it heals you to full** and consumes the loaf. Still one per life, restocked on respawn.

### Interruption behaviour: the loaf is WASTED

Taking a hit mid-bite ends the ritual **with no heal and no second loaf this life** (the owner's first option in the issue comment, rather than the softer abort). Eating in the open is meant to be a gamble, and the punishment has to be worth the attacker's trouble. It is unmistakable on the eater's screen: a sour code-generated two-tone cue plus the loaf hitting the floor, a red "Your bread!" line above the meter, the meter slammed to empty on a red flash, the scroller line *"That hit cost you your bread!"*, and the bread slot dropping back to fists with the HUD icon greying out.

A knock-on: a lethal hit mid-ritual ruins the loaf too, so that death drops one fewer item. Documented in `docs/CONTROLS.md`.

## Everyone can see you eating

A rooted, defenceless player is only interesting if opponents can spot one and punish it, so `Eating` is not just an animation flag. It replicates like `Sliding`/`Dancing`/`Fallen` - **ALWAYS mode, `Player.tscn` property index 23** (appended, indices stay contiguous), with an idempotent `ApplyEating` because ALWAYS re-fires the setter every tick. On **every** peer:

- the **loaf is raised to the face** on each bite, not a subtle idle hold (the held model is a `Camera3D` child, which is exactly the model other peers already render on you);
- a **munch bob** - procedural squash-and-stretch on the mesh only, so the hitbox stays honest, same technique as the dance (#103);
- **crumb specks** tumbling off the loaf and fading out, code-built, non-gory, goofy;
- a **"nom nom nom" tag** billboarded above the name tag, scaled with the same distance factor as the crown so it reads across the arena;
- the **munch plays positionally** from an `AudioStreamPlayer3D` on the eater (`ProceduralSounds.Munch()` from #160), so you can hear someone snacking nearby. The HUD's old 2D munch is gone - one source of truth for the sound.

`ApplySlidePose`/`ApplyCrouchScale` now yield to the munch bob the same way they already yield to the dance and the death tip-over.

## Authority

Nothing here is grantable or consumable by a client claim. The loaf is a flag on the owner's replicated `HeldWeapon` mask, granted only by the server's existing pickup confirmation (#190). The heal is the owner writing its own replicated `Health`, the same victim-authoritative model every other health path uses. The stationary precondition is checked against the eater's own state. The one cross-player effect - the cancel - is applied by the **victim itself** inside `ApplyDamage`, from a hit that peer has already validated (spawn armor, fallen); no peer can ever send "stop eating" at somebody else. Start, finish, and interrupt each file a server log line (#111).

## Messages

New `MessagePools.ZappedEating` pool (6 lines) for dying mid-ritual, wired through a new `DeathContext.VictimEating` flag captured in the death snapshot before the interrupt clears it. It outranks the stance and carried-weapon flavours (three seconds stock still *is* the story of that death) but never the scenarios above it. `MessageGeneratorTest` counts updated to 134 templates / 30 pools, plus a selection-and-ordering test.

## Validation

- `dotnet build`: 0 errors, 0 warnings.
- gdUnit4: 44/44 pass.
- Full 3-instance playtest: green, four consecutive runs.

New playtest coverage:

- bread selectable in its own slot, on both clients;
- eating on the move rejected, and the refused attempt costing nothing;
- the ritual rooting the eater - movement *and* jump input produce 0.00m of motion and never escape it;
- a completed eat healing to full, consuming the loaf, and dropping the slot back to fists;
- an **in-progress** eat replicating to another peer (the shooter waits on the victim's `Eating` while it is still running);
- an incoming punch cancelling it, with no heal and the loaf wasted.

Two playtest robustness fixes fell out of adding those phases, both pre-existing hazards the new timing exposed: the victim now waits for the shooter to finish its arena movement batch before parking on the shared catch mark (two bodies stacked on one mark left the shooter's slide airborne, swallowing its slide-jump), and it ditches a slingshot auto-claimed by an unlucky respawn before the landmine phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bread is equipped in slot 7 and consumed through a three-second eating ritual.
  - Completing the ritual restores health to full.
  - Added eating animations, sounds, particles, progress meter, and “nom nom nom” feedback.
  - Bread is included in starting equipment and death drops.

- **Bug Fixes**
  - Damage interrupts and wastes bread with clear HUD feedback.
  - Eating prevents movement, combat actions, dancing, and jumping.
  - Added contextual death messages for players caught eating.

- **Documentation**
  - Updated controls and gameplay instructions, including the slot 7 bread binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->