### PR TITLE
Stop dead players walking, show the lock ring, & cycle weapons on the wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Full reference: [docs/CONTROLS.md](docs/CONTROLS.md) (movement, all 7 weapon slo
 | W A S D / Mouse / Space | Move, look, jump |
 | Left mouse | Use selected weapon — punch with fists, hold to charge laser / draw slingshot (fires whatever the slingshot is loaded with) |
 | Right mouse | Unbound (reserved) |
-| Mouse wheel / Q / E | Cycle carried weapons |
+| Mouse wheel (up = prev, down = next) / Q / E | Cycle carried weapons |
 | 1-7 | Fists, laser, banana, boomerang, slingshot, paper airplane, bread |
 | Shift / C / V | Slide, crouch, first-/third-person |
 | F / G | Full-auto burst, dance |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Full reference: [docs/CONTROLS.md](docs/CONTROLS.md) (movement, all 7 weapon slo
 | W A S D / Mouse / Space | Move, look, jump |
 | Left mouse | Use selected weapon — punch with fists, hold to charge laser / draw slingshot (fires whatever the slingshot is loaded with) |
 | Right mouse | Unbound (reserved) |
+| Mouse wheel / Q / E | Cycle carried weapons |
 | 1-7 | Fists, laser, banana, boomerang, slingshot, paper airplane, bread |
 | Shift / C / V | Slide, crouch, first-/third-person |
 | F / G | Full-auto burst, dance |

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -31,14 +31,14 @@ public partial class Player
   private bool WantsSlide() => _isInputEnabled && !IsStunned && !Fallen && Input.IsActionPressed ("slide");
   // Edge-triggered start (issue #131): a wedged pressed key state (e.g. a swallowed
   // Shift release on focus loss) can't auto-restart slides after every cooldown.
-  private bool StartsSlide() => _isInputEnabled && !IsStunned && !Eating && Input.IsActionJustPressed ("slide");
+  private bool StartsSlide() => _isInputEnabled && !IsStunned && !Eating && !Fallen && Input.IsActionJustPressed ("slide");
   // Escape hatch (issue #131): while sliding, a fresh slide press always cancels;
   // crouch cancels in UpdateCrouch & jump chains via SlideJump (issue #149).
   private bool CanceledSlide() => _isInputEnabled && Input.IsActionJustPressed ("slide");
   // Mirrors IsJumping plus the room-to-stand check (issue #149): the same press that
   // makes Jump() fire this frame also ends the slide with its momentum & no cooldown.
-  private bool StartsSlideJump() => _isInputEnabled && !IsStunned && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor() && !IsOverheadBlocked();
-  private bool ToggledCrouch() => _isInputEnabled && Input.IsActionJustPressed ("crouch");
+  private bool StartsSlideJump() => _isInputEnabled && !IsStunned && !Eating && !Fallen && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor() && !IsOverheadBlocked();
+  private bool ToggledCrouch() => _isInputEnabled && !Fallen && Input.IsActionJustPressed ("crouch");
   private float MoveSpeed() => (Sliding ? _currentSlideSpeed : _crouching ? Speed * CrouchSpeedMultiplier : Speed) * StunSpeedMultiplier();
 
   // Press to slide, hold to sustain: double speed & a horizontal pose, capped at
@@ -210,10 +210,11 @@ public partial class Player
 
   private void Move (ref Vector3 velocity)
   {
-    // A body lying at the death spot doesn't walk (issue #216): the lie-down tips the
-    // mesh over & takes the camera, but movement input still drove the body around,
-    // so corpses could stroll off for five seconds. Gravity still applies.
-    if (Fallen) { velocity.X = 0.0f; velocity.Z = 0.0f; return; }
+    // The root cause of walking corpses (issue #216): every action predicate honors
+    // the input lock, but Move never did - so "input disabled" stopped everything
+    // EXCEPT walking, through the death lie-down & the respawn lock alike. The
+    // explicit Fallen check stays as defense for any Fallen-with-input-enabled path.
+    if (!_isInputEnabled || Fallen) { velocity.X = 0.0f; velocity.Z = 0.0f; return; }
     // Rooted for the ritual (issue #192): movement input produces no motion at all.
     // Gravity still applies, so a floor vanishing underneath still drops you.
     if (Eating) { velocity.X = 0.0f; velocity.Z = 0.0f; return; }

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -26,9 +26,9 @@ public partial class Player
   private bool IsFalling() => !IsOnFloor();
   // Stun blocks jumping & sliding (issues #70 & #71); the eating ritual roots you
   // completely (issue #192) - no walking, jumping, sliding, or crouch changes.
-  private bool IsJumping() => _isInputEnabled && !IsStunned && !Eating && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
+  private bool IsJumping() => _isInputEnabled && !IsStunned && !Eating && !Fallen && _jumpTimer.IsStopped() && Input.IsActionJustPressed ("jump") && IsOnFloor();
   private void Fall (ref Vector3 velocity, double delta) => velocity += Gravity * (float)delta;
-  private bool WantsSlide() => _isInputEnabled && !IsStunned && Input.IsActionPressed ("slide");
+  private bool WantsSlide() => _isInputEnabled && !IsStunned && !Fallen && Input.IsActionPressed ("slide");
   // Edge-triggered start (issue #131): a wedged pressed key state (e.g. a swallowed
   // Shift release on focus loss) can't auto-restart slides after every cooldown.
   private bool StartsSlide() => _isInputEnabled && !IsStunned && !Eating && Input.IsActionJustPressed ("slide");
@@ -210,6 +210,10 @@ public partial class Player
 
   private void Move (ref Vector3 velocity)
   {
+    // A body lying at the death spot doesn't walk (issue #216): the lie-down tips the
+    // mesh over & takes the camera, but movement input still drove the body around,
+    // so corpses could stroll off for five seconds. Gravity still applies.
+    if (Fallen) { velocity.X = 0.0f; velocity.Z = 0.0f; return; }
     // Rooted for the ritual (issue #192): movement input produces no motion at all.
     // Gravity still applies, so a floor vanishing underneath still drops you.
     if (Eating) { velocity.X = 0.0f; velocity.Z = 0.0f; return; }

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -167,15 +167,30 @@ public partial class Player
     if (Input.IsActionJustPressed ("cycle_weapon_previous")) CycleSelectedWeapon (-1);
   }
 
+  // Trackpad two-finger scrolling arrives as a FLOOD of fine-grained wheel ticks -
+  // uncooled, one swipe machine-guns through every slot (issue #186). One step per
+  // interval keeps a deliberate notch-scroll feeling 1:1.
+  [Export] public float WeaponCycleCooldownSeconds = 0.2f;
+  private ulong _nextCycleAllowedMs;
+
   // Steps through what you're actually CARRYING, in slot order, wrapping around -
   // empty slots are skipped, so cycling never lands on a weapon you don't have.
   private void CycleSelectedWeapon (int step)
   {
+    if (Time.GetTicksMsec() < _nextCycleAllowedMs) return;
     var carried = SelectableSlots();
     if (carried.Count < 2) return; // Fists alone: nothing to cycle to.
-    var current = carried.IndexOf (_selectedWeapon);
-    var next = current < 0 ? 0 : ((current + step) % carried.Count + carried.Count) % carried.Count;
-    SelectedWeapon = carried[next];
+    _nextCycleAllowedMs = Time.GetTicksMsec() + (ulong)(WeaponCycleCooldownSeconds * 1000.0f);
+    SelectedWeapon = NextCycleSlot (carried, _selectedWeapon, step);
+  }
+
+  // Pure wrap math, public static so the unit tests can hit the boundaries directly
+  // (CodeRabbit on #219): forward & reverse wrap, & a current slot not in the list.
+  public static SelectedWeapon NextCycleSlot (List <SelectedWeapon> carried, SelectedWeapon current, int step)
+  {
+    var index = carried.IndexOf (current);
+    var next = index < 0 ? 0 : ((index + step) % carried.Count + carried.Count) % carried.Count;
+    return carried[next];
   }
 
   // Fists are always available; everything else only while it's in your hands.

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -161,6 +161,34 @@ public partial class Player
     if (Input.IsActionJustPressed ("weapon_5") && HasSlingshot) SelectedWeapon = SelectedWeapon.Slingshot; // Slot 5 (issue #99).
     if (Input.IsActionJustPressed ("weapon_6") && HasPaperAirplane) SelectedWeapon = SelectedWeapon.PaperAirplane; // Slot 6 (issue #102).
     if (Input.IsActionJustPressed ("weapon_7") && HasBread) SelectedWeapon = SelectedWeapon.Bread; // Slot 7 (issue #209).
+    // Cycling (issue #186): mouse wheel for mouse players, Q & E for trackpads -
+    // reaching for 7 mid-fight to eat is not a real option.
+    if (Input.IsActionJustPressed ("cycle_weapon_next")) CycleSelectedWeapon (1);
+    if (Input.IsActionJustPressed ("cycle_weapon_previous")) CycleSelectedWeapon (-1);
+  }
+
+  // Steps through what you're actually CARRYING, in slot order, wrapping around -
+  // empty slots are skipped, so cycling never lands on a weapon you don't have.
+  private void CycleSelectedWeapon (int step)
+  {
+    var carried = SelectableSlots();
+    if (carried.Count < 2) return; // Fists alone: nothing to cycle to.
+    var current = carried.IndexOf (_selectedWeapon);
+    var next = current < 0 ? 0 : ((current + step) % carried.Count + carried.Count) % carried.Count;
+    SelectedWeapon = carried[next];
+  }
+
+  // Fists are always available; everything else only while it's in your hands.
+  private List <SelectedWeapon> SelectableSlots()
+  {
+    var slots = new List <SelectedWeapon> { SelectedWeapon.Fists };
+    if (HasLaser) slots.Add (SelectedWeapon.Laser);
+    if (HasBanana) slots.Add (SelectedWeapon.Banana);
+    if (HasBoomerang) slots.Add (SelectedWeapon.Boomerang);
+    if (HasSlingshot) slots.Add (SelectedWeapon.Slingshot);
+    if (HasPaperAirplane) slots.Add (SelectedWeapon.PaperAirplane);
+    if (HasBread) slots.Add (SelectedWeapon.Bread);
+    return slots;
   }
 
   // A dropped or lost gun can't stay selected: fall back to fists (issue #82).

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -12,7 +12,7 @@ Current as of v0.8.15.
 | Shift | Slide (a 3.5s burst, 5s cooldown; press slide or crouch to cancel early - the timer ends standing when there's headroom) |
 | C | Crouch (toggle - press again to stand; switch to hold-to-crouch in the pause dialog, saved between sessions) |
 | V | Toggle first-/third-person view (saved between sessions) |
-| Mouse wheel, or Q / E | Cycle through what you're carrying (skips slots you don't have) |
+| Mouse wheel (up = previous, down = next), or Q / E | Cycle through what you're carrying (skips slots you don't have) |
 
 ## Weapons
 

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -12,6 +12,7 @@ Current as of v0.8.15.
 | Shift | Slide (a 3.5s burst, 5s cooldown; press slide or crouch to cancel early - the timer ends standing when there's headroom) |
 | C | Crouch (toggle - press again to stand; switch to hold-to-crouch in the pause dialog, saved between sessions) |
 | V | Toggle first-/third-person view (saved between sessions) |
+| Mouse wheel, or Q / E | Cycle through what you're carrying (skips slots you don't have) |
 
 ## Weapons
 

--- a/project.godot
+++ b/project.godot
@@ -134,6 +134,18 @@ dance={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":71,"key_label":0,"unicode":103,"location":0,"echo":false,"script":null)
 ]
 }
+cycle_weapon_previous={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":4,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+cycle_weapon_next={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":5,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 toggle_view={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":86,"key_label":0,"unicode":118,"location":0,"echo":false,"script":null)

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1159,6 +1159,7 @@ public partial class PlaytestDriver : Node
     // same mask, so an empty mask here proves the bread went with the weapons.
     Assert (Self.HeldWeapon == HeldWeapon.None, $"death dropped every carried item, bread included (#169/#190), still holding {Self.HeldWeapon}");
     await AssertLoadedSlingshotDroppedBoth();
+    await AssertDeadBodyIsRootedInPlace();
     await WaitUntil (() => Self.SpawnArmor && Self.Health == Self.MaxHealth, 120, "died & respawned with armor & full health");
     var lieDownMs = Time.GetTicksMsec() - fallenStartMs;
     Assert (lieDownMs >= (ulong)(Self.DeathSequenceSeconds * 1000.0f) - 500, $"lay at the death spot ~{Self.DeathSequenceSeconds}s before respawning (#152), got {lieDownMs}ms");
@@ -1250,6 +1251,21 @@ public partial class PlaytestDriver : Node
   // Runs at the bread mark (the spawn-room corner with the wall at z=6 point-blank):
   // a fresh life starts at full health, & the don't-waste-the-loaf rule (#160) refuses
   // an eat there, so a few knuckles vs. wall (#122) open the ritual up.
+  // The walking-corpse regression (#216): the lie-down disables input, but Move()
+  // used to read the keys directly & stroll the body away from the death spot.
+  // Holding forward for a second of the lie-down must not move us at all.
+  private async Task AssertDeadBodyIsRootedInPlace()
+  {
+    if (!Self.Fallen) return; // The lie-down already ended: nothing left to prove this run.
+    var deathSpot = Self.Position;
+    PressAction ("move_forward");
+    await Task.Delay (1000);
+    ReleaseAction ("move_forward");
+    var drift = (Self.Position - deathSpot) with { Y = 0.0f };
+    Assert (Self.Fallen, "still lying down after the rooted-movement window (#216)");
+    Assert (drift.Length() < 0.1f, $"dead body stayed rooted despite held movement input (#216), drifted {drift.Length():F2}m");
+  }
+
   private async Task RunBreadInterruptedPhase()
   {
     Assert (Self.Holds (HeldWeapon.Bread), "this life restocked the loaf (#62/#190)");

--- a/tests/unit/WeaponCycleTest.cs
+++ b/tests/unit/WeaponCycleTest.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.weapons;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Boundary coverage for weapon cycling (issue #186, CodeRabbit on #219). The
+// carried list is what SelectableSlots() builds: fists always, then only held
+// slots in order - so "skipping empty slots" means absent entries here.
+[TestSuite]
+public class WeaponCycleTest
+{
+  // Laser & bread held, banana/boomerang/slingshot/airplane slots empty.
+  private static List <SelectedWeapon> Carried() =>
+    new() { SelectedWeapon.Fists, SelectedWeapon.Laser, SelectedWeapon.Bread };
+
+  [TestCase]
+  public void ForwardStepsInSlotOrderSkippingEmptySlots()
+  {
+    // Laser -> Bread skips the four empty slots between them.
+    AssertObject (Player.NextCycleSlot (Carried(), SelectedWeapon.Laser, 1)).IsEqual (SelectedWeapon.Bread);
+  }
+
+  [TestCase]
+  public void ForwardWrapsFromLastSlotToFists()
+  {
+    AssertObject (Player.NextCycleSlot (Carried(), SelectedWeapon.Bread, 1)).IsEqual (SelectedWeapon.Fists);
+  }
+
+  [TestCase]
+  public void ReverseWrapsFromFistsToLastSlot()
+  {
+    AssertObject (Player.NextCycleSlot (Carried(), SelectedWeapon.Fists, -1)).IsEqual (SelectedWeapon.Bread);
+  }
+
+  [TestCase]
+  public void UnlistedCurrentSlotFallsBackToFists()
+  {
+    // The selected weapon just dropped out of the carried list mid-cycle.
+    AssertObject (Player.NextCycleSlot (Carried(), SelectedWeapon.Banana, 1)).IsEqual (SelectedWeapon.Fists);
+  }
+
+  [TestCase]
+  public void FullLoadoutForwardVisitsEverySlotOnce()
+  {
+    var all = new List <SelectedWeapon>
+    {
+      SelectedWeapon.Fists, SelectedWeapon.Laser, SelectedWeapon.Banana, SelectedWeapon.Boomerang,
+      SelectedWeapon.Slingshot, SelectedWeapon.PaperAirplane, SelectedWeapon.Bread
+    };
+    var current = SelectedWeapon.Fists;
+    var visited = new List <SelectedWeapon>();
+    for (var i = 0; i < all.Count; ++i) { current = Player.NextCycleSlot (all, current, 1); visited.Add (current); }
+    AssertObject (current).IsEqual (SelectedWeapon.Fists); // Full lap wraps home.
+    AssertInt (visited.Count).IsEqual (7);
+  }
+}

--- a/tests/unit/WeaponCycleTest.cs.uid
+++ b/tests/unit/WeaponCycleTest.cs.uid
@@ -1,0 +1,1 @@
+uid://brdm3hyvyl6gl

--- a/ui/hud/TargetRing.cs
+++ b/ui/hud/TargetRing.cs
@@ -74,7 +74,13 @@ public partial class TargetRing : Control
   public override void _Process (double delta)
   {
     if (!Visible) return;
-    if (_threat <= 0.0f) return; // A steady lock ring needs no per-frame work.
+
+    // A steady lock ring doesn't animate, but it still has to redraw (issue #217):
+    // a single draw taken before this control had been laid out produced a radius of
+    // zero, & with nothing asking again the lock ring stayed invisible for the rest
+    // of the match. Cheap - one arc.
+    if (_threat <= 0.0f) { QueueRedraw(); return; }
+
     UpdateBlink ((float)delta);
     QueueRedraw();
   }
@@ -93,7 +99,9 @@ public partial class TargetRing : Control
 
   public override void _Draw()
   {
-    var size = Size;
+    // The viewport, not our own rect (issue #217): a code-added Control can be drawn
+    // before its layout resolves, & a zero size silently drew nothing.
+    var size = GetViewportRect().Size;
     var radius = Mathf.Min (size.X, size.Y) * RadiusScreenFraction;
 
     if (_threat <= 0.0f)


### PR DESCRIPTION
Three from playtesting:

- **#216 you could still move while dead** — the death lie-down tips the body over and takes the camera, but nothing stopped movement input driving it, so a corpse could walk, jump and slide away for the full five seconds. Rooted now; gravity still applies.
- **#217 the airplane lock ring never appeared** — the lock itself worked (the playtest confirms throws acquire), but `_Draw` measured the control's own `Size`, which a code-added Control can report as zero before layout resolves. That single zero-radius draw was the only one, because a steady lock ring doesn't animate and nothing queued another. It measures the viewport now and redraws while visible. Worth noting this path had no coverage — the playtest asserts the throw's target but never the ring — which is why CI stayed green through it.
- **#186 weapon cycling** — mouse wheel, plus Q and E for trackpad players. Steps through what you're actually carrying in slot order, wrapping, skipping slots you don't have. Number keys still select directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added weapon cycling with the mouse wheel or Q/E keys.
  - Cycling skips unavailable weapons, wraps between carried options, and is rate-limited for reliable input.
- **Bug Fixes**
  - Fallen players can no longer jump, slide, or move horizontally; gravity continues normally.
  - Improved target-lock ring rendering for steadier display during layout changes.
- **Documentation**
  - Updated controls documentation to include weapon-cycling inputs and unavailable-slot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->