### PR TITLE
Double full-auto per-shot energy so the burst is worth its slot

### DIFF
--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -62,7 +62,7 @@ public partial class Player
   private void DischargeWeapon() => _energyWeapon.Discharge();
   // Capped at 200: only banana energies exceed 1.0, & the sticky one-hit kill needs
   // the full 200 to zap out an Expert (issue #83).
-  private static int CalculateHealthDecrease (float energyShot) => Mathf.Min (200, Mathf.RoundToInt (energyShot * 100.0f));
+  public static int CalculateHealthDecrease (float energyShot) => Mathf.Min (200, Mathf.RoundToInt (energyShot * 100.0f));
 
   // Casts a ray from the camera along the aim direction, ignoring ourselves, &
   // returns whatever it hits (or null); punches need to know geometry from air (issue #122).

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -189,7 +189,9 @@ public partial class Player : CharacterBody3D
   [Export] public float FullAutoDurationSeconds = 3.0f;
   [Export] public float FullAutoCooldownSeconds = 15.0f;
   [Export] public float FullAutoShotIntervalSeconds = 0.15f;
-  [Export] public float FullAutoEnergy = 0.12f;
+  // Doubled from 0.12 (issue #218): 24 damage/shot means 9-17 shots to zap by health tier
+  // (480 potential per 3s burst) - real sustained pressure, nowhere near the one-shot threshold.
+  [Export] public float FullAutoEnergy = 0.24f;
   // Brief - the spawn room & spawn armor already prevent instant re-engagement (#48).
   [Export] public float RespawnInputLockSeconds = 0.3f;
   // Halved from 0.6 (issue #82): fast enough for combos, not autoclicker-spam fast.

--- a/tests/unit/FullAutoTuningTest.cs
+++ b/tests/unit/FullAutoTuningTest.cs
@@ -1,0 +1,36 @@
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.weapons;
+using GdUnit4;
+using Godot;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Regression coverage for the full-auto buff (issue #218, CodeRabbit on #220):
+// the tuning constants must stay strong enough that a full burst is worth its
+// ability slot, & each shot must stay far below the charged one-shot threshold.
+[TestSuite]
+public partial class FullAutoTuningTest
+{
+  [TestCase]
+  public void FullAutoShotDealsDoubledDamage()
+  {
+    var player = AutoFree (new Player())!;
+    AssertInt (Player.CalculateHealthDecrease (player.FullAutoEnergy)).IsEqual (24);
+  }
+
+  [TestCase]
+  public void FullAutoShotStaysFarBelowOneShotThreshold()
+  {
+    var player = AutoFree (new Player())!;
+    AssertFloat (player.FullAutoEnergy).IsLess (EnergyWeapon.FullChargeEnergyThreshold * 0.5f);
+  }
+
+  [TestCase]
+  public void FullBurstCanZapTheBiggestHealthPool()
+  {
+    var player = AutoFree (new Player())!;
+    var shots = Mathf.FloorToInt (player.FullAutoDurationSeconds / player.FullAutoShotIntervalSeconds);
+    AssertInt (shots * Player.CalculateHealthDecrease (player.FullAutoEnergy)).IsGreaterEqual (Player.MaxHealthFor (0));
+  }
+}

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -158,7 +158,7 @@ public class MessageGeneratorTest
   public void LaserPoolsSplitOnCharge()
   {
     AssertObject (MessageGenerator.SelectZappedPool (Laser (0.96f))).IsSame (MessagePools.FullCharge);
-    AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.FullAuto, Energy = 0.24f })).IsSame (MessagePools.FullAuto);
+    AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.FullAuto })).IsSame (MessagePools.FullAuto);
     AssertObject (MessageGenerator.SelectZappedPool (Laser())).IsSame (MessagePools.Zapped);
   }
 

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -158,7 +158,7 @@ public class MessageGeneratorTest
   public void LaserPoolsSplitOnCharge()
   {
     AssertObject (MessageGenerator.SelectZappedPool (Laser (0.96f))).IsSame (MessagePools.FullCharge);
-    AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.FullAuto, Energy = 0.12f })).IsSame (MessagePools.FullAuto);
+    AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.FullAuto, Energy = 0.24f })).IsSame (MessagePools.FullAuto);
     AssertObject (MessageGenerator.SelectZappedPool (Laser())).IsSame (MessagePools.Zapped);
   }
 


### PR DESCRIPTION
Playtester feedback (thepro) via #218: full-auto wasn't worth using. Aaron's tuning call: double per-shot damage, keep it clearly below the charged one-shot.

- `FullAutoEnergy` 0.12 → 0.24: **24 damage/shot**, 9–17 shots to zap by health tier (200/300/400), 480 potential damage per full 3s burst.
- Fire rate (0.15s), duration (3s), & cooldown (15s) unchanged — sustained pressure, not a second sniper. Red tint & sound already sell the burst.
- Message pool selection keys on `DamageKind.FullAuto`, not energy, so no behavior change there; updated the unit test's context energy to match the new tuning.
- No scene overrides of the exported default (checked Player.tscn).

Closes #218.

Verification is CI's job: this box can't build — run-tests & playtest must go green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Changes**
  * Increased energy available for full-auto attacks, enabling higher damage per shot and greater burst potential.

* **Tests**
  * Updated full-auto damage coverage and added checks for per-shot damage, energy thresholds, and full-burst effectiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->