### PR TITLE
Punch theft: direct steal, already-held fallback drop, & fly-out with pickup delay

### DIFF
--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -290,24 +290,17 @@ public partial class Player
     LastDamageKind = DamageKind.Punch; // Message context (issue #84).
     // No punch sfx here (issue #82): the victim hears the damage sound via ApplyDamage.
     ApplyPunchStun(); // Stacking slow; the blur stacks HUD-side via Punched (issues #68 & #71).
-    TryDropWeaponFromPunch();
+    TryLoseWeaponToPunch (Multiplayer.GetRemoteSenderId());
     EmitSignal (SignalName.Punched);
     ApplyDamage (PunchEnergy, punchedByPlayerName, PunchKnockbackScale);
   }
 
-  // 20% chance a connect knocks the victim's weapon loose (issue #71). The pickup/drop
-  // system lands in another branch; until DropHeldWeapon() exists, this just logs.
-  private void TryDropWeaponFromPunch()
+  // 20% chance a connect costs the victim their item (issue #71); with #193 that's
+  // a theft: the equipped item transfers straight to the puncher, server-validated.
+  private void TryLoseWeaponToPunch (int puncherId)
   {
     if (_rng.Randf() >= PunchDropChance) return;
-
-    if (!HasMethod ("DropHeldWeapon"))
-    {
-      GD.Print ($"{DisplayName}: That punch nearly knocked my weapon loose!");
-      return;
-    }
-
-    Call ("DropHeldWeapon");
+    LoseWeaponToPunch (puncherId);
   }
 
   private void ApplyDamage (float energy, string attackerName, float knockbackScale, bool isSurvivableAtFullHealth = false, bool throughBarrier = false)

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -285,7 +285,7 @@ public partial class Player
   // are nothing to steal.
   private HeldWeapon PickEquippedStealable()
   {
-    var type = _selectedWeapon switch { SelectedWeapon.Laser => HeldWeapon.Laser, SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, SelectedWeapon.Slingshot => HeldWeapon.Slingshot, SelectedWeapon.PaperAirplane => HeldWeapon.PaperAirplane, SelectedWeapon.Bread => HeldWeapon.Bread, _ => HeldWeapon.None };
+    var type = _selectedWeapon switch { SelectedWeapon.Laser => HeldWeapon.Laser, SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, SelectedWeapon.Slingshot => HeldWeapon.Slingshot, SelectedWeapon.PaperAirplane => HeldWeapon.PaperAirplane, SelectedWeapon.Blowgun => HeldWeapon.Blowgun, SelectedWeapon.Bread => HeldWeapon.Bread, _ => HeldWeapon.None };
     if (!Holds (type)) return HeldWeapon.None;
     if (type == HeldWeapon.Boomerang && IsBoomerangInFlight) return HeldWeapon.None;
     if (type == HeldWeapon.PaperAirplane && IsAirplaneInFlight) return HeldWeapon.None;

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -261,6 +261,37 @@ public partial class Player
     return true;
   }
 
+  // Punch theft (issue #193): the equipped item leaves the victim's hands toward the
+  // puncher - straight into them when the server allows the steal. With fists up (or
+  // the equipped thing out flying) a carried weapon is knocked loose the old #71 way
+  // instead - it still flies out, but a holstered gun isn't in hand, so it isn't stolen.
+  public void LoseWeaponToPunch (int puncherId)
+  {
+    var equipped = PickEquippedStealable();
+    var type = equipped != HeldWeapon.None ? equipped : PickDroppableWeapon();
+    if (type == HeldWeapon.None) return;
+    // Request BEFORE clearing, same as DropHeldWeapon (CodeRabbit on #145): the
+    // server validates against this player's replicated HeldWeapon.
+    Spawner.SendPunchTheftRequest (puncherId, GlobalPosition, type, steal: equipped != HeldWeapon.None);
+    if (type == HeldWeapon.Bread) SetBreadHeld (isHeld: false); // The one non-gun in hand (issue #192).
+    else HeldWeapon &= ~type;
+    ForgetTheft (type);
+    DeselectUnheldWeapon();
+    GD.Print ($"{DisplayName}: That punch took my {type}!");
+  }
+
+  // The thing actually in hand: slot -> flag, equipped bread included (issue #192).
+  // A boomerang or airplane out flying isn't in the hand (issues #98 & #102), & fists
+  // are nothing to steal.
+  private HeldWeapon PickEquippedStealable()
+  {
+    var type = _selectedWeapon switch { SelectedWeapon.Laser => HeldWeapon.Laser, SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, SelectedWeapon.Slingshot => HeldWeapon.Slingshot, SelectedWeapon.PaperAirplane => HeldWeapon.PaperAirplane, SelectedWeapon.Bread => HeldWeapon.Bread, _ => HeldWeapon.None };
+    if (!Holds (type)) return HeldWeapon.None;
+    if (type == HeldWeapon.Boomerang && IsBoomerangInFlight) return HeldWeapon.None;
+    if (type == HeldWeapon.PaperAirplane && IsAirplaneInFlight) return HeldWeapon.None;
+    return type;
+  }
+
   // Drops the selected gun (or another carried one while boxing) as a world pickup;
   // the punch branch calls this with a drop chance when a player gets punched.
   public void DropHeldWeapon()

--- a/core/weapons/WeaponPickup.cs
+++ b/core/weapons/WeaponPickup.cs
@@ -54,9 +54,20 @@ public partial class WeaponPickup : Area3D
   // only - the server reads it when awarding the pickup; empty for spawn-point pickups.
   public string PreviousOwner { get; set; } = string.Empty;
   [Export] public float ExpirySeconds = 5.0f;
+
+  // Where a punched-loose item left the victim's hands (issue #193); zero = a normal
+  // drop. Replicated at spawn so every peer plays the same fly-out arc.
+  [Export] public Vector3 TossFrom { get; set; }
   // Grace period so a dropper doesn't instantly re-collect their own drop.
   private const float ClaimDelaySeconds = 0.75f;
+  // The tiny cooldown on a fresh punched-loose drop (issue #193): long enough that
+  // the victim can't stand still & instantly re-grab what just flew out of them.
+  private const float PunchedClaimDelaySeconds = 1.5f;
   private const float RetryCooldownSeconds = 1.0f;
+  private float ClaimDelay => TossFrom == Vector3.Zero ? ClaimDelaySeconds : PunchedClaimDelaySeconds;
+  private const float TossSeconds = 0.4f;
+  private const float TossArcHeight = 0.8f;
+  private float _tossSecondsLeft;
   private static readonly Color BananaYellow = new(0.92f, 0.78f, 0.12f);
   private HeldWeapon _weapon = HeldWeapon.Laser;
   private Node3D _visual = null!;
@@ -101,6 +112,7 @@ public partial class WeaponPickup : Area3D
     _visual.AddChild (_dartVisual);
     _spawner = GetNode <WeaponSpawner> ("/root/World/WeaponSpawner");
     _expiryLeft = ExpirySeconds;
+    if (TossFrom != Vector3.Zero) _tossSecondsLeft = TossSeconds; // Fly-out arc (issue #193).
     UpdateVisuals();
     UpdateArmedLight(); // Spawn-state sync ran before this, when the node refs were null.
   }
@@ -119,6 +131,8 @@ public partial class WeaponPickup : Area3D
   {
     _ageSeconds += (float)delta;
 
+    if (_tossSecondsLeft > 0.0f) { UpdateToss (delta); return; }
+
     // An armed mine LIES on the ground (issue #204): it spawns at the standard
     // pickup hover like every other pickup, which left the airplane bobbing in
     // mid-air instead of sitting where it came down, waiting to be stepped on.
@@ -133,6 +147,18 @@ public partial class WeaponPickup : Area3D
     _visual.Position = Vector3.Up * (BobHeight * Mathf.Sin (Mathf.Tau * BobsPerSecond * _ageSeconds));
     // An armed airplane winks at everyone while it waits (issue #191).
     if (_armedLight != null) _armedLight.Visible = Mathf.PosMod (_ageSeconds * ArmedBlinksPerSecond, 1.0f) < 0.5f;
+  }
+
+  // Punched-loose fly-out (issue #193): a short hand-animated arc from the victim's
+  // hands down to the resting spot, with a tumble spin. Local cosmetic on every peer;
+  // claims & expiry live on the root, which sits at the spot the whole time.
+  private void UpdateToss (double delta)
+  {
+    _tossSecondsLeft = Mathf.Max (0.0f, _tossSecondsLeft - (float)delta);
+    var progress = 1.0f - _tossSecondsLeft / TossSeconds;
+    var start = TossFrom - GlobalPosition; // The root never rotates, so this is local space.
+    _visual.Position = start.Lerp (Vector3.Zero, progress) + Vector3.Up * (TossArcHeight * 4.0f * progress * (1.0f - progress));
+    _visual.RotateY (Mathf.Tau * 2.0f * (float)delta);
   }
 
   public override void _PhysicsProcess (double delta)
@@ -155,7 +181,7 @@ public partial class WeaponPickup : Area3D
   private void UpdateClaim (double delta)
   {
     _retryCooldownLeft = Mathf.Max (0.0f, _retryCooldownLeft - (float)delta);
-    if (_ageSeconds < ClaimDelaySeconds || _retryCooldownLeft > 0.0f) return;
+    if (_ageSeconds < ClaimDelay || _retryCooldownLeft > 0.0f) return;
     var collector = FindLocalCollector();
     if (collector == null) return;
     _retryCooldownLeft = RetryCooldownSeconds;

--- a/core/weapons/WeaponPickup.tscn
+++ b/core/weapons/WeaponPickup.tscn
@@ -17,6 +17,9 @@ properties/1/replication_mode = 0
 properties/2/path = NodePath(".:Armed")
 properties/2/spawn = true
 properties/2/replication_mode = 0
+properties/3/path = NodePath(".:TossFrom")
+properties/3/spawn = true
+properties/3/replication_mode = 0
 
 [node name="WeaponPickup" type="Area3D"]
 collision_layer = 0

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -850,7 +850,7 @@ public partial class WeaponSpawner : Node3D
   // the equipped loaf (#192) - unlike a boomerang, a fist can take your lunch.
   public static HeldWeapon FirstStealableFlag (HeldWeapon mask)
   {
-    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane, HeldWeapon.Bread }) { if ((mask & flag) != 0) return flag; }
+    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane, HeldWeapon.Blowgun, HeldWeapon.Bread }) { if ((mask & flag) != 0) return flag; }
     return HeldWeapon.None;
   }
 

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -156,6 +156,13 @@ public partial class WeaponSpawner : Node3D
   }
 
   // Client -> server entry point; when this peer already is the server, skip the RPC.
+  // Punch theft entry point (issue #193); when this peer already is the server, skip the RPC.
+  public void SendPunchTheftRequest (int puncherId, Vector3 position, HeldWeapon lost, bool steal)
+  {
+    if (Multiplayer.IsServer()) { RequestPunchTheft (puncherId, position, (int)lost, steal); return; }
+    RpcId (1, MethodName.RequestPunchTheft, puncherId, position, (int)lost, steal);
+  }
+
   public void SendDropRequest (Vector3 position, HeldWeapon dropped)
   {
     if (Multiplayer.IsServer())
@@ -247,7 +254,7 @@ public partial class WeaponSpawner : Node3D
     return point;
   }
 
-  private void Spawn (HeldWeapon type, Vector3 position, bool expires, string previousOwner = "", bool armed = false)
+  private void Spawn (HeldWeapon type, Vector3 position, bool expires, string previousOwner = "", bool armed = false, Vector3 tossFrom = default)
   {
     var pickup = _pickupScene.Instantiate <WeaponPickup>();
     pickup.Name = $"WeaponPickup{++_nextPickupId}";
@@ -256,6 +263,7 @@ public partial class WeaponSpawner : Node3D
     pickup.Expires = expires;
     pickup.PreviousOwner = previousOwner; // For theft-revenge messages (issue #84).
     pickup.Armed = armed; // An airplane that came down from flight is a live landmine (issue #191).
+    pickup.TossFrom = tossFrom; // Punched-loose fly-out start (issue #193); zero = normal drop.
     GetParent().AddChild (pickup); // The MultiplayerSpawner replicates the spawn to every peer.
     ServerLog.Event ($"weapon spawn: {type} pickup [{pickup.Name}] at {position}{(expires ? " (expiring drop)" : "")}{(armed ? " (armed)" : "")}");
   }
@@ -763,6 +771,87 @@ public partial class WeaponSpawner : Node3D
     var victimName = victim!.DisplayName; // Non-null: the mask intersection above proved the sender exists.
     _escrow.Add (new BoomerangCargo (throwerId, surrendered, victimName));
     ServerLog.Event (victimId, $"boomerang steal: {surrendered} taken from [{victimName}] for peer {throwerId}");
+  }
+
+  // A punch knocked the victim's equipped item loose (issue #193). The victim reports
+  // its own loss (#145/#167 convention: validated against its replicated state, one
+  // flag only). A steal transfers it straight into the puncher's hands through the
+  // ConfirmPickup path (auto-equip #128, theft-revenge #84); a type the puncher
+  // already holds (or is about to be granted), a vanished puncher, or a plain
+  // knocked-loose carried weapon flies out to the ground near the victim instead.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestPunchTheft (int puncherId, Vector3 position, int type, bool steal)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var victimId = SenderOrSelf();
+    var victim = Players().FirstOrDefault (player => player.NetworkId == victimId);
+    var lost = FirstStealableFlag ((HeldWeapon)type & (victim?.HeldOrRecentlyHeld ?? HeldWeapon.None));
+
+    if (lost == HeldWeapon.None)
+    {
+      ServerLog.Event (victimId, $"punch theft deny: mask [{(HeldWeapon)type}] not held by sender");
+      return;
+    }
+
+    var victimName = victim!.DisplayName; // Non-null: the mask intersection above proved the sender exists.
+    var puncher = Players().FirstOrDefault (player => player.NetworkId == puncherId);
+    var occupied = puncher != null && (puncher.Holds (lost) || _pendingGrants.Any (grant => grant.CollectorId == puncherId && grant.Type == lost));
+
+    if (!steal || puncher == null || occupied)
+    {
+      ServerLog.Event (victimId, $"punch theft: {lost} knocked from [{victimName}] to the ground{(occupied ? " (puncher already holds one)" : "")}");
+      SpawnPunchedLoose (lost, position, puncher, victimName);
+      return;
+    }
+
+    ServerLog.Event (victimId, $"punch theft: {lost} taken from [{victimName}] by peer {puncherId}");
+
+    if (puncherId == Multiplayer.GetUniqueId())
+    {
+      GrantToSelf ((int)lost, victimName); // Synchronous: the server's own HeldWeapon shows it immediately.
+      return;
+    }
+
+    TrackPendingGrant (puncherId, lost); // Bridge until the puncher's HeldWeapon replicates back (issue #154).
+    RpcId (puncherId, MethodName.ConfirmPickup, (int)lost, victimName);
+  }
+
+  // Punched-loose items fly out of the hands (issue #193): away from the puncher, a
+  // couple of meters, ray-grounded like any drop (#151). The pickup carries its toss
+  // origin so every peer plays the same arc, & fresh punched-loose drops use a longer
+  // claim delay so the victim can't stand still & instantly re-grab what just left.
+  private void SpawnPunchedLoose (HeldWeapon type, Vector3 from, Player? puncher, string previousOwner)
+  {
+    var away = puncher == null ? RandomHorizontal() : Horizontal (from - puncher.GlobalPosition);
+    var target = from + away * (float)GD.RandRange (1.5, 2.5);
+
+    if (!TryFindGround (target, out var spot))
+    {
+      ServerLog.Event ($"punched-loose skip: no ground beneath {target}; [{type}] returns via the caps");
+      return;
+    }
+
+    Spawn (type, spot, expires: true, previousOwner, armed: false, tossFrom: from + Vector3.Up * 1.2f);
+  }
+
+  private static Vector3 Horizontal (Vector3 direction)
+  {
+    var flat = new Vector3 (direction.X, 0.0f, direction.Z);
+    return flat.LengthSquared() < 0.01f ? RandomHorizontal() : flat.Normalized();
+  }
+
+  private static Vector3 RandomHorizontal()
+  {
+    var angle = (float)GD.RandRange (0.0, Mathf.Tau);
+    return new Vector3 (Mathf.Cos (angle), 0.0f, Mathf.Sin (angle));
+  }
+
+  // Punch theft covers every hand-holdable (issue #193): the guns, the airplane, &
+  // the equipped loaf (#192) - unlike a boomerang, a fist can take your lunch.
+  public static HeldWeapon FirstStealableFlag (HeldWeapon mask)
+  {
+    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane, HeldWeapon.Bread }) { if ((mask & flag) != 0) return flag; }
+    return HeldWeapon.None;
   }
 
   // Escrow & pickups carry exactly one weapon each: reduce a validated mask to its

--- a/tests/unit/PunchTheftTest.cs
+++ b/tests/unit/PunchTheftTest.cs
@@ -1,0 +1,27 @@
+using com.forerunnergames.energyshot.weapons;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Validation-reducer coverage for punch theft (issue #193): the server trusts only a
+// single flag proven against the victim's replicated state, & unlike the boomerang's
+// FirstFlag (#184/#190), a punch can take the airplane & the equipped loaf (#192).
+[TestSuite]
+public class PunchTheftTest
+{
+  [TestCase]
+  public void ReducesForgedMultiFlagMaskToSingleFlag() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.Laser | HeldWeapon.Banana | HeldWeapon.Bread)).IsEqual (HeldWeapon.Laser);
+
+  [TestCase]
+  public void StealsEquippedBread() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.Bread)).IsEqual (HeldWeapon.Bread);
+
+  [TestCase]
+  public void StealsThePaperAirplane() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.PaperAirplane)).IsEqual (HeldWeapon.PaperAirplane);
+
+  [TestCase]
+  public void EmptyMaskStealsNothing() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.None)).IsEqual (HeldWeapon.None);
+
+  [TestCase]
+  public void BananaChunkIsNeverStealable() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.BananaChunk)).IsEqual (HeldWeapon.None);
+}

--- a/tests/unit/PunchTheftTest.cs
+++ b/tests/unit/PunchTheftTest.cs
@@ -24,4 +24,10 @@ public class PunchTheftTest
 
   [TestCase]
   public void BananaChunkIsNeverStealable() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.BananaChunk)).IsEqual (HeldWeapon.None);
+
+  [TestCase]
+  public void StealsTheBlowgun() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.Blowgun)).IsEqual (HeldWeapon.Blowgun); // Issue #194.
+
+  [TestCase]
+  public void PoisonDartIsNeverStealable() => AssertObject (WeaponSpawner.FirstStealableFlag (HeldWeapon.PoisonDart)).IsEqual (HeldWeapon.None); // Ammo, not a hand weapon (issue #194).
 }


### PR DESCRIPTION
Implements #193 (owner spec) on top of #71's 20% drop chance:

**Direct steal.** A triggered punch theft transfers the victim's *equipped* item — guns, the airplane, or the equipped loaf (#192) — straight into the puncher's hands through the ConfirmPickup path, so auto-equip (#128) & theft-revenge attribution (#84) apply unchanged. With fists up (or the equipped item out flying, #98/#102) a carried weapon is knocked loose the old way instead: it flies out, but a holstered gun isn't in hand, so it isn't stolen.

**Already-held fallback.** The server refuses to double-grant — current hold *or* pending grant (#154 ledger) — & sends the item flying to the ground instead.

**Fly-out + pickup delay.** Punched-loose drops land 1.5–2.5 m from the victim, directed away from the puncher, ray-grounded per #151 (void drops skip & return via the caps). Every peer plays the same 0.4 s arc from the victim's hands via a spawn-replicated `TossFrom` (appended to the pickup's replication config, never inserted); claims & expiry stay on the root at the resting spot the whole time. Fresh punched-loose drops carry a 1.5 s claim delay (vs the normal 0.75 s) so the victim can't stand still & re-grab.

**Server validation** follows the #145/#167/#184 convention: the victim reports its own loss before clearing local flags, the server masks it against replicated `HeldOrRecentlyHeld` & reduces to a single flag via `FirstStealableFlag` — unit-tested in `PunchTheftTest` (multi-flag forgery, bread & airplane stealable, chunk & empty masks refused).

Closes #193.

Verification is CI's job: this box can't build — run-tests & playtest must go green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso