### PR TITLE
The blowgun: scoped stealth weapon with accumulating poison darts

### DIFF
--- a/core/players/DamageKind.cs
+++ b/core/players/DamageKind.cs
@@ -16,5 +16,7 @@ public enum DamageKind
   // The paper airplane's ignite-then-pop, thrown or slung onto you (issues #102 & #191)...
   PaperAirplane,
   // ...or set off by stepping on a grounded, armed one (issue #191).
-  Landmine
+  Landmine,
+  // Accumulated blowgun-dart ticks (issue #194): the poison zaps, never the impact.
+  Poison
 }

--- a/core/players/Player.Blowgun.cs
+++ b/core/players/Player.Blowgun.cs
@@ -1,0 +1,93 @@
+using com.forerunnergames.energyshot.ui.hud;
+using com.forerunnergames.energyshot.weapons;
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// The blowgun (issue #194): the game's stealth weapon, funny because it has a SCOPE.
+// Slot 8. Left click puffs a poison dart (no impact damage - the poison ticks are the
+// weapon, see Player.Poison.cs); right click scopes. Stealth audio: the muzzle pfft
+// is audible only within a few feet of the shooter, & everyone else only ever hears
+// the dart's own short-range whoosh as it passes them (BlowgunDart).
+public partial class Player
+{
+  [Export] public float BlowgunDartSpeed = 38.0f;
+  [Export] public float BlowgunCooldownSeconds = 1.1f;
+  [Export] public float ScopeFovDegrees = 30.0f;
+  private Node3D _blowgunHeld = null!;
+  private AudioStreamPlayer3D _blowgunShotSound = null!;
+  private float _blowgunCooldownLeft;
+  private float _unscopedFovDegrees;
+  private bool _isScoped;
+
+  public bool HasBlowgun => Holds (HeldWeapon.Blowgun);
+  public bool IsBlowgunSelected => SelectedWeapon == SelectedWeapon.Blowgun;
+
+  private void CreateBlowgunHeld()
+  {
+    _blowgunHeld = BlowgunDart.CreateBlowgunVisual();
+    _blowgunHeld.Position = new Vector3 (0.32f, -0.22f, -0.55f);
+    // Fetched directly: the held-model creators run before _Ready assigns _camera.
+    var camera = GetNode <Camera3D> ("Camera3D");
+    camera.AddChild (_blowgunHeld);
+    _unscopedFovDegrees = camera.Fov; // Whatever the project default is - never hardcode it twice.
+    // The muzzle pfft (issue #194): tiny UnitSize + hard MaxDistance cutoff = the
+    // shooter & anyone within a few feet hear it; beyond that, silence.
+    _blowgunShotSound = new AudioStreamPlayer3D { Stream = ProceduralSounds.DartPfft(), UnitSize = 1.2f, MaxDistance = 3.0f, MaxPolyphony = 3 };
+    AddChild (_blowgunShotSound);
+  }
+
+  // Gated like every action predicate: input, stance, stun, & ritual states all block.
+  private bool CanFireBlowgun() => _isInputEnabled && !Dancing && !Fallen && !Eating && IsBlowgunSelected && HasBlowgun && _blowgunCooldownLeft <= 0.0f;
+
+  private void UpdateBlowgun (double delta)
+  {
+    _blowgunCooldownLeft = Mathf.Max (0.0f, _blowgunCooldownLeft - (float)delta);
+    UpdateScope();
+    if (!CanFireBlowgun() || !Input.IsActionJustPressed ("shoot")) return;
+    FireBlowgunDart();
+  }
+
+  // Scope zoom on right click (issue #194; the button is free since #164 moved punch
+  // to left click). Local camera state only - nothing about scoping replicates.
+  private void UpdateScope()
+  {
+    var wantScope = _isInputEnabled && !Fallen && IsBlowgunSelected && HasBlowgun && Input.IsActionPressed ("scope");
+    if (wantScope == _isScoped) return;
+    _isScoped = wantScope;
+    _camera.Fov = wantScope ? ScopeFovDegrees : _unscopedFovDegrees;
+  }
+
+  private void FireBlowgunDart()
+  {
+    _blowgunCooldownLeft = BlowgunCooldownSeconds;
+    CancelSpawnArmorIfFired(); // Firing anything drops your spawn armor (issue #48).
+    _blowgunShotSound.Play();
+    var direction = -_camera.GlobalTransform.Basis.Z;
+    var sweepStart = _camera.GlobalPosition;
+    var origin = sweepStart + direction * MuzzleOffsetMeters;
+    SpawnDart (origin, sweepStart, direction, isLive: true);
+    Rpc (MethodName.SpawnVisualDart, origin, sweepStart, direction);
+  }
+
+  // Every peer flies a cosmetic copy, like SpawnVisualLaser & the visual stone: the
+  // whoosh has to pass NEAR each listener locally for the stealth audio to work.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void SpawnVisualDart (Vector3 origin, Vector3 sweepStart, Vector3 direction) => SpawnDart (origin, sweepStart, direction, isLive: false);
+
+  private void SpawnDart (Vector3 origin, Vector3 sweepStart, Vector3 direction, bool isLive)
+  {
+    var dart = new BlowgunDart();
+    GetParent().AddChild (dart);
+    dart.Launch (origin, sweepStart, direction, BlowgunDartSpeed, isLive, this);
+    if (isLive) dart.HitPlayer += OnDartHitPlayer;
+  }
+
+  // Victim-authoritative like every damage path: the shooter only reports the hit.
+  private void OnDartHitPlayer (Player victim)
+  {
+    _hitmarkerSound.Play();
+    if (victim.NetworkId == Multiplayer.GetUniqueId()) return; // Can't dart yourself.
+    victim.RpcId (victim.NetworkId, MethodName.ReceiveDartHit, DisplayName);
+  }
+}

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -254,6 +254,7 @@ public partial class Player
   {
     CaptureDeathSnapshot();
     DropAllHeldWeapons(); // Death drops everything carried at the death spot (issue #72).
+    ScatterEmbeddedDarts(); // Embedded darts fall beside the body as 5s pickups (issue #194).
     EmitSignal (SignalName.RespawnedShot, DisplayName, shotByPlayerName); // Message shows during the wait (issue #152).
     await LieFallen();
     // A disconnect can free this node mid-lie-down (CodeRabbit on #185): a freed
@@ -319,6 +320,7 @@ public partial class Player
     _energyWeapon.ResetCharge(); // Every life starts with a cold weapon (issue #67).
     ClearStun(); // Death shakes off any punch/banana stun.
     ClearBurning(); // No fire (or incoming airplane) carries into a new life (issue #191).
+    ClearPoison(); // No embedded darts either - fresh lives are clean (issue #194).
     _stickyFlightSecondsLeft = 0.0f; // A new life isn't still banana-launched (issue #83).
     ActivateSpawnArmor();
     // Fresh lives start standing & slide-ready: no lingering pose, no cooldown carryover (#104).

--- a/core/players/Player.Poison.cs
+++ b/core/players/Player.Poison.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using Godot;
+using com.forerunnergames.energyshot.weapons;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Poison darts (issue #194): blowgun & slung darts embed in the victim & accumulate
+// visibly; every tick, EACH embedded dart costs 10% of max health. Bread can't cure
+// the poison - it only refills health as usual, so you can out-eat one dart, not a
+// cluster. Victim-authoritative like every damage path; the dart count replicates so
+// all peers render the pincushion & the sickly-green bars. Attribution is victim-side.
+public partial class Player
+{
+  // Replicated ALWAYS like Burning (issue #131): the idempotent setter re-renders
+  // the embedded darts & the overhead bar tint on every peer, & self-heals.
+  [Export]
+  public int PoisonDarts
+  {
+    get => _poisonDarts;
+    set
+    {
+      _poisonDarts = value;
+      ApplyPoisonVisuals();
+    }
+  }
+
+  [Export] public float PoisonTickSeconds = 5.0f;
+  [Export] public float PoisonTickFractionPerDart = 0.1f;
+  public static readonly Color PoisonGreen = new(0.35f, 0.72f, 0.2f);
+  private int _poisonDarts;
+  // Victim-side attribution, oldest dart first: each tick applies one damage packet
+  // per dart through the standard sink, so handicap & scoring stay per-attacker.
+  private readonly List <(int Id, string Name)> _dartOwners = new();
+  private readonly List <Node3D> _dartVisuals = new();
+  // Bumped on every respawn so a tick loop from a previous life stops - the burn
+  // generation pattern (issue #191).
+  private int _poisonGeneration;
+  private bool _poisonTicking;
+
+  public bool IsPoisoned => PoisonDarts > 0;
+
+  // A dart found us (issue #194). The impact itself does no damage - it plants the
+  // next tick's problem. Runs only on the victim's own authority.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ReceiveDartHit (string shotByPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    if (SpawnArmor) return; // Armor shrugs darts off like everything else (issue #48).
+    if (Fallen) return; // A body mid-death-sequence is scenery (issue #152).
+    _dartOwners.Add ((Multiplayer.GetRemoteSenderId(), shotByPlayerName));
+    PoisonDarts = _dartOwners.Count;
+    _damageSound.Play(); // The sting is the victim's only impact feedback.
+    GD.Print ($"{DisplayName}: {shotByPlayerName}'s dart stuck in me! ({PoisonDarts} embedded)");
+    StartPoisonTicksIfIdle();
+  }
+
+  private async void StartPoisonTicksIfIdle()
+  {
+    if (_poisonTicking) return;
+    _poisonTicking = true;
+    var generation = _poisonGeneration;
+
+    while (IsPoisoned)
+    {
+      await ToSignal (GetTree().CreateTimer (PoisonTickSeconds), SceneTreeTimer.SignalName.Timeout);
+      if (!IsInstanceValid (this) || !IsInsideTree()) return;
+      if (generation != _poisonGeneration || Fallen) break;
+      ApplyPoisonTick();
+    }
+
+    _poisonTicking = false;
+  }
+
+  // One tick: every embedded dart costs its own 10% of max health through the
+  // standard damage sink, oldest first, each attributed to whoever blew it.
+  private void ApplyPoisonTick()
+  {
+    LastDamageKind = DamageKind.Poison; // Message context (issue #84).
+    foreach (var (id, name) in _dartOwners.ToArray())
+    {
+      if (Fallen) return; // An earlier dart in this same tick already zapped us out.
+      ApplyDamageFrom (id, MaxHealth * PoisonTickFractionPerDart / 100.0f, name, knockbackScale: 0.0f);
+    }
+  }
+
+  // Death shakes the darts out (issue #194): they fall beside the body as 5s-expiry
+  // pickups a slingshot can load. Request BEFORE clearing (the #145 convention): the
+  // server validates the count against this player's replicated PoisonDarts.
+  private void ScatterEmbeddedDarts()
+  {
+    if (!IsPoisoned) return;
+    Spawner.SendDartScatterRequest (GlobalPosition, PoisonDarts);
+    ClearPoison();
+  }
+
+  // Fresh lives are clean (& the setter path makes this idempotent, issue #131).
+  private void ClearPoison()
+  {
+    ++_poisonGeneration;
+    _dartOwners.Clear();
+    PoisonDarts = 0;
+  }
+
+  // Idempotent per state (ALWAYS-mode sync re-fires this constantly, issue #131):
+  // keep exactly PoisonDarts stick visuals on the body & tint the overhead bar.
+  private void ApplyPoisonVisuals()
+  {
+    if (!IsInsideTree()) return;
+    UpdateDartSticks();
+    UpdateOverheadBarPoisonTint();
+  }
+
+  private void UpdateDartSticks()
+  {
+    while (_dartVisuals.Count > _poisonDarts)
+    {
+      _dartVisuals[^1].QueueFree();
+      _dartVisuals.RemoveAt (_dartVisuals.Count - 1);
+    }
+
+    while (_dartVisuals.Count < _poisonDarts)
+    {
+      var stick = BlowgunDart.CreateDartVisual();
+      // Deterministic ring around the torso by index, so every peer renders the
+      // same pincushion without replicating positions.
+      var angle = Mathf.Tau * 0.318f * _dartVisuals.Count; // Golden-angle-ish spread.
+      var direction = new Vector3 (Mathf.Cos (angle), 0.0f, Mathf.Sin (angle));
+      stick.Position = direction * 0.34f + Vector3.Up * (1.05f + 0.12f * (_dartVisuals.Count % 3));
+      // Rotation set directly (LookAt needs the node in the tree): the dart's shaft
+      // points outward along its ring direction, tuft toward the body.
+      stick.Rotation = new Vector3 (0.0f, Mathf.Atan2 (direction.X, direction.Z), 0.0f);
+      AddChild (stick);
+      _dartVisuals.Add (stick);
+    }
+  }
+
+  private void UpdateOverheadBarPoisonTint()
+  {
+    if (_healthBar == null) return;
+    if (_healthBar.GetThemeStylebox ("fill") is not StyleBoxFlat fill) return;
+    fill.BgColor = IsPoisoned ? PoisonGreen : new Color (0.756863f, 0.0f, 0.0f);
+  }
+}

--- a/core/players/Player.Slingshot.cs
+++ b/core/players/Player.Slingshot.cs
@@ -217,6 +217,7 @@ public partial class Player
     stone.Launch (origin, sweepStart, direction, speed, gravity, energy, isLive, this);
     if (!isLive) return;
     if (ammo == HeldWeapon.PaperAirplane) stone.HitPlayer += (victim, _) => OnSlungAirplaneHitPlayer (stone, victim);
+    else if (ammo == HeldWeapon.PoisonDart) stone.HitPlayer += (victim, _) => OnSlungDartHitPlayer (stone, victim); // Issue #194.
     else stone.HitPlayer += (victim, hitEnergy) => OnStoneHitPlayer (victim, hitEnergy, ammo);
     if (ammo == HeldWeapon.None || IsCosmeticAmmo (ammo)) return;
     // Only the newest flight owns this player's server-side ammo escrow, so an older
@@ -244,6 +245,18 @@ public partial class Player
     _hitmarkerSound.Play();
     ReportToServer ($"airplane: {DisplayName} slung the paper airplane into {victim.DisplayName}");
     Spawner.SendAirplaneStrikeRequest (victim.NetworkId);
+  }
+
+  // A slung dart poisons exactly like a blown one (issue #194): no stone damage -
+  // the embed is the payload. Strike-consumes like the airplane: no landing, no
+  // pickup; the server just settles the escrow books.
+  private void OnSlungDartHitPlayer (SlingshotStone stone, Player victim)
+  {
+    if (_ammoStone == stone) _ammoStone = null;
+    _hitmarkerSound.Play();
+    Spawner.SendDartStrikeRequest();
+    if (victim.NetworkId == Multiplayer.GetUniqueId()) return;
+    victim.RpcId (victim.NetworkId, MethodName.ReceiveDartHit, DisplayName);
   }
 
   // Distinct release thwack (issue #99): the punch thud replayed fast & positional

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -54,7 +54,7 @@ public partial class Player
     // PaperAirplane rides the grace too (issue #102): its landing & catch handoff
     // depend on it. So does bread (issue #190): the death drop clears the loaf right
     // after sending the drop RPC, so without the grace the server denies it.
-    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane, HeldWeapon.Bread }) { if ((removed & flag) != 0) _recentlyHeldUntilMs[flag] = until; }
+    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane, HeldWeapon.Bread, HeldWeapon.Blowgun }) { if ((removed & flag) != 0) _recentlyHeldUntilMs[flag] = until; }
   }
 
   // Which slot is out (issue #82). Replicated so every peer renders the right model
@@ -138,13 +138,14 @@ public partial class Player
   // Runs on every peer via the replicated HeldWeapon & SelectedWeapon properties.
   private void UpdateWeaponVisibility()
   {
-    if (_bananaLauncher == null || _boomerangHeld == null || _slingshotHeld == null || _airplaneHeld == null || _breadHeld == null) return;
+    if (_bananaLauncher == null || _boomerangHeld == null || _slingshotHeld == null || _airplaneHeld == null || _breadHeld == null || _blowgunHeld == null) return;
     _breadHeld.Visible = IsBreadSelected && HasBread; // Slot 7 (issue #209): everyone sees the loaf in hand.
     _energyWeapon.Visible = IsLaserSelected && HasLaser;
     _bananaLauncher.Visible = IsBananaSelected && HasBanana;
     _boomerangHeld.Visible = IsBoomerangSelected && HasBoomerang && !IsBoomerangOut; // Empty hand while it's out flying (issue #98).
     _slingshotHeld.Visible = IsSlingshotSelected && HasSlingshot; // Slot 5 (issue #99).
     _airplaneHeld.Visible = IsPaperAirplaneSelected && HasPaperAirplane && !IsAirplaneOut; // Slot 6, empty hand mid-glide (issue #102).
+    _blowgunHeld.Visible = IsBlowgunSelected && HasBlowgun; // Slot 8 (issue #194).
     UpdateHandsVisibility(); // Hands render only while fists are selected (issue #82).
   }
 
@@ -161,6 +162,7 @@ public partial class Player
     if (Input.IsActionJustPressed ("weapon_5") && HasSlingshot) SelectedWeapon = SelectedWeapon.Slingshot; // Slot 5 (issue #99).
     if (Input.IsActionJustPressed ("weapon_6") && HasPaperAirplane) SelectedWeapon = SelectedWeapon.PaperAirplane; // Slot 6 (issue #102).
     if (Input.IsActionJustPressed ("weapon_7") && HasBread) SelectedWeapon = SelectedWeapon.Bread; // Slot 7 (issue #209).
+    if (Input.IsActionJustPressed ("weapon_8") && HasBlowgun) SelectedWeapon = SelectedWeapon.Blowgun; // Slot 8 (issue #194).
     // Cycling (issue #186): mouse wheel for mouse players, Q & E for trackpads -
     // reaching for 7 mid-fight to eat is not a real option.
     if (Input.IsActionJustPressed ("cycle_weapon_next")) CycleSelectedWeapon (1);
@@ -202,7 +204,8 @@ public partial class Player
     if (HasBoomerang) slots.Add (SelectedWeapon.Boomerang);
     if (HasSlingshot) slots.Add (SelectedWeapon.Slingshot);
     if (HasPaperAirplane) slots.Add (SelectedWeapon.PaperAirplane);
-    if (HasBread) slots.Add (SelectedWeapon.Bread);
+    if (HasBlowgun) slots.Add (SelectedWeapon.Blowgun); // Slot 8 rides with the guns (issue #194)...
+    if (HasBread) slots.Add (SelectedWeapon.Bread); // ...& the loaf stays the last stop on the wheel.
     return slots;
   }
 
@@ -215,6 +218,7 @@ public partial class Player
     if (IsBoomerangSelected && !HasBoomerang) SelectedWeapon = SelectedWeapon.Fists;
     if (IsSlingshotSelected && !HasSlingshot) SelectedWeapon = SelectedWeapon.Fists;
     if (IsPaperAirplaneSelected && !HasPaperAirplane) SelectedWeapon = SelectedWeapon.Fists;
+    if (IsBlowgunSelected && !HasBlowgun) SelectedWeapon = SelectedWeapon.Fists; // Slot 8 (issue #194).
   }
 
   // Called back (via the WeaponSpawner's ConfirmPickup RPC) after the server despawns
@@ -234,7 +238,7 @@ public partial class Player
 
     HeldWeapon |= type;
     // Every pickup auto-equips (issue #128), boomerang (#98), slingshot (#99), & paper airplane (#102) included.
-    SelectedWeapon = type switch { HeldWeapon.Banana => SelectedWeapon.Banana, HeldWeapon.Boomerang => SelectedWeapon.Boomerang, HeldWeapon.Slingshot => SelectedWeapon.Slingshot, HeldWeapon.PaperAirplane => SelectedWeapon.PaperAirplane, _ => SelectedWeapon.Laser };
+    SelectedWeapon = type switch { HeldWeapon.Banana => SelectedWeapon.Banana, HeldWeapon.Boomerang => SelectedWeapon.Boomerang, HeldWeapon.Slingshot => SelectedWeapon.Slingshot, HeldWeapon.PaperAirplane => SelectedWeapon.PaperAirplane, HeldWeapon.Blowgun => SelectedWeapon.Blowgun, _ => SelectedWeapon.Laser };
     RememberTheft (type, previousOwner);
     _weaponPickupSound.Play(); // Satisfying pickup chime, owner-local only (issue #123).
     GD.Print ($"{DisplayName}: I picked up a {type}!");
@@ -280,9 +284,9 @@ public partial class Player
   // boomerangs take weapons, not lunch - only dying drops the loaf.
   private HeldWeapon PickDroppableWeapon()
   {
-    var preferred = _selectedWeapon switch { SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, SelectedWeapon.Slingshot => HeldWeapon.Slingshot, SelectedWeapon.PaperAirplane => HeldWeapon.PaperAirplane, _ => HeldWeapon.Laser };
+    var preferred = _selectedWeapon switch { SelectedWeapon.Banana => HeldWeapon.Banana, SelectedWeapon.Boomerang => HeldWeapon.Boomerang, SelectedWeapon.Slingshot => HeldWeapon.Slingshot, SelectedWeapon.PaperAirplane => HeldWeapon.PaperAirplane, SelectedWeapon.Blowgun => HeldWeapon.Blowgun, _ => HeldWeapon.Laser };
 
-    foreach (var type in new[] { preferred, HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane })
+    foreach (var type in new[] { preferred, HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane, HeldWeapon.Blowgun })
     {
       if (!Holds (type)) continue;
       if (type == HeldWeapon.Boomerang && IsBoomerangInFlight) continue;
@@ -320,6 +324,7 @@ public partial class Player
     ApplyOverlayMaterials (_slingshotHeld); // Slot 5 (issue #99).
     ApplyOverlayMaterials (_airplaneHeld); // Slot 6 (issue #102).
     ApplyOverlayMaterials (_breadHeld); // Slot 7 (issue #209).
+    ApplyOverlayMaterials (_blowgunHeld); // Slot 8 (issue #194).
   }
 
   private void ApplyOverlayMaterials (Node node)

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -350,6 +350,7 @@ public partial class Player : CharacterBody3D
     CreateSlingshotHeld(); // Same, for the slot-5 slingshot (issue #99).
     CreateAirplaneHeld(); // Same, for the slot-6 paper airplane (issue #102).
     CreateBreadHeld(); // Same, for the slot-7 loaf (issue #209).
+    CreateBlowgunHeld(); // Slot 8 (issue #194).
     UpdateWeaponVisibility();
     // Spawn-state sync runs before _Ready, when the slingshot node was still null,
     // so re-apply or a late joiner never sees an already-nocked item (issue #190).
@@ -447,6 +448,7 @@ public partial class Player : CharacterBody3D
     UpdateAirplaneCatchWindow(); // An open swing keeps grabbing briefly (issue #102).
     UpdateBread (delta); // The slot-7 loaf & its 3s eating ritual (issues #209 & #192).
     UpdateFullAuto (delta);
+    UpdateBlowgun (delta); // Slot 8: dart firing & the scope (issue #194).
     UpdatePunch (delta);
     UpdateDance (delta); // After the fire/punch updates, so a canceling press can't also attack (issue #103).
     UpdateHandBob (delta);

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -126,6 +126,9 @@ properties/22/replication_mode = 1
 properties/23/path = NodePath(".:Eating")
 properties/23/spawn = true
 properties/23/replication_mode = 1
+properties/24/path = NodePath(".:PoisonDarts")
+properties/24/spawn = true
+properties/24/replication_mode = 1
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/core/weapons/BlowgunDart.cs
+++ b/core/weapons/BlowgunDart.cs
@@ -1,0 +1,118 @@
+using Godot;
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.ui.hud;
+
+namespace com.forerunnergames.energyshot.weapons;
+
+// The blowgun's poison dart (issue #194): a small, quiet, swept-ray projectile
+// modeled on LaserBolt. The impact does no damage - the poison ticks do (see
+// Player.Poison.cs). Stealth audio model: the dart carries its own whoosh with a
+// tiny audible radius, so players only hear it when it flies near them; the muzzle
+// pfft lives on the shooter with an even smaller radius (Player.Blowgun.cs).
+public partial class BlowgunDart : Node3D
+{
+  [Signal] public delegate void HitPlayerEventHandler (Player player);
+  private const float MaxLifetimeSeconds = 3.0f;
+  // Gentle arc: a dart is breath-powered, not a laser - the droop reads as funny.
+  private const float DropAcceleration = 6.0f;
+  private static readonly Color DartBody = new(0.35f, 0.25f, 0.15f);
+  private static readonly Color TuftGreen = new(0.4f, 0.8f, 0.3f);
+  private Vector3 _velocity;
+  private Vector3 _sweepStart;
+  private bool _sweptFromStart;
+  private bool _isLive;
+  private float _age;
+  private Godot.Collections.Array <Rid> _exclusions = new();
+
+  public override void _Ready()
+  {
+    AddChild (CreateDartVisual());
+    // The fly-by whoosh (issue #194): positional & short-range, so it IS the stealth
+    // model - audible only to whoever the dart passes close to. Looped for the
+    // dart's whole flight, like the boomerang's whoosh (issue #98).
+    var whoosh = new AudioStreamPlayer3D { Stream = ProceduralSounds.DartWhoosh(), UnitSize = 1.5f, MaxDistance = 5.0f, Autoplay = true };
+    whoosh.Finished += () => whoosh.Play();
+    AddChild (whoosh);
+  }
+
+  // sweepStart is the shooter's camera position, same reasoning as LaserBolt (issue
+  // #112): the first sweep covers camera->muzzle so point-blank walls can't be skipped.
+  public void Launch (Vector3 origin, Vector3 sweepStart, Vector3 direction, float speed, bool isLive, CharacterBody3D shooter)
+  {
+    GlobalPosition = origin;
+    _sweepStart = sweepStart;
+    _velocity = direction.Normalized() * speed;
+    _isLive = isLive;
+    _exclusions = new Godot.Collections.Array <Rid> { shooter.GetRid() };
+    Orient();
+  }
+
+  public override void _PhysicsProcess (double delta)
+  {
+    var dt = (float)delta;
+    _age += dt;
+
+    if (_age > MaxLifetimeSeconds)
+    {
+      QueueFree();
+      return;
+    }
+
+    var from = _sweptFromStart ? GlobalPosition : _sweepStart;
+    _sweptFromStart = true;
+    _velocity.Y -= DropAcceleration * dt;
+    var to = GlobalPosition + _velocity * dt;
+    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: _exclusions);
+    // Point-blank darts can start inside the target's collider (issue #52's lesson).
+    query.HitFromInside = true;
+    var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
+
+    if (hit.Count > 0)
+    {
+      ResolveHit (hit);
+      return;
+    }
+
+    GlobalPosition = to;
+    Orient();
+  }
+
+  // Players stop the dart & (on the shooter's live copy) get poisoned; geometry just
+  // stops it - a dart in a wall is spent, no pierce, no pickup (only darts embedded
+  // in a player fall out on death & become loadable, issue #194).
+  private void ResolveHit (Godot.Collections.Dictionary hit)
+  {
+    if (_isLive && hit["collider"].AsGodotObject() is CharacterBody3D player && player is Player victim) EmitSignal (SignalName.HitPlayer, victim);
+    QueueFree();
+  }
+
+  private void Orient()
+  {
+    if (_velocity.LengthSquared() < 0.001f) return;
+    LookAt (GlobalPosition + _velocity, Vector3.Up);
+  }
+
+  // Code-built visuals, fresh materials per call so overlay tweaks can't bleed
+  // between held models, pickups, & projectiles (the SlingshotStone convention).
+
+  // The dart: a thin shaft with a bright tuft so victims can spot their pincushion.
+  public static Node3D CreateDartVisual()
+  {
+    var root = new Node3D();
+    root.AddChild (new MeshInstance3D { Mesh = new CylinderMesh { TopRadius = 0.012f, BottomRadius = 0.012f, Height = 0.28f }, RotationDegrees = new Vector3 (90.0f, 0.0f, 0.0f), MaterialOverride = new StandardMaterial3D { AlbedoColor = DartBody, Roughness = 0.7f } });
+    root.AddChild (new MeshInstance3D { Mesh = new SphereMesh { Radius = 0.03f, Height = 0.06f }, Position = new Vector3 (0.0f, 0.0f, 0.16f), MaterialOverride = new StandardMaterial3D { AlbedoColor = TuftGreen, Roughness = 0.4f } });
+    return root;
+  }
+
+  // The blowgun itself: a long tube - with a scope, which is the whole joke.
+  public static Node3D CreateBlowgunVisual()
+  {
+    var root = new Node3D();
+    var wood = new StandardMaterial3D { AlbedoColor = new Color (0.45f, 0.3f, 0.15f), Roughness = 0.6f };
+    root.AddChild (new MeshInstance3D { Mesh = new CylinderMesh { TopRadius = 0.035f, BottomRadius = 0.045f, Height = 1.1f }, RotationDegrees = new Vector3 (90.0f, 0.0f, 0.0f), MaterialOverride = wood });
+    var scope = new MeshInstance3D { Mesh = new CylinderMesh { TopRadius = 0.03f, BottomRadius = 0.03f, Height = 0.18f }, Position = new Vector3 (0.0f, 0.075f, -0.15f), RotationDegrees = new Vector3 (90.0f, 0.0f, 0.0f), MaterialOverride = new StandardMaterial3D { AlbedoColor = new Color (0.15f, 0.15f, 0.18f), Roughness = 0.3f } };
+    root.AddChild (scope);
+    scope.AddChild (new MeshInstance3D { Mesh = new CylinderMesh { TopRadius = 0.026f, BottomRadius = 0.026f, Height = 0.01f }, Position = new Vector3 (0.0f, 0.09f, 0.0f), MaterialOverride = new StandardMaterial3D { AlbedoColor = new Color (0.4f, 0.7f, 1.0f), EmissionEnabled = true, Emission = new Color (0.2f, 0.35f, 0.5f), Roughness = 0.1f } });
+    return root;
+  }
+}

--- a/core/weapons/HeldWeapon.cs
+++ b/core/weapons/HeldWeapon.cs
@@ -4,11 +4,13 @@ namespace com.forerunnergames.energyshot.weapons;
 // banana launcher, the boomerang (issue #98), the slingshot (issue #99), & the
 // paper airplane (issue #102) at the same time; None = unarmed (fists only).
 //
-// The last two flags are not weapon slots. Bread (issue #190) rides the mask so the
+// The trailing non-slot flags: Bread (issue #190) rides the mask so the
 // one-per-life loaf flows through the same pickup, drop, & death-drop machinery as
 // the guns. BananaChunk (issue #190) is never carried at all - it exists only as
 // slingshot ammo (Player.SlingshotAmmo), which reuses this enum as its ammo
-// vocabulary so a nocked item & a held one are named the same thing.
+// vocabulary so a nocked item & a held one are named the same thing. PoisonDart
+// (issue #194) is likewise never a slot: it exists embedded in a victim, as a
+// short-lived ground pickup off a body, & as slingshot ammo.
 [System.Flags]
 public enum HeldWeapon
 {
@@ -19,5 +21,7 @@ public enum HeldWeapon
   Slingshot = 8,
   PaperAirplane = 16,
   Bread = 32,
-  BananaChunk = 64
+  BananaChunk = 64,
+  Blowgun = 128,
+  PoisonDart = 256
 }

--- a/core/weapons/SelectedWeapon.cs
+++ b/core/weapons/SelectedWeapon.cs
@@ -11,5 +11,6 @@ public enum SelectedWeapon
   Boomerang = 3,
   Slingshot = 4,
   PaperAirplane = 5,
-  Bread = 6
+  Bread = 6,
+  Blowgun = 7 // The scoped stealth weapon (issue #194), key 8.
 }

--- a/core/weapons/SlingshotStone.cs
+++ b/core/weapons/SlingshotStone.cs
@@ -92,6 +92,8 @@ public partial class SlingshotStone : Node3D
     HeldWeapon.Bread => Scaled (Bread.CreateVisual(), 0.9f),
     HeldWeapon.PaperAirplane => Scaled (PaperAirplaneProjectile.CreateVisual(), 0.8f),
     HeldWeapon.BananaChunk => MeshVisual (null, BananaYellow, 1.0f),
+    HeldWeapon.Blowgun => Scaled (BlowgunDart.CreateBlowgunVisual(), 0.55f), // A found blowgun is slingable like any ground item (issue #194).
+    HeldWeapon.PoisonDart => Scaled (BlowgunDart.CreateDartVisual(), 1.0f), // Issue #194.
     _ => CreateStoneVisual()
   };
 

--- a/core/weapons/WeaponPickup.cs
+++ b/core/weapons/WeaponPickup.cs
@@ -66,6 +66,8 @@ public partial class WeaponPickup : Area3D
   private Node3D _slingshotVisual = null!;
   private Node3D _breadVisual = null!;
   private Node3D _airplaneVisual = null!;
+  private Node3D _blowgunVisual = null!;
+  private Node3D _dartVisual = null!;
   private OmniLight3D? _armedLight;
   private bool _armed;
   private WeaponSpawner _spawner = null!;
@@ -93,6 +95,10 @@ public partial class WeaponPickup : Area3D
     _visual.AddChild (_breadVisual);
     _airplaneVisual = PaperAirplaneProjectile.CreateVisual(); // Code-built, shared with the projectile (issue #102).
     _visual.AddChild (_airplaneVisual);
+    _blowgunVisual = BlowgunDart.CreateBlowgunVisual(); // Code-built, shared with the held model (issue #194).
+    _visual.AddChild (_blowgunVisual);
+    _dartVisual = BlowgunDart.CreateDartVisual(); // A death-scattered dart (issue #194).
+    _visual.AddChild (_dartVisual);
     _spawner = GetNode <WeaponSpawner> ("/root/World/WeaponSpawner");
     _expiryLeft = ExpirySeconds;
     UpdateVisuals();
@@ -199,18 +205,21 @@ public partial class WeaponPickup : Area3D
   {
     if (!player.IsMultiplayerAuthority() || player.Fallen) return false;
     if (player.IsLoadingAmmo) return true;
+    if (Weapon == HeldWeapon.PoisonDart) return false; // A fallen dart is ammo, never a hand weapon (issue #194).
     if (IsArmedMine) return !player.SpawnArmor && !player.Burning;
     return !player.Holds (Weapon);
   }
 
   private void UpdateVisuals()
   {
-    if (_laserVisual == null || _boomerangVisual == null || _slingshotVisual == null || _breadVisual == null || _airplaneVisual == null) return;
+    if (_laserVisual == null || _boomerangVisual == null || _slingshotVisual == null || _breadVisual == null || _airplaneVisual == null || _blowgunVisual == null || _dartVisual == null) return;
     _laserVisual.Visible = Weapon == HeldWeapon.Laser;
     _bananaVisual.Visible = Weapon == HeldWeapon.Banana;
     _boomerangVisual.Visible = Weapon == HeldWeapon.Boomerang;
     _slingshotVisual.Visible = Weapon == HeldWeapon.Slingshot; // Issue #99.
     _breadVisual.Visible = Weapon == HeldWeapon.Bread; // Issue #190.
     _airplaneVisual.Visible = Weapon == HeldWeapon.PaperAirplane; // Issue #102.
+    _blowgunVisual.Visible = Weapon == HeldWeapon.Blowgun; // Issue #194.
+    _dartVisual.Visible = Weapon == HeldWeapon.PoisonDart; // Issue #194.
   }
 }

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -25,6 +25,10 @@ public partial class WeaponSpawner : Node3D
   [Export] public int MaxBoomerangs = 1;
   [Export] public int MaxSlingshots = 1;
   [Export] public int MaxPaperAirplanes = 1;
+  [Export] public int MaxBlowguns = 1; // The stealth weapon (issue #194).
+  // Sanity bound on a death's dart scatter (issue #194): more embedded darts than
+  // this is already a story, & the pickups expire in 5s anyway.
+  private const int MaxScatteredDarts = 8;
   [Export] public float ReconcileIntervalSeconds = 1.0f;
   [Export] public float PickupHoverHeight = 0.9f;
   // Playtest-only (#72 & #197): deterministic pickups the driver can walk to, parked
@@ -202,6 +206,7 @@ public partial class WeaponSpawner : Node3D
     if (candidates.Count > 0 && Count (HeldWeapon.Banana, pickups, players) < MaxBananas) Spawn (HeldWeapon.Banana, TakeRandom (candidates), expires: false);
     if (candidates.Count > 0 && Count (HeldWeapon.Boomerang, pickups, players) < MaxBoomerangs) Spawn (HeldWeapon.Boomerang, TakeRandom (candidates), expires: false);
     if (candidates.Count > 0 && Count (HeldWeapon.Slingshot, pickups, players) < MaxSlingshots) Spawn (HeldWeapon.Slingshot, TakeRandom (candidates), expires: false);
+    if (candidates.Count > 0 && Count (HeldWeapon.Blowgun, pickups, players) < MaxBlowguns) Spawn (HeldWeapon.Blowgun, TakeRandom (candidates), expires: false); // Issue #194.
     // Exactly 1 airplane in the game (issue #102), refolded at a spawn point whenever
     // the level's only one is spent - a mine popped its target, or a thrown or slung
     // one ignited somebody (issue #191). A fresh spawn-point airplane is unarmed, so
@@ -347,6 +352,7 @@ public partial class WeaponSpawner : Node3D
     if (dropped.HasFlag (HeldWeapon.Boomerang)) Spawn (HeldWeapon.Boomerang, spot + Vector3.Left * 0.8f, expires: true, dropperName); // Issue #98.
     if (dropped.HasFlag (HeldWeapon.Slingshot)) Spawn (HeldWeapon.Slingshot, spot + Vector3.Back * 0.8f, expires: true, dropperName); // Issue #99.
     if (dropped.HasFlag (HeldWeapon.PaperAirplane)) Spawn (HeldWeapon.PaperAirplane, spot + Vector3.Forward * 0.8f, expires: true, dropperName); // Issue #102.
+    if (dropped.HasFlag (HeldWeapon.Blowgun)) Spawn (HeldWeapon.Blowgun, spot + Vector3.Forward * 1.6f, expires: true, dropperName); // Issue #194.
     // Death drops the uneaten loaf too (issue #190), & it expires like any other
     // drop so dropped bread can never pile up - respawns restock it anyway.
     if (dropped.HasFlag (HeldWeapon.Bread)) Spawn (HeldWeapon.Bread, spot + Vector3.Right * 1.6f, expires: true, dropperName);
@@ -469,6 +475,59 @@ public partial class WeaponSpawner : Node3D
     // landmine right where it fell & never expires, since it's the only one there is.
     var isAirplane = ammo.Type == HeldWeapon.PaperAirplane;
     Spawn (ammo.Type, spot, expires: !isAirplane, ammo.PreviousOwner, armed: isAirplane);
+  }
+
+  // ------------------------------------------------ poison darts (issue #194)
+
+  // Client -> server entry points; when this peer already is the server, skip the RPC.
+  public void SendDartScatterRequest (Vector3 position, int count)
+  {
+    if (Multiplayer.IsServer()) { RequestDartScatter (position, count); return; }
+    RpcId (1, MethodName.RequestDartScatter, position, count);
+  }
+
+  public void SendDartStrikeRequest()
+  {
+    if (Multiplayer.IsServer()) { RequestDartStrike(); return; }
+    RpcId (1, MethodName.RequestDartStrike);
+  }
+
+  // A death shook the victim's embedded darts out (issue #194): they fall in a ring
+  // beside the body as 5s-expiry pickups a slingshot can load. The count is the
+  // sender's own report, sanity-clamped rather than checked against the replicated
+  // PoisonDarts: the death-path clear can replicate ahead of this RPC (the #167
+  // lesson), darts carry no cap to defend, & the worst a liar buys is a few
+  // seconds of extra scenery.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestDartScatter (Vector3 position, int count)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var victimId = SenderOrSelf();
+    var victim = Players().FirstOrDefault (player => player.NetworkId == victimId);
+    if (victim == null) return;
+    var scattered = Mathf.Clamp (count, 0, MaxScatteredDarts);
+    ServerLog.Event (victimId, $"dart scatter: {scattered} dart(s) fall off [{victim.DisplayName}]");
+
+    for (var i = 0; i < scattered; ++i)
+    {
+      var angle = Mathf.Tau * i / Mathf.Max (1, scattered);
+      var target = position + new Vector3 (Mathf.Cos (angle), 0.0f, Mathf.Sin (angle)) * 0.9f;
+      if (!TryFindGround (target, out var spot)) continue; // Over the void: that dart is simply gone.
+      Spawn (HeldWeapon.PoisonDart, spot, expires: true, victim.DisplayName);
+    }
+  }
+
+  // A slung dart connected (issue #194): consume the shooter's escrowed dart so it
+  // can't ALSO land as a pickup - the strike-consumes rule the airplane uses (#191).
+  // The poisoning itself travels shooter -> victim (ReceiveDartHit), so attribution
+  // stays victim-authoritative; this RPC only settles the server's books.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestDartStrike()
+  {
+    if (!Multiplayer.IsServer()) return;
+    var attackerId = SenderOrSelf();
+    var slung = _ammoEscrow.RemoveAll (ammo => ammo.LoaderId == attackerId && ammo.Type == HeldWeapon.PoisonDart) > 0;
+    ServerLog.Event (attackerId, slung ? "dart strike: slung dart consumed from escrow" : "dart strike deny: sender had no dart nocked");
   }
 
   // ------------------------------------------- paper airplane hazard (issue #191)
@@ -711,7 +770,7 @@ public partial class WeaponSpawner : Node3D
   // Bread is deliberately absent (issue #190): a boomerang steals weapons, not lunch.
   private static HeldWeapon FirstFlag (HeldWeapon mask)
   {
-    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot }) { if ((mask & flag) != 0) return flag; }
+    foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.Blowgun }) { if ((mask & flag) != 0) return flag; }
     return HeldWeapon.None;
   }
 

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -16,7 +16,7 @@ Current as of v0.8.15.
 
 ## Weapons
 
-Slot keys select what's in your hands. You spawn with fists **and bread**; every gun is picked up in the arena (picking one up auto-equips it - bread is the one exception, so a loaf never swaps a weapon out of your hands mid-fight). Every slot uses the same primary button: left click acts with whatever slot is selected; right click is unbound (reserved).
+Slot keys select what's in your hands. You spawn with fists **and bread**; every gun is picked up in the arena (picking one up auto-equips it - bread is the one exception, so a loaf never swaps a weapon out of your hands mid-fight). Every slot uses the same primary button: left click acts with whatever slot is selected; right click scopes the blowgun (slot 8) & does nothing elsewhere.
 
 | Key | Weapon | How it works |
 |---|---|---|
@@ -27,6 +27,7 @@ Slot keys select what's in your hands. You spawn with fists **and bread**; every
 | 5 | Slingshot | Hold left-click to draw, release to fling a stone. Longer draw = faster, flatter, harder (never a one-hit). A quick tap just relaxes the band - stones need a minimum draw, & a short cooldown separates shots. **Universal ammo**: see below |
 | 6 | Paper airplane | Left-click to throw. Locks onto whoever's under your crosshair & glides slowly after them; punch an incoming one (fists out) to catch it & throw it back. Only one exists in the whole game, & it is a personal hazard - see below |
 | 7 | Bread | Left-click to eat: a 3-second rooted ritual that heals you to full. One loaf per life - see below |
+| 8 | Blowgun | The stealth weapon - with a scope, because of course it has a scope. Left-click puffs a poison dart, right-click (hold) zooms. The shot is nearly silent: only players within a few feet of you hear it, & everyone else only hears a dart that flies close by them. Darts do no impact damage - they stick in & poison: every 5 seconds the victim loses 10% health PER embedded dart, & their health bar turns green. Bread heals as normal but does NOT remove darts. On a zap-out the darts fall beside the body for 5 seconds - slingshot players can load one as ammo (a slung dart poisons identically) |
 
 ### Slingshot universal ammo
 

--- a/project.godot
+++ b/project.godot
@@ -114,6 +114,16 @@ weapon_7={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":55,"location":0,"echo":false,"script":null)
 ]
 }
+weapon_8={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":56,"key_label":0,"unicode":56,"location":0,"echo":false,"script":null)
+]
+}
+scope={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 ability={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -12,16 +12,16 @@ public class MessageGeneratorTest
   private static DeathContext Laser (float energy = 0.5f) => new() { Kind = DamageKind.Laser, Energy = energy };
 
   [TestCase]
-  public void ExactlyOneHundredThirtyFourUniqueMessageTemplates()
+  public void ExactlyOneHundredThirtyEightUniqueMessageTemplates()
   {
     // 100 from the content wave (issue #84) + 3 through-wall zaps (issue #94)
     // + 4 boomerang zap-outs (issue #98) + 4 slingshot zap-outs (issue #99)
     // + 6 paper airplane zap-outs & 3 airplane catches (issues #102 & #191)
     // + 4 slung-item zap-outs (issue #190) + 4 landmines (issue #191)
-    // + 6 zapped-mid-bread-ritual (issue #192).
+    // + 6 zapped-mid-bread-ritual (issue #192) + 4 poison zap-outs (issue #194).
     var templates = MessagePools.All.SelectMany (pool => pool).ToList();
-    AssertInt (templates.Count).IsEqual (134);
-    AssertInt (templates.Distinct().Count()).IsEqual (134);
+    AssertInt (templates.Count).IsEqual (138);
+    AssertInt (templates.Distinct().Count()).IsEqual (138);
   }
 
   [TestCase]
@@ -34,10 +34,13 @@ public class MessageGeneratorTest
   }
 
   [TestCase]
+  public void PoisonPoolSelectedByDamageKind() => AssertObject (MessageGenerator.SelectZappedPool (new DeathContext { Kind = DamageKind.Poison })).IsSame (MessagePools.Poison);
+
+  [TestCase]
   public void EveryPoolIsInTheRegistry()
   {
-    // 30 scenario pools registered, none empty.
-    AssertInt (MessagePools.All.Count).IsEqual (30);
+    // 31 scenario pools registered, none empty.
+    AssertInt (MessagePools.All.Count).IsEqual (31);
     foreach (var pool in MessagePools.All) AssertBool (pool.Count > 0).IsTrue();
   }
 

--- a/tests/unit/PoisonTuningTest.cs
+++ b/tests/unit/PoisonTuningTest.cs
@@ -1,0 +1,32 @@
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.weapons;
+using GdUnit4;
+using Godot;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Regression coverage for the poison tuning (issue #194): 10% of max health per
+// embedded dart per tick, & a single tick can never be a surprise one-shot.
+[TestSuite]
+public partial class PoisonTuningTest
+{
+  [TestCase]
+  public void OneDartTickCostsTenPercentOfEachHealthPool()
+  {
+    var player = AutoFree (new Player())!;
+    foreach (var difficulty in new[] { 0, 1, 2 })
+    {
+      var pool = Player.MaxHealthFor (difficulty);
+      AssertInt (Player.CalculateHealthDecrease (pool * player.PoisonTickFractionPerDart / 100.0f)).IsEqual (pool / 10);
+    }
+  }
+
+  [TestCase]
+  public void OneDartTickStaysFarBelowTheOneShotThreshold()
+  {
+    var player = AutoFree (new Player())!;
+    AssertFloat (Player.MaxHealthFor (0) * player.PoisonTickFractionPerDart / 100.0f).IsLess (EnergyWeapon.FullChargeEnergyThreshold * 0.5f);
+  }
+
+}

--- a/tests/unit/WeaponCycleTest.cs
+++ b/tests/unit/WeaponCycleTest.cs
@@ -48,12 +48,12 @@ public class WeaponCycleTest
     var all = new List <SelectedWeapon>
     {
       SelectedWeapon.Fists, SelectedWeapon.Laser, SelectedWeapon.Banana, SelectedWeapon.Boomerang,
-      SelectedWeapon.Slingshot, SelectedWeapon.PaperAirplane, SelectedWeapon.Bread
+      SelectedWeapon.Slingshot, SelectedWeapon.PaperAirplane, SelectedWeapon.Blowgun, SelectedWeapon.Bread
     };
     var current = SelectedWeapon.Fists;
     var visited = new List <SelectedWeapon>();
     for (var i = 0; i < all.Count; ++i) { current = Player.NextCycleSlot (all, current, 1); visited.Add (current); }
     AssertObject (current).IsEqual (SelectedWeapon.Fists); // Full lap wraps home.
-    AssertInt (visited.Count).IsEqual (7);
+    AssertInt (visited.Count).IsEqual (8); // Blowgun joined the wheel (issue #194).
   }
 }

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -18,6 +18,8 @@ public partial class Hud : Control
   [Signal] public delegate void GameQuitEventHandler();
   private World _world = null!;
   private ProgressBar _healthBar = null!;
+  private StyleBoxFlat? _poisonFill; // Green fill swapped in while poisoned (issue #194).
+  private bool _poisonTintShown;
   private MessageScroller _messageScroller = null!;
   private ConfirmationDialog2 _quitDialog = null!;
   private Label _scoreLabel = null!;
@@ -229,6 +231,7 @@ public partial class Hud : Control
     UpdateSplatter (delta);
     UpdateCooldownMeters();
     UpdateBreadIcon();
+    UpdatePoisonTint(); // Issue #194.
     UpdateBreadNotice();
     UpdateDeathOverlay();
     UpdateTargetRing();
@@ -341,6 +344,19 @@ public partial class Hud : Control
     _fullAutoMeter.SetFraction (self.FullAutoReadyFraction);
     _bananaMeter.SetFraction (self.BananaReadyFraction);
     _eatMeter.SetDraining (self.BreadEatRemainingFraction, self.Eating); // Reverse: it drains to empty (issue #192).
+  }
+
+  // The health bar turns sickly green while darts are embedded (issue #194); polling
+  // like the bread icon, since the dart count changes with no HUD-facing signal.
+  private void UpdatePoisonTint()
+  {
+    var self = _world.SelfPlayer;
+    if (self == null || !Visible) return;
+    if (self.IsPoisoned == _poisonTintShown) return;
+    _poisonTintShown = self.IsPoisoned;
+    if (_poisonFill == null && _healthBar.GetThemeStylebox ("fill") is StyleBoxFlat fill) { _poisonFill = (StyleBoxFlat)fill.Duplicate(); _poisonFill.BgColor = Player.PoisonGreen; }
+    if (_poisonTintShown && _poisonFill != null) { _healthBar.AddThemeStyleboxOverride ("fill", _poisonFill); return; }
+    _healthBar.RemoveThemeStyleboxOverride ("fill");
   }
 
   // The bread icon dims once the loaf is eaten & brightens when a respawn restocks

--- a/ui/hud/ProceduralSounds.cs
+++ b/ui/hud/ProceduralSounds.cs
@@ -9,6 +9,26 @@ public static class ProceduralSounds
   private const int SampleRate = 22050;
 
   // A satisfying munch: three quick, soft crunches followed by a warm rising heal chime.
+  // The blowgun's muzzle pfft (issue #194): one soft, dark breath of noise - quiet
+  // on purpose, & its emitter clamps the audible radius to a few feet.
+  public static AudioStreamWav DartPfft()
+  {
+    var samples = new float[(int)(SampleRate * 0.18f)];
+    AddCrunch (samples, startSeconds: 0.0f, brightness: 0.12f);
+    AddChime (samples, startSeconds: 0.02f, fromHz: 220.0f, toHz: 140.0f, seconds: 0.12f, amplitude: 0.08f);
+    return FromSamples (samples);
+  }
+
+  // The dart's fly-by whoosh (issue #194): a airy falling sweep, looped for the
+  // flight; short-range on its emitter, so hearing it means the dart is NEAR you.
+  public static AudioStreamWav DartWhoosh()
+  {
+    var samples = new float[(int)(SampleRate * 0.3f)];
+    AddChime (samples, startSeconds: 0.0f, fromHz: 900.0f, toHz: 650.0f, seconds: 0.3f, amplitude: 0.05f);
+    AddChime (samples, startSeconds: 0.0f, fromHz: 1400.0f, toHz: 950.0f, seconds: 0.3f, amplitude: 0.03f);
+    return FromSamples (samples);
+  }
+
   public static AudioStreamWav Munch()
   {
     var samples = new float[(int)(SampleRate * 0.7f)];

--- a/ui/hud/messages/MessageGenerator.cs
+++ b/ui/hud/messages/MessageGenerator.cs
@@ -59,7 +59,7 @@ public static class MessageGenerator
     if (context.Kind == DamageKind.Boomerang) return MessagePools.Boomerang; // Issue #98.
     if (context.Kind == DamageKind.SlungItem) return MessagePools.SlungItem; // Issue #190.
     if (context.Kind == DamageKind.Slingshot) return MessagePools.Slingshot; // Issue #99.
-    if (context.Kind == DamageKind.PaperAirplane) return MessagePools.PaperAirplane; // Issue #102.
+    if (context.Kind == DamageKind.Poison) return MessagePools.Poison; // Issue #194: the poison is the story, whatever else was going on.
     // Standing stock still for three seconds is the whole story of that death, so it
     // outranks every stance & carried-weapon flavor below it (issue #192).
     if (context.VictimEating) return MessagePools.ZappedEating;

--- a/ui/hud/messages/MessagePools.cs
+++ b/ui/hud/messages/MessagePools.cs
@@ -248,6 +248,15 @@ public static class MessagePools
     "beep, beep, beep, pop: goodnight {v}"
   };
 
+  // Accumulated poison-dart ticks got them (issue #194): sickly-goofy, never gory.
+  public static readonly List <string> Poison = new()
+  {
+    "{v} turned a lovely shade of swamp. {z}'s darts finally added up",
+    "{v} wobbled, hiccuped, & folded like lawn furniture. {z}'s poison, probably",
+    "{z}'s little pincushion project is complete: {v} is out",
+    "{v} got out-toxined by {z}. Hydrate next time"
+  };
+
   // Someone punched an incoming paper airplane out of the air (issue #102):
   // {z} = the catcher, {v} = the thrower it's being returned to.
   public static readonly List <string> AirplaneCatch = new()
@@ -284,7 +293,7 @@ public static class MessagePools
     Fall, FallStreak, Zapped, ThroughWall, FullCharge, FullAuto, Punch, PunchedOutArmed, FistsVsFists,
     BananaBlast, BananaDirect, HoldingBananaGun, ComboSplatterPunch, JumpShot, SlideShotKiller,
     SlideShotVictim, ZapStreakTier3, ZapStreakTier5, ZapStreakTier7, StreakEnded, StreakLost,
-    ZappedStreak, Boomerang, Slingshot, SlungItem, PaperAirplane, Landmine, AirplaneCatch, TheftRevenge,
+    ZappedStreak, Boomerang, Slingshot, SlungItem, PaperAirplane, Landmine, Poison, AirplaneCatch, TheftRevenge,
     ZappedEating
   };
 }


### PR DESCRIPTION
Implements #194 (owner spec) — slot 8, key 8, right-click scope.

**Weapon.** World pickup under a 1-cap like the other specials. Left click puffs a poison dart — swept-ray projectile (LaserBolt pattern) with a gentle breath-powered arc & **no impact damage**: the poison is the weapon. Right click scopes (local FOV zoom; the button #164 freed). New `scope` & `weapon_8` input actions.

**Stealth audio.** The muzzle pfft is an `AudioStreamPlayer3D` with tiny `UnitSize` + 3 m `MaxDistance` — the shooter & anyone within a few feet hear it, nobody else. Every peer flies a cosmetic dart (SpawnVisualLaser pattern) whose own short-range looping whoosh is the only other audible trace: hearing it means the dart is near YOU. Both sounds are new PCM generators in ProceduralSounds — no downloaded assets.

**Darts & poison.** Darts embed & accumulate visibly — a deterministic golden-angle ring driven by a new ALWAYS-mode replicated `PoisonDarts` (Player.tscn **index 24, appended**). Every 5 s each embedded dart costs 10% of max health through `ApplyDamageFrom`, per-dart attribution & the #191 burn-generation cancellation pattern. Health bars go sickly green: HUD via fill-stylebox swap, overhead bar on every peer via the idempotent setter. Bread heals normally but never removes darts. Poison zap-outs get their own sickly-goofy pool via `DamageKind.Poison` (& the dead duplicate PaperAirplane branch in `SelectZappedPool` is gone).

**Death & slingshot interop (#190).** Death scatters the embedded darts in a ring of 5 s-expiry pickups (server-side; count sanity-clamped rather than replication-checked — the #167 race, reasoning in-line). A fallen dart is loadable **only** as slingshot ammo (`IsEligibleCollector` refuses it as a hand weapon); a slung dart poisons identically through the shooter-report path & is consumed from escrow on strike exactly like the airplane (#191), so a hit can never double as a landing pickup. A found blowgun is slingable like any ground item; the blowgun is boomerang-stealable (`FirstFlag`).

**Deliberately not in this PR:** adding Blowgun to punch-theft's `FirstStealableFlag` — that method lands with #221; one-line follow-up once both are in.

Tests: `PoisonTuningTest` (per-tick math across all three health tiers, one-shot-threshold headroom), `WeaponCycleTest` full lap = 8 slots, message counts 138/31, poison pool selection. `docs/CONTROLS.md` documents slot 8.

Verification is CI's job: this box can't build — run-tests & playtest must go green before merge.

Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso