### PR TITLE
Bind B as a second key for bread - it's too important to fumble for

### DIFF
--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -16,7 +16,7 @@ Current as of v0.8.15.
 
 ## Weapons
 
-Slot keys select what's in your hands. You spawn with fists **and bread**; every gun is picked up in the arena (picking one up auto-equips it - bread is the one exception, so a loaf never swaps a weapon out of your hands mid-fight). Every slot uses the same primary button: left click acts with whatever slot is selected; right click scopes the blowgun (slot 8) & does nothing elsewhere.
+Slot keys select what's in your hands. You spawn with fists **and bread** (B is a second key for bread - it is too important to fumble for); every gun is picked up in the arena (picking one up auto-equips it - bread is the one exception, so a loaf never swaps a weapon out of your hands mid-fight). Every slot uses the same primary button: left click acts with whatever slot is selected; right click scopes the blowgun (slot 8) & does nothing elsewhere.
 
 | Key | Weapon | How it works |
 |---|---|---|
@@ -26,7 +26,7 @@ Slot keys select what's in your hands. You spawn with fists **and bread**; every
 | 4 | Boomerang | Left-click to throw. Curves out & returns; steals weapons from anyone it clips & scoops pickups it passes; auto-catches on return |
 | 5 | Slingshot | Hold left-click to draw, release to fling a stone. Longer draw = faster, flatter, harder (never a one-hit). A quick tap just relaxes the band - stones need a minimum draw, & a short cooldown separates shots. **Universal ammo**: see below |
 | 6 | Paper airplane | Left-click to throw. Locks onto whoever's under your crosshair & glides slowly after them; punch an incoming one (fists out) to catch it & throw it back. Only one exists in the whole game, & it is a personal hazard - see below |
-| 7 | Bread | Left-click to eat: a 3-second rooted ritual that heals you to full. One loaf per life - see below |
+| 7 or B | Bread | Left-click to eat: a 3-second rooted ritual that heals you to full. One loaf per life - see below |
 | 8 | Blowgun | The stealth weapon - with a scope, because of course it has a scope. Left-click puffs a poison dart, right-click (hold) zooms. The shot is nearly silent: only players within a few feet of you hear it, & everyone else only hears a dart that flies close by them. Darts do no impact damage - they stick in & poison: every 5 seconds the victim loses 10% health PER embedded dart, & their health bar turns green. Bread heals as normal but does NOT remove darts. On a zap-out the darts fall beside the body for 5 seconds - slingshot players can load one as ammo (a slung dart poisons identically) |
 
 ### Slingshot universal ammo

--- a/project.godot
+++ b/project.godot
@@ -111,7 +111,7 @@ weapon_6={
 }
 weapon_7={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":55,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":55,"location":0,"echo":false,"script":null), Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"location":0,"echo":false,"script":null)
 ]
 }
 weapon_8={


### PR DESCRIPTION
Aaron's ruling on #223, option A: bread stays slot 7 & **B selects it too**. One extra `InputEventKey` on the `weapon_7` action + the controls doc. No renumbering, no muscle-memory change, no playtest churn (the driver's slot presses are untouched).

Verification is CI's job: this box can't build.

Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Players can now select the bread weapon using either the `7` key or the `B` key.
  * Updated controls documentation to reflect the available key bindings and starting equipment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->