### PR TITLE
Rounds: 5 minutes or first to 20 zaps, end scoreboard, & superlative titles

### DIFF
--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -338,8 +338,11 @@ public partial class Player
     {
       _zapOutSound.Play();
       attacker?.RpcId (attackerId, MethodName.NotifyScored, DisplayName);
+      CreditAssist (attackerId); // Whoever softened us up within the window (issue #153).
       RespawnShot (attackerName);
     }
+
+    if (Health > 0) RememberDamager (attackerId); // Survived: this hit may become somebody's assist (issue #153).
     // Survived it (CodeRabbit on #214): the capture is only ever the death snapshot's
     // context, so a nonlethal interruption must not still read as "died eating" when
     // a later, unrelated hit finishes the job.

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -253,6 +253,7 @@ public partial class Player
   private async void RespawnShot (string shotByPlayerName)
   {
     CaptureDeathSnapshot();
+    ++ZapOuts; // Round stats (issue #153).
     DropAllHeldWeapons(); // Death drops everything carried at the death spot (issue #72).
     ScatterEmbeddedDarts(); // Embedded darts fall beside the body as 5s pickups (issue #194).
     EmitSignal (SignalName.RespawnedShot, DisplayName, shotByPlayerName); // Message shows during the wait (issue #152).
@@ -299,6 +300,7 @@ public partial class Player
   {
     if (Fallen) return; // A dead body drifting past the boundary mid-lie-down already has a respawn scheduled (issue #152).
     --Score; // Falling off the world costs a point.
+    ++Falls; // Round stats (issue #153): self-inflicted, separately counted.
     ClearHeldWeapons(); // A drop below the world would be unreachable; the weapons respawn at spawn points instead (issue #72).
     Respawn();
     EmitSignal (SignalName.RespawnedFell, DisplayName);
@@ -309,6 +311,7 @@ public partial class Player
   private async void Respawn()
   {
     ZapStreakCount = 0; // Any respawn ends the streak.
+    ForgetDamager(); // A fresh life owes nobody an assist (issue #153).
     Health = MaxHealth;
     // Announce it (issue #201): the HUD's health bar & the red death-vignette both
     // follow this signal, so a silent reset left the vignette glowing for the rest

--- a/core/players/Player.Stats.cs
+++ b/core/players/Player.Stats.cs
@@ -1,0 +1,59 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Round stats (issue #153): alongside Score, each player owns & replicates its own
+// zap-outs, falls, & assists, the way Score already works - the dying or scoring
+// player's authority writes, everyone reads for the scoreboard. An assist is damage
+// dealt to the victim within AssistWindowSeconds before somebody ELSE zapped them.
+public partial class Player
+{
+  [Export] public int ZapOuts { get; set; }
+  [Export] public int Falls { get; set; }
+  [Export] public int Assists { get; set; }
+  [Export] public float AssistWindowSeconds = 10.0f;
+  private int _lastDamagerId;
+  private ulong _lastDamagerAtMs;
+
+  // Victim-side bookkeeping from ApplyDamageFrom: the most recent non-lethal damager.
+  private void RememberDamager (int attackerId)
+  {
+    if (attackerId == 0) return; // Ownerless hazards (a landmine) assist nobody.
+    _lastDamagerId = attackerId;
+    _lastDamagerAtMs = Time.GetTicksMsec();
+  }
+
+  // Called from the lethal branch: credit the previous damager, if fresh & not the zapper.
+  private void CreditAssist (int zapperId)
+  {
+    if (_lastDamagerId == 0 || _lastDamagerId == zapperId) return;
+    if (Time.GetTicksMsec() - _lastDamagerAtMs > (ulong)(AssistWindowSeconds * 1000.0f)) return;
+    GetParent().GetNodeOrNull <Player> ($"{_lastDamagerId}")?.RpcId (_lastDamagerId, MethodName.NotifyAssisted, DisplayName);
+  }
+
+  private void ForgetDamager() => _lastDamagerId = 0;
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void NotifyAssisted (string zappedPlayerName)
+  {
+    if (!IsMultiplayerAuthority()) return;
+    ++Assists;
+    GD.Print ($"{DisplayName}: assist on {zappedPlayerName} ({Assists} total)");
+  }
+
+  // A new round (issue #153): the server tells every player to zero its counters &
+  // respawn fresh. Peer-1-only, the admin-message rule; the host calls it directly.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  public void ResetForNewRound()
+  {
+    var sender = Multiplayer.GetRemoteSenderId();
+    if (sender != 1 && sender != 0) return;
+    if (!IsMultiplayerAuthority()) return;
+    Score = 0;
+    ZapOuts = 0;
+    Falls = 0;
+    Assists = 0;
+    ForgetDamager();
+    if (!Fallen) Respawn();
+  }
+}

--- a/core/players/Player.Stats.cs
+++ b/core/players/Player.Stats.cs
@@ -42,12 +42,15 @@ public partial class Player
   }
 
   // A new round (issue #153): the server tells every player to zero its counters &
-  // respawn fresh. Peer-1-only, the admin-message rule; the host calls it directly.
+  // respawn fresh. Peer-1-only, the admin-message rule; a direct (non-RPC) call is
+  // honored only inside the server process - the host resetting its own player
+  // (CodeRabbit on #226).
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
   public void ResetForNewRound()
   {
     var sender = Multiplayer.GetRemoteSenderId();
-    if (sender != 1 && sender != 0) return;
+    var authorized = sender == 1 || (sender == 0 && Multiplayer.IsServer());
+    if (!authorized) return;
     if (!IsMultiplayerAuthority()) return;
     Score = 0;
     ZapOuts = 0;

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -129,6 +129,15 @@ properties/23/replication_mode = 1
 properties/24/path = NodePath(".:PoisonDarts")
 properties/24/spawn = true
 properties/24/replication_mode = 1
+properties/25/path = NodePath(".:ZapOuts")
+properties/25/spawn = true
+properties/25/replication_mode = 2
+properties/26/path = NodePath(".:Falls")
+properties/26/spawn = true
+properties/26/replication_mode = 2
+properties/27/path = NodePath(".:Assists")
+properties/27/spawn = true
+properties/27/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/core/world/Match.cs
+++ b/core/world/Match.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using com.forerunnergames.energyshot.ui.hud.messages;
+using com.forerunnergames.energyshot.ui.hud;
 
 namespace com.forerunnergames.energyshot.core.world;
 

--- a/core/world/Match.cs
+++ b/core/world/Match.cs
@@ -12,6 +12,8 @@ public static class Match
 {
   public const int DefaultRoundMinutes = 5;
   public const int DefaultZapLimit = 20;
+  public const int MaxRoundMinutes = 60;
+  public const int MaxZapLimit = 200;
   public const float IntermissionSeconds = 10.0f;
 
   // Either limit ends it; a limit of 0 means "no limit" on that axis.
@@ -37,13 +39,17 @@ public static class Match
     awards.Add ((pool, best.Name));
   }
 
+  // Player names are player-typed & land in a BBCode label (CodeRabbit on #226): an
+  // opening bracket renders as itself, never as a smuggled tag.
+  public static string EscapeBbcode (string text) => text.Replace ("[", "[lb]");
+
   // BBCode for the end-of-round overlay: a table of everybody's numbers, then the
   // superlatives. titleFor renders one award line (the generator picks the template).
   public static string BuildScoreboard (IReadOnlyList <RoundStats> stats, List <(List <string> Pool, string Name)> awards, System.Func <List <string>, string, string> titleFor)
   {
-    var rows = stats.Select (s => $"[cell][color=#{s.ColorHex}]{s.Name}[/color][/cell][cell]{s.Zaps}[/cell][cell]{s.ZapOuts}[/cell][cell]{s.Assists}[/cell][cell]{s.Falls}[/cell]");
+    var rows = stats.Select (s => $"[cell][color=#{s.ColorHex}]{EscapeBbcode (s.Name)}[/color][/cell][cell]{s.Zaps}[/cell][cell]{s.ZapOuts}[/cell][cell]{s.Assists}[/cell][cell]{s.Falls}[/cell]");
     var table = $"[table=5][cell][b]Player[/b][/cell][cell][b]Zaps[/b][/cell][cell][b]Zap-outs[/b][/cell][cell][b]Assists[/b][/cell][cell][b]Falls[/b][/cell]{string.Concat (rows)}[/table]";
-    var titles = string.Join ("\n", awards.Select (award => titleFor (award.Pool, award.Name)));
+    var titles = string.Join ("\n", awards.Select (award => titleFor (award.Pool, EscapeBbcode (award.Name))));
     return $"[center][b]ROUND OVER[/b]\n\n{table}\n\n{titles}[/center]";
   }
 }

--- a/core/world/Match.cs
+++ b/core/world/Match.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using com.forerunnergames.energyshot.ui.hud.messages;
+
+namespace com.forerunnergames.energyshot.core.world;
+
+// Rounds (issue #153), the pure part: when a round is over, who earns which
+// superlative, & the scoreboard text. No nodes, no network - unit-tested directly.
+public readonly record struct RoundStats (string Name, string ColorHex, int Zaps, int ZapOuts, int Assists, int Falls);
+
+public static class Match
+{
+  public const int DefaultRoundMinutes = 5;
+  public const int DefaultZapLimit = 20;
+  public const float IntermissionSeconds = 10.0f;
+
+  // Either limit ends it; a limit of 0 means "no limit" on that axis.
+  public static bool IsOver (float elapsedSeconds, int roundSeconds, int topScore, int zapLimit) => (roundSeconds > 0 && elapsedSeconds >= roundSeconds) || (zapLimit > 0 && topScore >= zapLimit);
+
+  // One award per category, only when somebody actually did the thing (max > 0);
+  // ties go to whoever is listed first (the caller passes leaderboard order).
+  public static List <(List <string> Pool, string Name)> AwardTitles (IReadOnlyList <RoundStats> stats)
+  {
+    var awards = new List <(List <string>, string)>();
+    Award (awards, MessagePools.TitleMostZaps, stats, s => s.Zaps);
+    Award (awards, MessagePools.TitleMostZapOuts, stats, s => s.ZapOuts);
+    Award (awards, MessagePools.TitleMostAssists, stats, s => s.Assists);
+    Award (awards, MessagePools.TitleMostFalls, stats, s => s.Falls);
+    return awards;
+  }
+
+  private static void Award (List <(List <string>, string)> awards, List <string> pool, IReadOnlyList <RoundStats> stats, System.Func <RoundStats, int> metric)
+  {
+    if (stats.Count == 0) return;
+    var best = stats.MaxBy (metric);
+    if (metric (best) <= 0) return;
+    awards.Add ((pool, best.Name));
+  }
+
+  // BBCode for the end-of-round overlay: a table of everybody's numbers, then the
+  // superlatives. titleFor renders one award line (the generator picks the template).
+  public static string BuildScoreboard (IReadOnlyList <RoundStats> stats, List <(List <string> Pool, string Name)> awards, System.Func <List <string>, string, string> titleFor)
+  {
+    var rows = stats.Select (s => $"[cell][color=#{s.ColorHex}]{s.Name}[/color][/cell][cell]{s.Zaps}[/cell][cell]{s.ZapOuts}[/cell][cell]{s.Assists}[/cell][cell]{s.Falls}[/cell]");
+    var table = $"[table=5][cell][b]Player[/b][/cell][cell][b]Zaps[/b][/cell][cell][b]Zap-outs[/b][/cell][cell][b]Assists[/b][/cell][cell][b]Falls[/b][/cell]{string.Concat (rows)}[/table]";
+    var titles = string.Join ("\n", awards.Select (award => titleFor (award.Pool, award.Name)));
+    return $"[center][b]ROUND OVER[/b]\n\n{table}\n\n{titles}[/center]";
+  }
+}

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -263,7 +263,7 @@ public partial class World : Node3D
     // axis. Playtest runs assert exact scores & crowns across ~3 minutes, so a round
     // end mid-run would break them: the harness flag turns rounds off.
     var isPlaytest = OS.GetCmdlineUserArgs().Contains ("--playtest");
-    ConfigureRound (isPlaytest ? 0 : ParseArgInt ("--round-minutes", Match.DefaultRoundMinutes) * 60, isPlaytest ? 0 : ParseArgInt ("--zap-limit", Match.DefaultZapLimit));
+    ConfigureRound (isPlaytest ? 0 : Mathf.Clamp (ParseArgInt ("--round-minutes", Match.DefaultRoundMinutes), 0, Match.MaxRoundMinutes) * 60, isPlaytest ? 0 : Mathf.Clamp (ParseArgInt ("--zap-limit", Match.DefaultZapLimit), 0, Match.MaxZapLimit));
     var peer = new ENetMultiplayerPeer();
     var error = peer.CreateServer (port);
 
@@ -424,6 +424,9 @@ public partial class World : Node3D
   {
     var player = _playerScene.Instantiate <Player>();
     player.Name = $"{peerId}";
+    // Joining during the intermission (CodeRabbit on #226): you get the frozen
+    // scoreboard too, not a private head start; ReceiveRoundStarted releases everyone.
+    if (_intermission && IsActiveServer() && peerId != Multiplayer.GetUniqueId()) RpcId (peerId, MethodName.ReceiveRoundEnded, _lastBoard);
     player.MaxHealth = maxHealth;
     player.ColorIndex = colorIndex; // Chosen body color (issue #43), carried into spawn state for every peer.
     player.RespawnedShot += (respawnedPlayerName, shotByPlayerName) => _networkManager.NotifyPlayerRespawnedShot (respawnedPlayerName, shotByPlayerName);
@@ -490,6 +493,7 @@ public partial class World : Node3D
   private int _zapLimit;
   private float _roundElapsed;
   private bool _intermission;
+  private string _lastBoard = string.Empty; // Replayed to anyone who joins mid-intermission (CodeRabbit on #226).
 
   private void ConfigureRound (int roundSeconds, int zapLimit)
   {
@@ -520,6 +524,7 @@ public partial class World : Node3D
     var stats = ordered.Select (player => new RoundStats (player.DisplayName, PlayerColors.TextHex (player.ColorIndex), player.Score, player.ZapOuts, player.Assists, player.Falls)).ToList();
     var board = Match.BuildScoreboard (stats, Match.AwardTitles (stats), MessageGenerator.RoundTitle);
     ServerLog.Event ($"round over: {string.Join (", ", stats.Select (s => $"{s.Name} {s.Zaps}/{s.ZapOuts}/{s.Assists}/{s.Falls}"))}");
+    _lastBoard = board;
     Rpc (MethodName.ReceiveRoundEnded, board);
     await ToSignal (GetTree().CreateTimer (Match.IntermissionSeconds), SceneTreeTimer.SignalName.Timeout);
     if (!IsInsideTree() || !IsActiveServer()) return;

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using com.forerunnergames.energyshot.players;
 using com.forerunnergames.energyshot.ui;
-using com.forerunnergames.energyshot.ui.hud.messages;
+using com.forerunnergames.energyshot.ui.hud;
 using com.forerunnergames.energyshot.utilities;
 using Godot;
 

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using com.forerunnergames.energyshot.players;
 using com.forerunnergames.energyshot.ui;
+using com.forerunnergames.energyshot.ui.hud.messages;
 using com.forerunnergames.energyshot.utilities;
 using Godot;
 
@@ -27,6 +29,9 @@ public partial class World : Node3D
   [Signal] public delegate void SelfPlayerBreadInterruptedEventHandler();
   [Signal] public delegate void RemoteMessageReceivedEventHandler (string message);
   [Signal] public delegate void AdminMessageReceivedEventHandler (string message);
+  [Signal] public delegate void RoundClockUpdatedEventHandler (int secondsLeft, int zapLimit);
+  [Signal] public delegate void RoundEndedEventHandler (string scoreboardBbcode);
+  [Signal] public delegate void RoundStartedEventHandler();
   [Signal] public delegate void KickedFromServerEventHandler (string reason);
   [Signal] public delegate void ServerShutDownEventHandler();
   private const int DefaultServerPort = 55556;
@@ -239,6 +244,8 @@ public partial class World : Node3D
   // required, so the official server keeps working until its owner sets one.
   private static string ParseServerPassword() => ParseArgValue ("--password");
 
+  private static int ParseArgInt (string name, int fallback) => int.TryParse (ParseArgValue (name), out var value) && value >= 0 ? value : fallback;
+
   private static string ParseArgValue (string name)
   {
     var args = OS.GetCmdlineUserArgs();
@@ -252,6 +259,11 @@ public partial class World : Node3D
   {
     _ui.Hide();
     var port = ParseServerPort();
+    // Rounds (issue #153): --round-minutes N & --zap-limit N, 0 = no limit on that
+    // axis. Playtest runs assert exact scores & crowns across ~3 minutes, so a round
+    // end mid-run would break them: the harness flag turns rounds off.
+    var isPlaytest = OS.GetCmdlineUserArgs().Contains ("--playtest");
+    ConfigureRound (isPlaytest ? 0 : ParseArgInt ("--round-minutes", Match.DefaultRoundMinutes) * 60, isPlaytest ? 0 : ParseArgInt ("--zap-limit", Match.DefaultZapLimit));
     var peer = new ENetMultiplayerPeer();
     var error = peer.CreateServer (port);
 
@@ -353,6 +365,7 @@ public partial class World : Node3D
   {
     _maxPlayers = Mathf.Clamp (maxPlayers, 2, MaxPlayers);
     _serverPassword = password;
+    ConfigureRound (Settings.RoundMinutes * 60, Settings.ZapLimit); // Issue #153.
     Multiplayer.PeerConnected += OnClientConnectedToServer;
     Multiplayer.PeerDisconnected += OnClientDisconnectedFromServer;
     AddPlayer (Multiplayer.GetUniqueId(), playerName, Player.MaxHealthFor (difficulty), colorIndex);
@@ -464,7 +477,91 @@ public partial class World : Node3D
     var timer = new Timer { WaitTime = 1.0, Autostart = true };
     timer.Timeout += UpdateCrownHolder;
     timer.Timeout += UpdatePings;
+    timer.Timeout += TickRound; // Issue #153.
     AddChild (timer);
+  }
+
+  // ------------------------------------------------------- rounds (issue #153)
+
+  // Server-owned: the clock only runs while a round is live with at least two
+  // players, so an empty server never "ends" rounds to nobody. Each tick broadcasts
+  // the seconds left (late joiners catch up on the next tick - no separate sync).
+  private int _roundSeconds;
+  private int _zapLimit;
+  private float _roundElapsed;
+  private bool _intermission;
+
+  private void ConfigureRound (int roundSeconds, int zapLimit)
+  {
+    _roundSeconds = roundSeconds;
+    _zapLimit = zapLimit;
+    _roundElapsed = 0.0f;
+    ServerLog.Event ($"rounds: {(roundSeconds > 0 ? $"{roundSeconds / 60} min" : "no time limit")}, {(zapLimit > 0 ? $"first to {zapLimit}" : "no zap limit")}");
+  }
+
+  private bool RoundsEnabled => _roundSeconds > 0 || _zapLimit > 0;
+
+  private void TickRound()
+  {
+    if (!IsActiveServer() || !RoundsEnabled || _intermission) return;
+    var players = GetPlayers().ToList();
+    if (players.Count < 2) return;
+    _roundElapsed += 1.0f;
+    var secondsLeft = _roundSeconds > 0 ? Mathf.Max (0, _roundSeconds - (int)_roundElapsed) : -1;
+    Rpc (MethodName.ReceiveRoundClock, secondsLeft, _zapLimit);
+    if (!Match.IsOver (_roundElapsed, _roundSeconds, players.Max (player => player.Score), _zapLimit)) return;
+    EndRound (players);
+  }
+
+  private async void EndRound (List <Player> players)
+  {
+    _intermission = true;
+    var ordered = players.OrderByDescending (player => player.Score).ThenBy (player => player.DisplayName).ToList();
+    var stats = ordered.Select (player => new RoundStats (player.DisplayName, PlayerColors.TextHex (player.ColorIndex), player.Score, player.ZapOuts, player.Assists, player.Falls)).ToList();
+    var board = Match.BuildScoreboard (stats, Match.AwardTitles (stats), MessageGenerator.RoundTitle);
+    ServerLog.Event ($"round over: {string.Join (", ", stats.Select (s => $"{s.Name} {s.Zaps}/{s.ZapOuts}/{s.Assists}/{s.Falls}"))}");
+    Rpc (MethodName.ReceiveRoundEnded, board);
+    await ToSignal (GetTree().CreateTimer (Match.IntermissionSeconds), SceneTreeTimer.SignalName.Timeout);
+    if (!IsInsideTree() || !IsActiveServer()) return;
+    StartNewRound();
+  }
+
+  private void StartNewRound()
+  {
+    foreach (var player in GetPlayers())
+    {
+      if (player.NetworkId == Multiplayer.GetUniqueId()) { player.ResetForNewRound(); continue; }
+      player.RpcId (player.NetworkId, Player.MethodName.ResetForNewRound);
+    }
+
+    _roundElapsed = 0.0f;
+    _intermission = false;
+    ServerLog.Event ("round start");
+    Rpc (MethodName.ReceiveRoundStarted);
+  }
+
+  // Only peer 1 runs the match - the admin-message rule (issue #158).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer, CallLocal = true)]
+  private void ReceiveRoundClock (int secondsLeft, int zapLimit)
+  {
+    if (Multiplayer.GetRemoteSenderId() != 1) return;
+    EmitSignal (SignalName.RoundClockUpdated, secondsLeft, zapLimit);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer, CallLocal = true)]
+  private void ReceiveRoundEnded (string scoreboardBbcode)
+  {
+    if (Multiplayer.GetRemoteSenderId() != 1) return;
+    _selfPlayer?.SetInputEnabled (isEnabled: false); // Everyone stands still & reads (issue #153).
+    EmitSignal (SignalName.RoundEnded, scoreboardBbcode);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer, CallLocal = true)]
+  private void ReceiveRoundStarted()
+  {
+    if (Multiplayer.GetRemoteSenderId() != 1) return;
+    _selfPlayer?.SetInputEnabled (isEnabled: true);
+    EmitSignal (SignalName.RoundStarted);
   }
 
   // Crown rules (issue #178): no crown anywhere until the leader's score is above

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -85,3 +85,7 @@ There is exactly **one** paper airplane in the arena. It's a slot-6 weapon like 
 - Getting zapped out also drops **everything** you were carrying - weapons, your uneaten bread, and anything nocked in your slingshot - right where you fell. Dropped items expire after a few seconds. (A loaf ruined by an interrupted eat is gone, not dropped.)
 - Kills heal you 50 HP. Falling off the world costs a point - your score can go negative.
 - Difficulty picks your health pool (Beginner 400 / Intermediate 300 / Expert 200), and lower-tier players hit higher-tier players harder.
+
+## Rounds
+
+A round ends after **5 minutes or when somebody reaches 20 zaps**, whichever comes first (the clock sits top-center while at least two players are in). Then everyone freezes for 10 seconds on the scoreboard - zaps, zap-outs, assists (you damaged them within 10 s of someone else's zap), falls - with sarcastic superlatives, and a fresh round starts: scores zeroed, everybody respawned. Hosts set both limits in the Host Game dialog (0 = no limit); the dedicated server takes `--round-minutes N` and `--zap-limit N`.

--- a/tests/unit/MatchTest.cs
+++ b/tests/unit/MatchTest.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using com.forerunnergames.energyshot.core.world;
-using com.forerunnergames.energyshot.ui.hud.messages;
+using com.forerunnergames.energyshot.ui.hud;
 using GdUnit4;
 using static GdUnit4.Assertions;
 

--- a/tests/unit/MatchTest.cs
+++ b/tests/unit/MatchTest.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using com.forerunnergames.energyshot.core.world;
+using com.forerunnergames.energyshot.ui.hud.messages;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Rounds (issue #153): the end condition & the superlative rules are pure, so they
+// get pinned here - a limit of 0 disables that axis, awards need a real max, ties go
+// to leaderboard order.
+[TestSuite]
+public class MatchTest
+{
+  private static RoundStats Stats (string name, int zaps, int zapOuts, int assists, int falls) => new(name, "ffffff", zaps, zapOuts, assists, falls);
+
+  [TestCase]
+  public void TimeLimitEndsTheRound() => AssertBool (Match.IsOver (300.0f, 300, 3, 20)).IsTrue();
+
+  [TestCase]
+  public void ZapLimitEndsTheRound() => AssertBool (Match.IsOver (10.0f, 300, 20, 20)).IsTrue();
+
+  [TestCase]
+  public void ZeroLimitsMeanNoEnd() => AssertBool (Match.IsOver (99999.0f, 0, 999, 0)).IsFalse();
+
+  [TestCase]
+  public void NoAwardWithoutADeed()
+  {
+    var awards = Match.AwardTitles (new List <RoundStats> { Stats ("a", 0, 0, 0, 0), Stats ("b", 0, 0, 0, 0) });
+    AssertInt (awards.Count).IsEqual (0);
+  }
+
+  [TestCase]
+  public void EveryCategoryGoesToItsLeaderAndTiesToListOrder()
+  {
+    var awards = Match.AwardTitles (new List <RoundStats> { Stats ("a", 5, 2, 1, 1), Stats ("b", 5, 7, 3, 1) });
+    AssertInt (awards.Count).IsEqual (4);
+    AssertObject (awards[0].Pool).IsSame (MessagePools.TitleMostZaps);
+    AssertString (awards[0].Name).IsEqual ("a"); // Tie on zaps: first listed.
+    AssertString (awards[1].Name).IsEqual ("b"); // Most zap-outs.
+    AssertString (awards[2].Name).IsEqual ("b"); // Most assists.
+    AssertString (awards[3].Name).IsEqual ("a"); // Tie on falls: first listed.
+  }
+
+  [TestCase]
+  public void ScoreboardCarriesEveryPlayerAndTitle()
+  {
+    var stats = new List <RoundStats> { Stats ("alpha", 3, 1, 0, 0), Stats ("beta", 1, 3, 0, 2) };
+    var board = Match.BuildScoreboard (stats, Match.AwardTitles (stats), (pool, name) => $"TITLE:{name}");
+    AssertBool (board.Contains ("alpha") && board.Contains ("beta") && board.Contains ("TITLE:alpha") && board.Contains ("TITLE:beta") && board.Contains ("[table=5]")).IsTrue();
+  }
+}

--- a/tests/unit/MatchTest.cs
+++ b/tests/unit/MatchTest.cs
@@ -43,6 +43,13 @@ public class MatchTest
   }
 
   [TestCase]
+  public void ScoreboardEscapesSmuggledTagsInNames()
+  {
+    var stats = new List <RoundStats> { Stats ("[img]x[/img]", 1, 0, 0, 0) };
+    AssertBool (Match.BuildScoreboard (stats, Match.AwardTitles (stats), (pool, name) => name).Contains ("[img]")).IsFalse();
+  }
+
+  [TestCase]
   public void ScoreboardCarriesEveryPlayerAndTitle()
   {
     var stats = new List <RoundStats> { Stats ("alpha", 3, 1, 0, 0), Stats ("beta", 1, 3, 0, 2) };

--- a/tests/unit/MessageGeneratorTest.cs
+++ b/tests/unit/MessageGeneratorTest.cs
@@ -12,16 +12,17 @@ public class MessageGeneratorTest
   private static DeathContext Laser (float energy = 0.5f) => new() { Kind = DamageKind.Laser, Energy = energy };
 
   [TestCase]
-  public void ExactlyOneHundredThirtyEightUniqueMessageTemplates()
+  public void ExactlyOneHundredFiftyUniqueMessageTemplates()
   {
     // 100 from the content wave (issue #84) + 3 through-wall zaps (issue #94)
     // + 4 boomerang zap-outs (issue #98) + 4 slingshot zap-outs (issue #99)
     // + 6 paper airplane zap-outs & 3 airplane catches (issues #102 & #191)
     // + 4 slung-item zap-outs (issue #190) + 4 landmines (issue #191)
-    // + 6 zapped-mid-bread-ritual (issue #192) + 4 poison zap-outs (issue #194).
+    // + 6 zapped-mid-bread-ritual (issue #192) + 4 poison zap-outs (issue #194)
+    // + 12 end-of-round superlatives (issue #153).
     var templates = MessagePools.All.SelectMany (pool => pool).ToList();
-    AssertInt (templates.Count).IsEqual (138);
-    AssertInt (templates.Distinct().Count()).IsEqual (138);
+    AssertInt (templates.Count).IsEqual (150);
+    AssertInt (templates.Distinct().Count()).IsEqual (150);
   }
 
   [TestCase]
@@ -39,8 +40,8 @@ public class MessageGeneratorTest
   [TestCase]
   public void EveryPoolIsInTheRegistry()
   {
-    // 31 scenario pools registered, none empty.
-    AssertInt (MessagePools.All.Count).IsEqual (31);
+    // 35 scenario pools registered, none empty.
+    AssertInt (MessagePools.All.Count).IsEqual (35);
     foreach (var pool in MessagePools.All) AssertBool (pool.Count > 0).IsTrue();
   }
 

--- a/ui/dialogs/host/HostGameDialog.cs
+++ b/ui/dialogs/host/HostGameDialog.cs
@@ -14,6 +14,8 @@ public partial class HostGameDialog : Control
   private OptionButton _difficulty = null!;
   private OptionButton _playerColor = null!;
   private SpinBox _maxPlayers = null!;
+  private SpinBox _roundMinutes = null!; // Issue #153.
+  private SpinBox _zapLimit = null!;
   private LineEdit _password = null!;
   private LineEdit _serverAddress = null!;
   private Label _middleText = null!;
@@ -39,6 +41,8 @@ public partial class HostGameDialog : Control
     _playerColor.GetPopup().AddThemeFontSizeOverride ("font_size", 90);
     PlayerColors.Populate (_playerColor); // Selectable body color (issue #43).
     _maxPlayers = GetNode <SpinBox> ("PanelContainer/MarginContainer/VBoxContainer/MaxPlayers");
+    _roundMinutes = GetNode <SpinBox> ("PanelContainer/MarginContainer/VBoxContainer/RoundMinutes");
+    _zapLimit = GetNode <SpinBox> ("PanelContainer/MarginContainer/VBoxContainer/ZapLimit");
     _password = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/Password");
     _serverAddress = GetNode <LineEdit> ("PanelContainer/MarginContainer/VBoxContainer/ServerAddress");
     _middleText = GetNode <Label> ("PanelContainer/MarginContainer/VBoxContainer/MiddleText");
@@ -63,6 +67,8 @@ public partial class HostGameDialog : Control
     _difficulty.Selected = Settings.Difficulty;
     _playerColor.Selected = PlayerColors.NormalizeIndex (Settings.PlayerColor);
     _maxPlayers.Value = Settings.MaxPlayers;
+    _roundMinutes.Value = Settings.RoundMinutes;
+    _zapLimit.Value = Settings.ZapLimit;
     UpdateHostGameButtonState();
     Show();
     // UPnP discovery can take seconds; run it off the main thread so the UI stays responsive (see issue #25).
@@ -111,6 +117,8 @@ public partial class HostGameDialog : Control
     Settings.Difficulty = _difficulty.Selected;
     Settings.PlayerColor = _playerColor.Selected;
     Settings.MaxPlayers = (int)_maxPlayers.Value;
+    Settings.RoundMinutes = (int)_roundMinutes.Value; // Read back by World.OnHostGameSuccess (issue #153).
+    Settings.ZapLimit = (int)_zapLimit.Value;
     Settings.HostPassword = _password.Text;
     Hide();
     EmitSignal (SignalName.HostGameSuccess, _playerName.Text, _difficulty.Selected, (int)_maxPlayers.Value, _password.Text, _playerColor.Selected);

--- a/ui/dialogs/host/HostGameDialog.tscn
+++ b/ui/dialogs/host/HostGameDialog.tscn
@@ -117,6 +117,34 @@ value = 12.0
 rounded = true
 alignment = 1
 
+[node name="RoundMinutesLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "Round Minutes (0 = no limit)"
+horizontal_alignment = 1
+
+[node name="RoundMinutes" type="SpinBox" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 90
+max_value = 60.0
+value = 5.0
+rounded = true
+alignment = 1
+
+[node name="ZapLimitLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 50
+text = "First To (zaps, 0 = no limit)"
+horizontal_alignment = 1
+
+[node name="ZapLimit" type="SpinBox" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 90
+max_value = 200.0
+value = 20.0
+rounded = true
+alignment = 1
+
 [node name="PasswordLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 50

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -18,6 +18,9 @@ public partial class Hud : Control
   [Signal] public delegate void GameQuitEventHandler();
   private World _world = null!;
   private ProgressBar _healthBar = null!;
+  private Label _roundClock = null!; // Issue #153.
+  private ColorRect _roundOverlay = null!;
+  private RichTextLabel _roundBoard = null!;
   private StyleBoxFlat? _poisonFill; // Green fill swapped in while poisoned (issue #194).
   private bool _poisonTintShown;
   private MessageScroller _messageScroller = null!;
@@ -166,6 +169,10 @@ public partial class Hud : Control
     _world.PlayerLeftGame += OnPlayerLeftGame;
     _world.RemoteMessageReceived += OnRemoteMessageReceived;
     _world.AdminMessageReceived += OnAdminMessageReceived;
+    _world.RoundClockUpdated += OnRoundClockUpdated; // Issue #153.
+    _world.RoundEnded += OnRoundEnded;
+    _world.RoundStarted += OnRoundStarted;
+    CreateRoundUi();
     _world.PlayerScored += OnPlayerScored;
     _world.PlayerRespawnedShot += OnPlayerRespawnedShot;
     _world.PlayerRespawnedFell += OnPlayerRespawnedFell;
@@ -200,6 +207,45 @@ public partial class Hud : Control
     _deathCountdown.SetAnchorsPreset (LayoutPreset.FullRect);
     _deathOverlay.AddChild (_deathCountdown);
   }
+
+  // Rounds (issue #153), code-built like the death overlay: a top-center clock while
+  // a round runs & a full-screen scoreboard between rounds. Neither captures input.
+  private void CreateRoundUi()
+  {
+    _roundClock = new Label { HorizontalAlignment = HorizontalAlignment.Center, MouseFilter = MouseFilterEnum.Ignore, Visible = false };
+    _roundClock.AddThemeFontSizeOverride ("font_size", 40);
+    _roundClock.SetAnchorsPreset (LayoutPreset.CenterTop);
+    _roundClock.OffsetTop = 12.0f;
+    AddChild (_roundClock);
+    _roundOverlay = new ColorRect { Color = new Color (0.0f, 0.0f, 0.0f, 0.7f), MouseFilter = MouseFilterEnum.Ignore, Visible = false };
+    _roundOverlay.SetAnchorsPreset (LayoutPreset.FullRect);
+    AddChild (_roundOverlay);
+    _roundBoard = new RichTextLabel { BbcodeEnabled = true, FitContent = true, ScrollActive = false, MouseFilter = MouseFilterEnum.Ignore };
+    _roundBoard.AddThemeFontSizeOverride ("normal_font_size", 40);
+    _roundBoard.AddThemeFontSizeOverride ("bold_font_size", 44);
+    _roundBoard.SetAnchorsPreset (LayoutPreset.Center);
+    _roundBoard.GrowHorizontal = GrowDirection.Both;
+    _roundBoard.GrowVertical = GrowDirection.Both;
+    _roundBoard.CustomMinimumSize = new Vector2 (1100.0f, 0.0f);
+    _roundOverlay.AddChild (_roundBoard);
+  }
+
+  private void OnRoundClockUpdated (int secondsLeft, int zapLimit)
+  {
+    var clock = secondsLeft >= 0 ? $"{secondsLeft / 60}:{secondsLeft % 60:00}" : string.Empty;
+    var target = zapLimit > 0 ? $"first to {zapLimit}" : string.Empty;
+    _roundClock.Text = string.Join ("   ·   ", new[] { clock, target }.Where (part => part.Length > 0));
+    _roundClock.Visible = _roundClock.Text.Length > 0 && !_roundOverlay.Visible;
+  }
+
+  private void OnRoundEnded (string scoreboardBbcode)
+  {
+    _roundBoard.Text = scoreboardBbcode;
+    _roundOverlay.Visible = true;
+    _roundClock.Visible = false;
+  }
+
+  private void OnRoundStarted() => _roundOverlay.Visible = false;
 
   // Crouch toggle-vs-hold (issue #147), persisted & offered in the pause (quit)
   // dialog - the only in-game UI with a visible mouse - like the music toggle (#137).

--- a/ui/hud/messages/MessageGenerator.cs
+++ b/ui/hud/messages/MessageGenerator.cs
@@ -23,6 +23,7 @@ public static class MessageGenerator
   public static string OnFallStreak (string victimName) => Fill (Pick (MessagePools.FallStreak), victimName, "");
   public static string OnTheftRevenge (string victimName, string zapperName) => Fill (Pick (MessagePools.TheftRevenge), victimName, zapperName);
   public static string OnAirplaneCatch (string throwerName, string catcherName) => Fill (Pick (MessagePools.AirplaneCatch), throwerName, catcherName);
+  public static string RoundTitle (List <string> pool, string honoree) => Fill (Pick (pool), honoree, honoree); // Issue #153.
   public static string OnZapped (string victimName, string zapperName, DeathContext context) => Fill (Pick (SelectZappedPool (context)), victimName, zapperName);
   private static string Fill (string template, string victimName, string zapperName) => Capitalize (template.Replace ("{v}", victimName).Replace ("{z}", zapperName));
   private static string Capitalize (string message) => char.ToUpper (message[0]) + message[1..];

--- a/ui/hud/messages/MessagePools.cs
+++ b/ui/hud/messages/MessagePools.cs
@@ -287,6 +287,35 @@ public static class MessagePools
     "return to sender: {z} gave {v}'s weapon back the fun way"
   };
 
+  // End-of-round superlatives (issue #153): {v} = the honoree. Sarcastic, never gory.
+  public static readonly List <string> TitleMostZaps = new()
+  {
+    "Top Zapper: {v}. Somebody give them a juice box",
+    "Most Zaps: {v} - touch grass, champ",
+    "{v} zapped the most people & will not stop talking about it"
+  };
+
+  public static readonly List <string> TitleMostZapOuts = new()
+  {
+    "Most Dishonorable: {v}, zapped out more than anyone & still smiling",
+    "Human Target Practice: {v}",
+    "{v} got zapped out the most. Thanks for your service"
+  };
+
+  public static readonly List <string> TitleMostAssists = new()
+  {
+    "Best Supporting Actor: {v}",
+    "Most Assists: {v} did the work, somebody else got the credit",
+    "{v} softened them up all round. Generous"
+  };
+
+  public static readonly List <string> TitleMostFalls = new()
+  {
+    "Gravity's Favorite: {v}",
+    "Most Falls: {v} keeps discovering the edge",
+    "{v} fell off the world the most. The world is flat, apparently"
+  };
+
   // Registry so the unit test can verify all templates stay unique (issue #84).
   public static readonly IReadOnlyList <List <string>> All = new List <List <string>>
   {
@@ -294,6 +323,6 @@ public static class MessagePools
     BananaBlast, BananaDirect, HoldingBananaGun, ComboSplatterPunch, JumpShot, SlideShotKiller,
     SlideShotVictim, ZapStreakTier3, ZapStreakTier5, ZapStreakTier7, StreakEnded, StreakLost,
     ZappedStreak, Boomerang, Slingshot, SlungItem, PaperAirplane, Landmine, Poison, AirplaneCatch, TheftRevenge,
-    ZappedEating
+    ZappedEating, TitleMostZaps, TitleMostZapOuts, TitleMostAssists, TitleMostFalls
   };
 }

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -53,13 +53,13 @@ public static class Settings
   // Host-chosen round limits (issue #153): 0 disables that axis.
   public static int RoundMinutes
   {
-    get => Mathf.Clamp (GetInt ("round_minutes", core.world.Match.DefaultRoundMinutes), 0, 60);
+    get => Mathf.Clamp (GetInt ("round_minutes", core.world.Match.DefaultRoundMinutes), 0, core.world.Match.MaxRoundMinutes);
     set => Set ("round_minutes", value);
   }
 
   public static int ZapLimit
   {
-    get => Mathf.Clamp (GetInt ("zap_limit", core.world.Match.DefaultZapLimit), 0, 200);
+    get => Mathf.Clamp (GetInt ("zap_limit", core.world.Match.DefaultZapLimit), 0, core.world.Match.MaxZapLimit);
     set => Set ("zap_limit", value);
   }
 

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -50,6 +50,19 @@ public static class Settings
     set => Set ("max_players", value);
   }
 
+  // Host-chosen round limits (issue #153): 0 disables that axis.
+  public static int RoundMinutes
+  {
+    get => Mathf.Clamp (GetInt ("round_minutes", core.world.Match.DefaultRoundMinutes), 0, 60);
+    set => Set ("round_minutes", value);
+  }
+
+  public static int ZapLimit
+  {
+    get => Mathf.Clamp (GetInt ("zap_limit", core.world.Match.DefaultZapLimit), 0, 200);
+    set => Set ("zap_limit", value);
+  }
+
   // Game passwords (issue #90), remembered like the other dialog fields.
   public static string HostPassword
   {


### PR DESCRIPTION
Implements #153. The title's owner spec (5 min / first to 20) wins over the body's original 10–20 min feedback — both limits are configurable anyway.

**Stats.** `ZapOuts`, `Falls`, `Assists` replicate like `Score` (Player.tscn indices 25–27, appended). An **assist** = you damaged the victim within 10 s before somebody else's zap; credited victim-side via a `NotifyAssisted` RPC shaped exactly like `NotifyScored`.

**Clock & end.** Server-owned, on the existing 1 s ticker; runs only with ≥ 2 players; broadcasts seconds-left every tick (so late joiners need no catch-up path); ends on either limit (`Match.IsOver`). The server builds the scoreboard — BBCode table + superlatives picked from four new pools (*Top Zapper*, *Most Dishonorable*, *Best Supporting Actor*, *Gravity's Favorite*…) — broadcasts it, freezes everyone's input for a 10 s intermission, then sends each player `ResetForNewRound` (zero counters, respawn) & play resumes. All three RPCs carry the peer-1-only guard.

**Limits.** Host Game dialog spinboxes (persisted in `Settings`, read back by `World.OnHostGameSuccess` — no signal-signature churn), or `--round-minutes N` / `--zap-limit N` on the dedicated server; 0 = no limit on that axis. **`--playtest` disables rounds** so the harness's exact score/crown assertions keep their meaning.

**HUD.** Top-center clock + full-screen overlay scoreboard, code-built like the death overlay, neither captures input.

**Judgment calls under the delegation:** assist window 10 s; intermission 10 s; no lobby trip (fresh round in place); clock paused below 2 players; leaderboard rows untouched (the scoreboard carries the new columns).

Tests: `MatchTest` (both limits, zero = off, no award without a deed, per-category leaders & tie order, scoreboard contents), message counts 150/35. `docs/CONTROLS.md` gains a Rounds section.

Verification is CI's job: this box can't build. The dedicated server's flags are worth one manual check on es1 after release (it currently runs with no flags → defaults 5 min / 20).

Closes #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timed rounds with configurable zap limits.
  * Added round clock, end-of-round scoreboard, intermission, and automatic player resets.
  * Added host settings for round duration and zap limits, including unlimited options.
  * Added tracking for zaps, zap-outs, falls, and assists.
  * Added end-of-round superlative awards and titles.
* **Documentation**
  * Documented round rules, scoreboard behavior, resets, and host configuration.
* **Tests**
  * Added coverage for round completion, awards, ties, and scoreboard results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->