### PR TITLE
Head hitbox & headshots: floating sphere head, 1-shot vs Expert/Intermediate, 2 vs Beginner

### DIFF
--- a/core/players/HeadHitbox.cs
+++ b/core/players/HeadHitbox.cs
@@ -1,0 +1,24 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// The floating sensor dome (issue #179): an Area3D child of the player on its own
+// collision layer, so projectiles that sweep with CollideWithAreas can tell a head
+// hit from a body hit - & movement never feels it, since it isn't part of the
+// CharacterBody3D's shapes. Every peer renders it; replication rides the player's
+// existing pose sync because it simply moves with the body.
+public partial class HeadHitbox : Area3D
+{
+  public const uint Layer = 1u << 7; // Layer 8: nothing else lives there.
+  public const float Radius = 0.3f;
+  public static readonly Vector3 LocalOffset = new(0.0f, 2.45f, 0.0f); // Hovering just above the 2m capsule.
+
+  public Player Player => (Player)GetParent();
+
+  public static HeadHitbox Create()
+  {
+    var head = new HeadHitbox { Name = "Head", Position = LocalOffset, CollisionLayer = Layer, CollisionMask = 0, Monitoring = false, Monitorable = true };
+    head.AddChild (new CollisionShape3D { Shape = new SphereShape3D { Radius = Radius } });
+    return head;
+  }
+}

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -245,28 +245,35 @@ public partial class Player
     var bolt = _laserBoltScene.Instantiate <LaserBolt>();
     GetParent().AddChild (bolt);
     bolt.Launch (origin, sweepStart, direction, energy, isLive, this);
-    if (isLive) bolt.HitPlayer += (body, hitEnergy, throughBarrier) => OnLaserHitPlayer (body, hitEnergy, throughBarrier, isFullAuto);
+    if (isLive) bolt.HitPlayer += (body, hitEnergy, throughBarrier, isHeadshot) => OnLaserHitPlayer (body, hitEnergy, throughBarrier, isFullAuto, isHeadshot);
   }
 
-  private void OnLaserHitPlayer (CharacterBody3D body, float energy, bool throughBarrier, bool isFullAuto)
+  private void OnLaserHitPlayer (CharacterBody3D body, float energy, bool throughBarrier, bool isFullAuto, bool isHeadshot)
   {
     if (body is not Player victim || victim.NetworkId == NetworkId) return;
-    HitPuppet (victim, energy, throughBarrier, isFullAuto);
+    HitPuppet (victim, energy, throughBarrier, isFullAuto, isHeadshot);
   }
 
   // The victim is the single owner of its health: the shooter only reports the hit,
   // the victim applies damage & replicates Health to everyone, & tells the shooter
   // when it scored a kill (see issue #20).
-  private void HitPuppet (Player playerPuppet, float energy, bool throughBarrier, bool isFullAuto)
+  private void HitPuppet (Player playerPuppet, float energy, bool throughBarrier, bool isFullAuto, bool isHeadshot)
   {
-    GD.Print ($"{DisplayName}: I hit {playerPuppet.DisplayName}!");
+    GD.Print ($"{DisplayName}: I hit {playerPuppet.DisplayName}{(isHeadshot ? " on the dome" : "")}!");
+    PlayHitmarker (isHeadshot);
+    ReportToServer ($"hit: {DisplayName} zapped {playerPuppet.DisplayName} (energy {energy:0.00}{(isHeadshot ? ", headshot" : "")})");
+    playerPuppet.RpcId (playerPuppet.NetworkId, MethodName.ReceiveHit, energy, DisplayName, throughBarrier, isFullAuto, isHeadshot);
+  }
+
+  // A headshot's hitmarker rings higher (issue #179): the shooter knows it landed.
+  private void PlayHitmarker (bool isHeadshot)
+  {
+    _hitmarkerSound.PitchScale = isHeadshot ? 1.6f : 1.0f;
     _hitmarkerSound.Play();
-    ReportToServer ($"hit: {DisplayName} zapped {playerPuppet.DisplayName} (energy {energy:0.00})");
-    playerPuppet.RpcId (playerPuppet.NetworkId, MethodName.ReceiveHit, energy, DisplayName, throughBarrier, isFullAuto);
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void ReceiveHit (float energy, string shotByPlayerName, bool throughBarrier, bool isFullAuto)
+  private void ReceiveHit (float energy, string shotByPlayerName, bool throughBarrier, bool isFullAuto, bool isHeadshot)
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
@@ -277,7 +284,7 @@ public partial class Player
     LastDamageKind = isFullAuto ? DamageKind.FullAuto : DamageKind.Laser; // Message context (issue #84).
     // Distinct victim feedback for a through-barrier zap (issue #94).
     if (throughBarrier) _throughWallZapSound.Play();
-    ApplyDamage (energy, shotByPlayerName, knockbackScale: 1.0f, throughBarrier: throughBarrier);
+    ApplyDamage (energy, shotByPlayerName, knockbackScale: 1.0f, throughBarrier: throughBarrier, isHeadshot: isHeadshot);
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
@@ -303,12 +310,12 @@ public partial class Player
     LoseWeaponToPunch (puncherId);
   }
 
-  private void ApplyDamage (float energy, string attackerName, float knockbackScale, bool isSurvivableAtFullHealth = false, bool throughBarrier = false)
-    => ApplyDamageFrom (Multiplayer.GetRemoteSenderId(), energy, attackerName, knockbackScale, isSurvivableAtFullHealth, throughBarrier);
+  private void ApplyDamage (float energy, string attackerName, float knockbackScale, bool isSurvivableAtFullHealth = false, bool throughBarrier = false, bool isHeadshot = false)
+    => ApplyDamageFrom (Multiplayer.GetRemoteSenderId(), energy, attackerName, knockbackScale, isSurvivableAtFullHealth, throughBarrier, isHeadshot);
 
   // Split from ApplyDamage so delayed damage (the sticky banana fuse) can carry the
   // attacker id captured while the RPC context still existed (issue #83).
-  private void ApplyDamageFrom (int attackerId, float energy, string attackerName, float knockbackScale, bool isSurvivableAtFullHealth = false, bool throughBarrier = false)
+  private void ApplyDamageFrom (int attackerId, float energy, string attackerName, float knockbackScale, bool isSurvivableAtFullHealth = false, bool throughBarrier = false, bool isHeadshot = false)
   {
     // Already zapped out (issue #152): a body lying through its death sequence takes
     // no further damage - late stickies, blasts, & punches land on scenery.
@@ -323,6 +330,9 @@ public partial class Player
     var attacker = GetParent().GetNodeOrNull <Player> ($"{attackerId}");
     var handicap = 1.0f + 0.5f * Mathf.Max (0, TierOf (MaxHealth) - TierOf (attacker?.MaxHealth ?? MaxHealth));
     var decrease = Mathf.RoundToInt (CalculateHealthDecrease (energy) * handicap);
+    // A headshot is a flat, unhandicapped HeadshotDamage (issue #179): one zaps an
+    // Expert or Intermediate outright, a Beginner takes exactly two.
+    if (isHeadshot) decrease = HeadshotDamage;
     // A full-charge shot is lethal on ANY target (issue #93): the 100-damage cap &
     // tier handicap don't apply - only the survivable banana blast is exempt.
     if (energy >= EnergyWeapon.FullChargeEnergyThreshold && !isSurvivableAtFullHealth) decrease = Health;

--- a/core/players/Player.Cosmetics.cs
+++ b/core/players/Player.Cosmetics.cs
@@ -16,7 +16,11 @@ public partial class Player
   private Color BaseColor => PlayerColors.At (_colorIndex);
   // White glow blended over the player's chosen color, so armored players stay identifiable.
   private Color SpawnArmorColor => BaseColor.Lerp (Colors.White, 0.65f);
-  private void SetColor (Color color) => (_mesh.GetSurfaceOverrideMaterial (0) as StandardMaterial3D)!.AlbedoColor = color;
+  private void SetColor (Color color)
+  {
+    (_mesh.GetSurfaceOverrideMaterial (0) as StandardMaterial3D)!.AlbedoColor = color;
+    if (_headMesh != null) (_headMesh.GetSurfaceOverrideMaterial (0) as StandardMaterial3D)!.AlbedoColor = color; // The dome matches (issue #179).
+  }
   // Restores the player's resting color: white glow while spawn armor holds, the chosen color otherwise.
   private void RestoreBaseColor() => SetColor (SpawnArmor ? SpawnArmorColor : BaseColor);
 

--- a/core/players/Player.Head.cs
+++ b/core/players/Player.Head.cs
@@ -1,0 +1,30 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// Headshots (issue #179): a floating sphere head above the capsule, robot-style, with
+// its own hitbox (HeadHitbox). A headshot deals a flat HeadshotDamage, unscaled by the
+// difficulty handicap: one zaps an Expert (200) or Intermediate (300) outright, a
+// Beginner (400) takes exactly two. Laser bolts & slingshot stones report it.
+public partial class Player
+{
+  public const int HeadshotDamage = 300;
+  private HeadHitbox _head = null!;
+  private MeshInstance3D _headMesh = null!;
+
+  public Rid HeadRid => _head.GetRid();
+
+  private void CreateHead()
+  {
+    _head = HeadHitbox.Create();
+    AddChild (_head);
+    // Same tinted material as the body (duplicated, so the color setters drive both).
+    _headMesh = new MeshInstance3D { Mesh = new SphereMesh { Radius = HeadHitbox.Radius, Height = HeadHitbox.Radius * 2.0f }, Position = HeadHitbox.LocalOffset };
+    _headMesh.SetSurfaceOverrideMaterial (0, (Material)_mesh.GetSurfaceOverrideMaterial (0).Duplicate());
+    AddChild (_headMesh);
+  }
+
+  // Your own dome would fill the view when you look up: hide it in first person,
+  // show it in third person & on every other peer's copy of you.
+  private void UpdateHeadVisibility() => _headMesh.Visible = !IsMultiplayerAuthority() || _thirdPerson;
+}

--- a/core/players/Player.Slingshot.cs
+++ b/core/players/Player.Slingshot.cs
@@ -217,12 +217,12 @@ public partial class Player
     GetParent().AddChild (stone);
     stone.Launch (origin, sweepStart, direction, speed, gravity, energy, isLive, this);
     if (!isLive) return;
-    if (ammo == HeldWeapon.PaperAirplane) stone.HitPlayer += (victim, _) => OnSlungAirplaneHitPlayer (stone, victim);
-    else if (ammo == HeldWeapon.PoisonDart) stone.HitPlayer += (victim, _) => OnSlungDartHitPlayer (stone, victim); // Issue #194.
-    else stone.HitPlayer += (victim, hitEnergy) => OnStoneHitPlayer (victim, hitEnergy, ammo);
+    if (ammo == HeldWeapon.PaperAirplane) stone.HitPlayer += (victim, _, _) => OnSlungAirplaneHitPlayer (stone, victim);
+    else if (ammo == HeldWeapon.PoisonDart) stone.HitPlayer += (victim, _, _) => OnSlungDartHitPlayer (stone, victim); // Issue #194.
+    else stone.HitPlayer += (victim, hitEnergy, isHeadshot) => OnStoneHitPlayer (victim, hitEnergy, ammo, isHeadshot);
     // The berserk slung laser (issue #208) reports like full-auto fire from us; the
     // thrower stays immune to their own spray only because a self-zap would score.
-    if (ammo == HeldWeapon.Laser) stone.SpreeHit += (body, hitEnergy, throughBarrier) => OnLaserHitPlayer (body, hitEnergy, throughBarrier, isFullAuto: true);
+    if (ammo == HeldWeapon.Laser) stone.SpreeHit += (body, hitEnergy, throughBarrier) => OnLaserHitPlayer (body, hitEnergy, throughBarrier, isFullAuto: true, isHeadshot: false);
     if (ammo == HeldWeapon.None || IsCosmeticAmmo (ammo)) return;
     // Only the newest flight owns this player's server-side ammo escrow, so an older
     // stone still arcing somewhere can never land somebody else's item (issue #190).
@@ -278,18 +278,18 @@ public partial class Player
   // (victim-authoritative, same as ReceiveHit & ReceiveBoomerangHit). Slung world
   // items sting exactly like the stone baseline (issue #190) - only the flavor & the
   // death message change.
-  private void OnStoneHitPlayer (Player victim, float energy, HeldWeapon ammo)
+  private void OnStoneHitPlayer (Player victim, float energy, HeldWeapon ammo, bool isHeadshot)
   {
     if (victim.NetworkId == NetworkId) return;
     var what = ammo == HeldWeapon.None ? "stone" : ammo.ToString().ToLower();
-    GD.Print ($"{DisplayName}: My {what} thwacked {victim.DisplayName}!");
-    _hitmarkerSound.Play();
-    ReportToServer ($"slingshot: {DisplayName} thwacked {victim.DisplayName} with a slung {what} (energy {energy:0.00})");
-    victim.RpcId (victim.NetworkId, MethodName.ReceiveSlingshotHit, energy, DisplayName, (int)ammo);
+    GD.Print ($"{DisplayName}: My {what} thwacked {victim.DisplayName}{(isHeadshot ? " on the dome" : "")}!");
+    PlayHitmarker (isHeadshot); // Issue #179.
+    ReportToServer ($"slingshot: {DisplayName} thwacked {victim.DisplayName} with a slung {what} (energy {energy:0.00}{(isHeadshot ? ", headshot" : "")})");
+    victim.RpcId (victim.NetworkId, MethodName.ReceiveSlingshotHit, energy, DisplayName, (int)ammo, isHeadshot);
   }
 
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void ReceiveSlingshotHit (float energy, string slungByPlayerName, int ammo)
+  private void ReceiveSlingshotHit (float energy, string slungByPlayerName, int ammo, bool isHeadshot)
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return;
@@ -300,6 +300,6 @@ public partial class Player
     // Bulk (issue #208): a big slung item hits & shoves harder, capped just under the
     // full-charge threshold so the slingshot keeps its never-a-one-hit promise.
     var bulk = SlingshotStone.BulkFactor ((HeldWeapon)ammo);
-    ApplyDamage (Mathf.Min (energy * bulk, SlungBulkEnergyCap), slungByPlayerName, SlingshotKnockbackScale * bulk);
+    ApplyDamage (Mathf.Min (energy * bulk, SlungBulkEnergyCap), slungByPlayerName, SlingshotKnockbackScale * bulk, isHeadshot: isHeadshot);
   }
 }

--- a/core/players/Player.View.cs
+++ b/core/players/Player.View.cs
@@ -52,6 +52,7 @@ public partial class Player
     // The #124 draw-over-walls weapon overlay is a first-person trick only: in third
     // person the own weapons & hands render normally, like every other peer sees them.
     SetFirstPersonOverlayEnabled (!enabled);
+    UpdateHeadVisibility(); // Issue #179.
     (enabled ? _thirdPersonCamera! : _camera).Current = true;
   }
 

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -342,6 +342,7 @@ public partial class Player : CharacterBody3D
     _laserBoltScene = ResourceLoader.Load <PackedScene> ("res://core/weapons/LaserBolt.tscn");
     _bananaProjectileScene = ResourceLoader.Load <PackedScene> ("res://core/weapons/BananaProjectile.tscn");
     _mesh = GetNode <MeshInstance3D> ("MeshInstance3D");
+    CreateHead(); // The floating sensor dome & its hitbox (issue #179).
     _collisionShape = GetNode <CollisionShape3D> ("CollisionShape3D");
     _energyWeapon = GetNode <EnergyWeapon> ("Camera3D/EnergyWeapon");
     _bananaLauncher = GetNode <BananaLauncher> ("Camera3D/BananaLauncher");
@@ -405,6 +406,7 @@ public partial class Player : CharacterBody3D
     _energyWeapon.FullChargeReached += OnFullChargeReached;
     _crosshairBaseScale = _crossHairs.Scale;
     _camera = GetNode <Camera3D> ("Camera3D");
+    UpdateHeadVisibility(); // Own dome hidden in first person (issue #179).
     _camera.Current = true;
     _standingCameraHeight = _camera.Position.Y;
     _isInputEnabled = true;

--- a/core/weapons/LaserBolt.cs
+++ b/core/weapons/LaserBolt.cs
@@ -1,3 +1,4 @@
+using com.forerunnergames.energyshot.players;
 using Godot;
 
 namespace com.forerunnergames.energyshot.weapons;
@@ -27,7 +28,7 @@ public partial class LaserBolt : Node3D
   // bolt drooping onto the ground at the end of its arc leaves nothing, while
   // deliberately shooting at the ground still scorches it.
   [Export] public float BurnMarkMinImpactSpeedFraction = 0.5f;
-  [Signal] public delegate void HitPlayerEventHandler (CharacterBody3D player, float energy, bool throughBarrier);
+  [Signal] public delegate void HitPlayerEventHandler (CharacterBody3D player, float energy, bool throughBarrier, bool isHeadshot);
   // Baseline bright red at every charge level (issue #92); charge only makes it hotter.
   private static readonly Color LowEnergyColor = new(3.0f, 0.12f, 0.1f);
   private static readonly Color HighEnergyColor = new(6.0f, 0.3f, 0.15f);
@@ -54,6 +55,7 @@ public partial class LaserBolt : Node3D
     _energy = energy;
     _isLive = isLive;
     _exclusions = shooter == null ? new Godot.Collections.Array <Rid>() : new Godot.Collections.Array <Rid> { shooter.GetRid() };
+    if (shooter is Player own) _exclusions.Add (own.HeadRid); // Your own dome is not a target (issue #179).
     Orient();
     ApplyEnergyVisuals();
   }
@@ -82,6 +84,7 @@ public partial class LaserBolt : Node3D
       // Point-blank bolts can spawn inside the target's collider; without this the
       // sweep never registers & the bolt sails through (see issue #52).
       query.HitFromInside = true;
+      query.CollideWithAreas = true; // Heads are Area3D hitboxes (issue #179).
       var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
       if (hit.Count == 0) break;
       if (!ResolveHit (hit)) return;
@@ -96,9 +99,19 @@ public partial class LaserBolt : Node3D
   // pierced collider so the sweep doesn't re-hit it (see issue #50).
   private bool ResolveHit (Godot.Collections.Dictionary hit)
   {
-    if (hit["collider"].AsGodotObject() is CharacterBody3D player)
+    var collider = hit["collider"].AsGodotObject();
+
+    // The dome first (issue #179): a head hit is a body hit with a flag.
+    if (collider is HeadHitbox head)
     {
-      if (_isLive) EmitSignal (SignalName.HitPlayer, player, _energy, _piercedBarrier);
+      if (_isLive) EmitSignal (SignalName.HitPlayer, head.Player, _energy, _piercedBarrier, true);
+      QueueFree();
+      return false;
+    }
+
+    if (collider is CharacterBody3D player)
+    {
+      if (_isLive) EmitSignal (SignalName.HitPlayer, player, _energy, _piercedBarrier, false);
       QueueFree();
       return false;
     }

--- a/core/weapons/SlingshotStone.cs
+++ b/core/weapons/SlingshotStone.cs
@@ -18,7 +18,7 @@ public partial class SlingshotStone : Node3D
   // Doubled from 6 (issue #163): stones fly their full arc & only despawn on impact
   // or well past relevance.
   [Export] public float MaxLifetimeSeconds = 12.0f;
-  [Signal] public delegate void HitPlayerEventHandler (Player victim, float energy);
+  [Signal] public delegate void HitPlayerEventHandler (Player victim, float energy, bool isHeadshot);
   // Where the flight ended (issue #190): a slung world item becomes a normal pickup
   // again wherever it stops, so nothing loaded into a slingshot can vanish.
   [Signal] public delegate void LandedEventHandler (Vector3 position);
@@ -50,7 +50,7 @@ public partial class SlingshotStone : Node3D
   private float _energy;
   private float _age;
   private bool _isLive;
-  private Rid _shooterRid;
+  private Godot.Collections.Array <Rid> _exclusions = new();
 
   // Shared look for the world pickup & the held model (issue #99): a simple Y-frame
   // slingshot built from primitive boxes - a wooden handle, two angled prongs, & a
@@ -149,7 +149,8 @@ public partial class SlingshotStone : Node3D
     GravityAcceleration = gravity; // Draw-scaled (issue #163): full draws fly flatter arcs.
     _energy = energy;
     _isLive = isLive;
-    _shooterRid = shooter.GetRid();
+    _exclusions = new Godot.Collections.Array <Rid> { shooter.GetRid() };
+    if (shooter is Player own) _exclusions.Add (own.HeadRid); // Your own dome is not a target (issue #179).
   }
 
   public override void _PhysicsProcess (double delta)
@@ -162,8 +163,9 @@ public partial class SlingshotStone : Node3D
     _sweptFromStart = true;
     _velocity.Y -= GravityAcceleration * dt;
     var to = GlobalPosition + _velocity * dt;
-    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: new Godot.Collections.Array <Rid> { _shooterRid });
+    var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: _exclusions);
     query.HitFromInside = true;
+    query.CollideWithAreas = true; // Heads are Area3D hitboxes (issue #179).
     var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
 
     if (hit.Count == 0)
@@ -180,7 +182,9 @@ public partial class SlingshotStone : Node3D
     // ray a metre too, so this is belt & braces - & it also keeps the resting item
     // from z-fighting with whatever it landed against.
     GlobalPosition = (Vector3)hit["position"] + (Vector3)hit["normal"] * SurfaceClearance;
-    End (hit["collider"].AsGodotObject() as Player);
+    var collider = hit["collider"].AsGodotObject();
+    if (collider is HeadHitbox head) { End (head.Player, isHeadshot: true); return; } // Issue #179.
+    End (collider as Player, isHeadshot: false);
   }
 
   private void UpdateSpree (float dt)
@@ -192,7 +196,7 @@ public partial class SlingshotStone : Node3D
     var bolt = BoltScene.Instantiate <LaserBolt>();
     GetParent().AddChild (bolt);
     bolt.Launch (GlobalPosition, GlobalPosition, direction, SpreeEnergy, _isLive, shooter: null);
-    if (_isLive) bolt.HitPlayer += (body, energy, throughBarrier) => EmitSignal (SignalName.SpreeHit, body, energy, throughBarrier);
+    if (_isLive) bolt.HitPlayer += (body, energy, throughBarrier, _) => EmitSignal (SignalName.SpreeHit, body, energy, throughBarrier); // A tumbling gun never lands dome shots.
     var pew = new AudioStreamPlayer3D { Stream = SpreeShotSound, PitchScale = 1.3f, VolumeDb = -6.0f };
     GetParent().AddChild (pew);
     pew.GlobalPosition = GlobalPosition;
@@ -214,13 +218,13 @@ public partial class SlingshotStone : Node3D
   // One terminal report per flight (issue #190): the hit (if any) & then the resting
   // spot, so the shooter can both damage the victim & ask the server to turn the
   // slung item back into a world pickup where it came to rest.
-  private void End (Player? victim)
+  private void End (Player? victim, bool isHeadshot = false)
   {
     PlayImpactFlavor();
 
     if (_isLive)
     {
-      if (victim != null) EmitSignal (SignalName.HitPlayer, victim, _energy);
+      if (victim != null) EmitSignal (SignalName.HitPlayer, victim, _energy, isHeadshot);
       EmitSignal (SignalName.Landed, GlobalPosition);
     }
 

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -83,6 +83,10 @@ There is exactly **one** paper airplane in the arena. It's a slot-6 weapon like 
 
 The spawn box is a boxing ring: its walls are rubber ropes. Run, slide, or get punched into one and you bounce back the way you came with a shove - knock someone into the ropes and they come right back to you. Land on top of another player's head and you spring high into the air. Spawn armor & the room's protection work exactly as before.
 
+## Headshots
+
+Every player has a floating sensor dome above the body. A laser bolt or a slingshot stone (or slung item) that hits the dome is a headshot: a flat 300 damage that ignores the difficulty handicap - one zaps an Expert or Intermediate outright, a Beginner takes exactly two. Punches, bananas, boomerangs, airplanes & darts don't care where they land. Your hitmarker rings higher on a dome hit.
+
 ## Good to know
 
 - White glow = spawn armor (5s of invulnerability after spawning; firing or punching cancels it).

--- a/tests/unit/HeadshotTest.cs
+++ b/tests/unit/HeadshotTest.cs
@@ -1,0 +1,29 @@
+using com.forerunnergames.energyshot.players;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Headshots (issue #179): the flat dome damage must one-shot Expert (200) &
+// Intermediate (300) & take exactly two on a Beginner (400) - pinned against the
+// real health tiers so a retune of either side can't silently break the promise.
+[TestSuite]
+public class HeadshotTest
+{
+  [TestCase]
+  public void OneHeadshotZapsExpertAndIntermediate()
+  {
+    AssertBool (Player.HeadshotDamage >= Player.MaxHealthFor (2)).IsTrue();
+    AssertBool (Player.HeadshotDamage >= Player.MaxHealthFor (1)).IsTrue();
+  }
+
+  [TestCase]
+  public void BeginnerSurvivesOneHeadshotButNotTwo()
+  {
+    AssertBool (Player.HeadshotDamage < Player.MaxHealthFor (0)).IsTrue();
+    AssertBool (2 * Player.HeadshotDamage >= Player.MaxHealthFor (0)).IsTrue();
+  }
+
+  [TestCase]
+  public void HeadHitboxSitsAboveTheBody() => AssertFloat (HeadHitbox.LocalOffset.Y - HeadHitbox.Radius).IsGreater (2.0f);
+}


### PR DESCRIPTION
Implements #179.

**The dome.** `HeadHitbox` is an `Area3D` on its own collision layer (8), a child of the player — it rides the existing pose sync on every peer & is *not* one of the `CharacterBody3D`'s shapes, so movement, doorways & ceilings are unchanged. A matching sphere mesh shares the body's tint (hit flash & spawn-armor glow included); hidden from your own first-person camera, visible in third person & on every other peer's copy of you.

**Detection.** Laser bolts & slingshot stones (any slung ammo) sweep with `CollideWithAreas`, exclude the shooter's own body *and* dome, & report `isHeadshot` through `HitPlayer` → `ReceiveHit` / `ReceiveSlingshotHit`. Punches, bananas, boomerangs, airplanes & darts don't look at the dome (their rays keep bodies-only).

**Damage.** A headshot is a flat `HeadshotDamage = 300`, applied before the full-charge override & **outside the difficulty handicap**: one zaps an Expert (200) or Intermediate (300) outright, a Beginner (400) takes exactly two. `HeadshotTest` pins both against `MaxHealthFor`. The shooter's hitmarker rings higher on a dome hit.

No scene-file edits: the dome & its mesh are code-built in `Player._Ready`. Non-violent framing throughout (sensor dome, zaps).

Verification is CI's job: this box can't build. Worth a human eye in the next playtest: dome placement at head height (y 2.45, r 0.3) & that your own dome never shows in first person.

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso