### PR TITLE
Boxing ring spawn box: rope walls that bounce players, bounceable heads

### DIFF
--- a/core/players/Player.BoxingRing.cs
+++ b/core/players/Player.BoxingRing.cs
@@ -1,0 +1,45 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.players;
+
+// The spawn box is a boxing ring (issue #174): its walls are rubber ropes that bounce
+// you back the way you came - with a shove, so a punch into the ropes returns the
+// victim to the puncher - & landing on another player's head springs you high.
+// The room's spawn-protection job (spawn armor, layout) is untouched.
+public partial class Player
+{
+  [Export] public float RopeRestitution = 0.9f;
+  [Export] public float RopeShove = 6.0f;
+  [Export] public float RopeBounceSeconds = 0.35f;
+  [Export] public float HeadBounceVelocity = 26.0f;
+  private const float MinRopeImpactSpeed = 1.0f;
+  private Vector3 _preMoveVelocity;
+
+  private bool IsRope (GodotObject? collider) => collider is CsgBox3D box && box.GetParent() == _spawnRoom && box.Name.ToString().StartsWith ("Wall");
+
+  // Ropes (issue #174): reflect the velocity we arrived with (MoveAndSlide already
+  // scrubbed the into-wall part from Velocity), scale by restitution, add a shove
+  // along the rope's normal, & let momentum own the ride briefly - the same
+  // "launched" flag the sticky banana uses, so Move() doesn't brake the bounce.
+  private bool TryRopeBounce (KinematicCollision3D collision)
+  {
+    if (!IsRope (collision.GetCollider())) return false;
+    var normal = collision.GetNormal();
+    if (Mathf.Abs (normal.Y) > 0.5f) return false; // The top edge isn't a rope.
+    if (-_preMoveVelocity.Dot (normal) < MinRopeImpactSpeed) return false; // Leaning on it, not hitting it.
+    var bounced = _preMoveVelocity.Bounce (normal) * RopeRestitution + normal * RopeShove;
+    Velocity = new Vector3 (bounced.X, Velocity.Y, bounced.Z);
+    _stickyFlightSecondsLeft = Mathf.Max (_stickyFlightSecondsLeft, RopeBounceSeconds);
+    return true;
+  }
+
+  // Head bounce (issue #174): landing on top of another player springs you up, higher
+  // than a jump. Only the one on top bounces; the trampoline feels nothing.
+  private bool TryHeadBounce (KinematicCollision3D collision)
+  {
+    if (collision.GetCollider() is not Player || collision.GetNormal().Y < 0.7f) return false;
+    Velocity = new Vector3 (Velocity.X, HeadBounceVelocity, Velocity.Z);
+    _jumpSound.Play();
+    return true;
+  }
+}

--- a/core/players/Player.Movement.cs
+++ b/core/players/Player.Movement.cs
@@ -243,6 +243,7 @@ public partial class Player
 
   private void HandleCollision (KinematicCollision3D collision)
   {
+    if (TryRopeBounce (collision) || TryHeadBounce (collision)) return; // The boxing ring (issue #174).
     if (collision.GetColliderShape() is not CollisionShape3D { Shape: WorldBoundaryShape3D }) return;
     RespawnFell();
   }

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -466,6 +466,7 @@ public partial class Player : CharacterBody3D
     if (IsJumping()) Jump (ref velocity);
     Move (ref velocity);
     Velocity = velocity;
+    _preMoveVelocity = velocity; // What we arrived with, for the ring ropes (issue #174).
     if (!MoveAndSlide()) return;
     HandleCollisions();
   }

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -78,6 +78,7 @@ public partial class World : Node3D
 
   public override void _Ready()
   {
+    DressTheRing(); // The spawn box is a boxing ring (issue #174).
     _onServerDisconnectedCallable = Callable.From (OnServerDisconnected);
     _playerScene = ResourceLoader.Load <PackedScene> ("res://core/players/Player.tscn");
     _networkManager = GetNode <NetworkManager> ("NetworkManager");
@@ -107,6 +108,14 @@ public partial class World : Node3D
     StartAdminMessagePolling();
     _serverVersion = ReadServerVersion();
     StartCrownTicker();
+  }
+
+  // Boxing-ring ropes (issue #174): the spawn box's walls read as red ropes. Bounce
+  // physics lives in Player.BoxingRing; this is the look, shared by every peer.
+  private void DressTheRing()
+  {
+    var rope = new StandardMaterial3D { AlbedoColor = new Color (0.85f, 0.1f, 0.12f), Roughness = 0.4f };
+    foreach (var wall in GetNode <Node3D> ("SpawnRoom").GetChildren().OfType <CsgBox3D>().Where (box => box.Name.ToString().StartsWith ("Wall"))) wall.Material = rope;
   }
 
   // Admin announcements (issue #158): only active with --admin-message-file; no

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -78,6 +78,10 @@ There is exactly **one** paper airplane in the arena. It's a slot-6 weapon like 
 - **With a slingshot equipped** you load an armed one as ammo instead of setting it off. A slung airplane flies fast and dead straight (no homing): hit a player and they ignite and pop exactly as a thrown hit would; hit anything else and it just falls and is a landmine again. Reload it as often as you like.
 - A fresh airplane is folded somewhere in the arena every time the old one goes off - and a fresh one is a normal pickup, not a mine.
 
+## The boxing ring
+
+The spawn box is a boxing ring: its walls are rubber ropes. Run, slide, or get punched into one and you bounce back the way you came with a shove - knock someone into the ropes and they come right back to you. Land on top of another player's head and you spring high into the air. Spawn armor & the room's protection work exactly as before.
+
 ## Good to know
 
 - White glow = spawn armor (5s of invulnerability after spawning; firing or punching cancels it).


### PR DESCRIPTION
Implements #174.

**Ropes.** A wall collision inside the spawn room reflects the velocity you *arrived* with (`_preMoveVelocity`, captured before `MoveAndSlide` scrubs the into-wall component), scaled by `RopeRestitution` (0.9), plus a `RopeShove` (6 m/s) along the rope's normal — so a punch into the ropes sends the victim straight back. The sticky-banana "launched" flag (`_stickyFlightSecondsLeft`) holds for 0.35 s so `Move()` doesn't brake the bounce. The wall's top edge & mere leaning (impact < 1 m/s) don't bounce.

**Head bounce.** Landing on top of another player (collision normal pointing up) sets your vertical velocity to `HeadBounceVelocity` (26, above the 20 jump) with the jump sound; the one underneath feels nothing. Global, not ring-only — a judgment call under the delegation; trivial to fence if unwanted.

**Look.** The four spawn-room walls get a red rope material at `World._Ready` — code-built, no scene-file edits, same geometry, so the room's spawn protection & the third-person arm's parapet behavior are unchanged.

Verification is CI's job: this box can't build. The playtest's short spawn-room walks are lane-aware, but a rope bounce on a corner approach is the thing to watch in the run.

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso