### PR TITLE
Slingshot-fired weapons: laser goes on a full-auto spree, big objects hit hard

### DIFF
--- a/core/players/Player.Slingshot.cs
+++ b/core/players/Player.Slingshot.cs
@@ -44,6 +44,7 @@ public partial class Player
   [Export] public float SlingshotMinEnergy = 0.15f;
   [Export] public float SlingshotMaxEnergy = 0.6f;
   [Export] public float SlingshotKnockbackScale = 0.6f;
+  public const float SlungBulkEnergyCap = 0.9f; // Just under the one-shot threshold (issue #208).
   // Arc flattening (issue #163): stone gravity eases off as the draw rises, so
   // full-draw stones fly flat long shots while taps stay lobbed.
   [Export] public float SlingshotMinDrawGravity = 24.0f;
@@ -219,6 +220,9 @@ public partial class Player
     if (ammo == HeldWeapon.PaperAirplane) stone.HitPlayer += (victim, _) => OnSlungAirplaneHitPlayer (stone, victim);
     else if (ammo == HeldWeapon.PoisonDart) stone.HitPlayer += (victim, _) => OnSlungDartHitPlayer (stone, victim); // Issue #194.
     else stone.HitPlayer += (victim, hitEnergy) => OnStoneHitPlayer (victim, hitEnergy, ammo);
+    // The berserk slung laser (issue #208) reports like full-auto fire from us; the
+    // thrower stays immune to their own spray only because a self-zap would score.
+    if (ammo == HeldWeapon.Laser) stone.SpreeHit += (body, hitEnergy, throughBarrier) => OnLaserHitPlayer (body, hitEnergy, throughBarrier, isFullAuto: true);
     if (ammo == HeldWeapon.None || IsCosmeticAmmo (ammo)) return;
     // Only the newest flight owns this player's server-side ammo escrow, so an older
     // stone still arcing somewhere can never land somebody else's item (issue #190).
@@ -293,6 +297,9 @@ public partial class Player
     GD.Print ($"{DisplayName}: I was thwacked by {slungByPlayerName}'s slingshot!");
     // Getting zapped out by a slung LOAF deserves its own line (issue #190).
     LastDamageKind = (HeldWeapon)ammo == HeldWeapon.None ? DamageKind.Slingshot : DamageKind.SlungItem; // Message context (issue #84).
-    ApplyDamage (energy, slungByPlayerName, SlingshotKnockbackScale);
+    // Bulk (issue #208): a big slung item hits & shoves harder, capped just under the
+    // full-charge threshold so the slingshot keeps its never-a-one-hit promise.
+    var bulk = SlingshotStone.BulkFactor ((HeldWeapon)ammo);
+    ApplyDamage (Mathf.Min (energy * bulk, SlungBulkEnergyCap), slungByPlayerName, SlingshotKnockbackScale * bulk);
   }
 }

--- a/core/weapons/LaserBolt.cs
+++ b/core/weapons/LaserBolt.cs
@@ -44,14 +44,16 @@ public partial class LaserBolt : Node3D
   // sweepStart is the shooter's camera position: the bolt spawns at the muzzle, but
   // the first sweep covers camera->muzzle too, so a wall closer than the muzzle
   // offset can't be skipped (issue #112).
-  public void Launch (Vector3 origin, Vector3 sweepStart, Vector3 direction, float energy, bool isLive, CharacterBody3D shooter)
+  // A null shooter (issue #208: a slung laser's spree) excludes nobody - the gun is
+  // out of control & owes no one safety.
+  public void Launch (Vector3 origin, Vector3 sweepStart, Vector3 direction, float energy, bool isLive, CharacterBody3D? shooter)
   {
     GlobalPosition = origin;
     _sweepStart = sweepStart;
     _velocity = direction.Normalized() * Speed;
     _energy = energy;
     _isLive = isLive;
-    _exclusions = new Godot.Collections.Array <Rid> { shooter.GetRid() };
+    _exclusions = shooter == null ? new Godot.Collections.Array <Rid>() : new Godot.Collections.Array <Rid> { shooter.GetRid() };
     Orient();
     ApplyEnergyVisuals();
   }

--- a/core/weapons/SlingshotStone.cs
+++ b/core/weapons/SlingshotStone.cs
@@ -22,6 +22,15 @@ public partial class SlingshotStone : Node3D
   // Where the flight ended (issue #190): a slung world item becomes a normal pickup
   // again wherever it stops, so nothing loaded into a slingshot can vanish.
   [Signal] public delegate void LandedEventHandler (Vector3 position);
+  // A slung LASER goes berserk in flight (issue #208): full-auto shots spray in random
+  // directions as it tumbles. The live stone's spree reports hits here; visual copies
+  // spray cosmetic bolts so every peer sees (& fears) the same chaos.
+  [Signal] public delegate void SpreeHitEventHandler (CharacterBody3D body, float energy, bool throughBarrier);
+  [Export] public float SpreeIntervalSeconds = 0.15f;
+  [Export] public float SpreeEnergy = 0.24f; // The full-auto per-shot energy (issue #218).
+  private static readonly PackedScene BoltScene = ResourceLoader.Load <PackedScene> ("res://core/weapons/LaserBolt.tscn");
+  private static readonly AudioStream SpreeShotSound = ResourceLoader.Load <AudioStream> ("res://assets/sounds/shoot2.mp3");
+  private float _spreeLeft;
   // What's flying: None = a plain stone, anything else = a loaded world item (issue #190).
   public HeldWeapon Ammo { get; init; } = HeldWeapon.None;
   private static readonly Color StoneGray = new(0.55f, 0.55f, 0.58f);
@@ -148,6 +157,7 @@ public partial class SlingshotStone : Node3D
     var dt = (float)delta;
     _age += dt;
     if (_age > MaxLifetimeSeconds) { End (victim: null); return; }
+    if (Ammo == HeldWeapon.Laser) UpdateSpree (dt);
     var from = _sweptFromStart ? GlobalPosition : _sweepStart;
     _sweptFromStart = true;
     _velocity.Y -= GravityAcceleration * dt;
@@ -172,6 +182,34 @@ public partial class SlingshotStone : Node3D
     GlobalPosition = (Vector3)hit["position"] + (Vector3)hit["normal"] * SurfaceClearance;
     End (hit["collider"].AsGodotObject() as Player);
   }
+
+  private void UpdateSpree (float dt)
+  {
+    _spreeLeft -= dt;
+    if (_spreeLeft > 0.0f) return;
+    _spreeLeft = SpreeIntervalSeconds;
+    var direction = new Vector3 (GD.Randf() - 0.5f, GD.Randf() - 0.5f, GD.Randf() - 0.5f).Normalized();
+    var bolt = BoltScene.Instantiate <LaserBolt>();
+    GetParent().AddChild (bolt);
+    bolt.Launch (GlobalPosition, GlobalPosition, direction, SpreeEnergy, _isLive, shooter: null);
+    if (_isLive) bolt.HitPlayer += (body, energy, throughBarrier) => EmitSignal (SignalName.SpreeHit, body, energy, throughBarrier);
+    var pew = new AudioStreamPlayer3D { Stream = SpreeShotSound, PitchScale = 1.3f, VolumeDb = -6.0f };
+    GetParent().AddChild (pew);
+    pew.GlobalPosition = GlobalPosition;
+    pew.Finished += pew.QueueFree;
+    pew.Play();
+  }
+
+  // Bulk (issue #208): big things hit hard. Scales the draw-scaled energy & the
+  // knockback when a slung item connects; a stone stays a stone, a launcher is a
+  // wrecking ball. Pure & unit-tested.
+  public static float BulkFactor (HeldWeapon ammo) => ammo switch
+  {
+    HeldWeapon.Banana => 3.0f,
+    HeldWeapon.Laser or HeldWeapon.Blowgun => 2.2f,
+    HeldWeapon.Boomerang or HeldWeapon.Slingshot => 2.0f,
+    _ => 1.0f
+  };
 
   // One terminal report per flight (issue #190): the hit (if any) & then the resting
   // spot, so the shooter can both damage the victim & ask the server to turn the

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -34,7 +34,8 @@ Slot keys select what's in your hands. You spawn with fists **and bread** (B is 
 With the slingshot **out and empty**, walking onto any world item **loads it** instead of collecting it - another player's dropped laser, the banana launcher, the boomerang, even another slingshot, plus loose bread, banana chunks, and a grounded paper airplane. You can only ever load what's on the ground: your own equipped weapons stay in your hands.
 
 - One item at a time. While something is nocked, normal pickup rules apply again.
-- Slung items fly the same draw-scaled arc as a stone and sting about the same, with their own flavor on impact (bread bonks, banana splatters).
+- Slung items fly the same draw-scaled arc as a stone. Small things sting like a stone; **big things hit hard** - a slung gun deals roughly double the damage and knockback, the banana launcher triple (never a one-hit, even at full draw).
+- A **slung laser goes berserk**: it sprays full-auto shots in random directions as it tumbles, until it lands. Dangerous to everyone near its flight path.
 - Wherever the item lands, it becomes an ordinary world pickup again - nothing is ever destroyed by being fired.
 - Holster the slingshot (or fill it) if you'd rather just pick things up.
 

--- a/tests/unit/SlungBulkTest.cs
+++ b/tests/unit/SlungBulkTest.cs
@@ -1,0 +1,30 @@
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.weapons;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Slung-item bulk (issue #208): weapons hit harder than a stone, the launcher hardest,
+// & the capped energy stays under the one-shot threshold at a full draw.
+[TestSuite]
+public class SlungBulkTest
+{
+  [TestCase]
+  public void StoneBreadAndChunkStayBaseline()
+  {
+    AssertFloat (SlingshotStone.BulkFactor (HeldWeapon.None)).IsEqual (1.0f);
+    AssertFloat (SlingshotStone.BulkFactor (HeldWeapon.Bread)).IsEqual (1.0f);
+    AssertFloat (SlingshotStone.BulkFactor (HeldWeapon.BananaChunk)).IsEqual (1.0f);
+  }
+
+  [TestCase]
+  public void LauncherIsTheWreckingBall()
+  {
+    AssertFloat (SlingshotStone.BulkFactor (HeldWeapon.Banana)).IsGreater (SlingshotStone.BulkFactor (HeldWeapon.Laser));
+    AssertFloat (SlingshotStone.BulkFactor (HeldWeapon.Laser)).IsGreater (1.0f);
+  }
+
+  [TestCase]
+  public void CapKeepsTheNeverOneHitPromise() => AssertFloat (Player.SlungBulkEnergyCap).IsLess (EnergyWeapon.FullChargeEnergyThreshold);
+}


### PR DESCRIPTION
Implements #208 — the two #190 intents the shipped universal-ammo work skipped.

**Berserk slung laser.** While a slung laser is in flight, every 0.15 s it spawns a full-auto bolt (0.24 energy, the #218 value) in a random direction with a pitched-up shot sound. Every peer's visual copy sprays cosmetic bolts, so the chaos reads the same everywhere; the live stone's spree reports hits as the thrower's full-auto fire (`OnLaserHitPlayer(isFullAuto: true)`). `LaserBolt.Launch` takes a nullable shooter now — a spree bolt excludes nobody. Judgment call: the thrower stays immune to their *own* spray, purely because a self-zap would score a point through `NotifyScored`.

**Bulk.** `SlingshotStone.BulkFactor`: banana launcher 3×, laser/blowgun 2.2×, boomerang/slingshot 2×, everything else 1×. Applied victim-side from the ammo already in `ReceiveSlingshotHit` — no RPC change — to both energy & knockback, with energy capped at 0.9 (just under the full-charge threshold) so the slingshot keeps its never-a-one-hit promise even at full draw with the launcher.

Tests: `SlungBulkTest` (baseline items, launcher > gun > 1, cap below one-shot). Controls doc updated.

Verification is CI's job: this box can't build.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso