### PR TITLE
Bread moves to key 0 (B stays) & leads the weapon wheel, one notch left of fists

### DIFF
--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -7,7 +7,7 @@ namespace com.forerunnergames.energyshot.players;
 // Weapon lifecycle & selection (issues #72 & #82): players spawn with fists only &
 // arm up from world pickups; death drops everything held at the death spot. Slot 1 =
 // fists (always available), slot 2 = laser, slot 3 = banana, slot 4 = boomerang (#98),
-// slot 5 = slingshot (#99), slot 6 = paper airplane (#102), slot 7 = bread (#209);
+// slot 5 = slingshot (#99), slot 6 = paper airplane (#102), key 0 (or B) = bread (#209, #223);
 // everything but fists is selectable only while held. The server-side WeaponSpawner
 // owns pickup spawning & the weapon caps.
 public partial class Player
@@ -87,7 +87,7 @@ public partial class Player
   private bool HasSlingshot => Holds (HeldWeapon.Slingshot);
   private bool HasPaperAirplane => Holds (HeldWeapon.PaperAirplane);
   private bool IsFistsSelected => _selectedWeapon == SelectedWeapon.Fists;
-  private bool IsBreadSelected => _selectedWeapon == SelectedWeapon.Bread; // Slot 7 (issue #209).
+  private bool IsBreadSelected => _selectedWeapon == SelectedWeapon.Bread; // Key 0 / B (issues #209 & #223).
   private bool IsLaserSelected => _selectedWeapon == SelectedWeapon.Laser;
   private bool IsBananaSelected => _selectedWeapon == SelectedWeapon.Banana;
   private bool IsBoomerangSelected => _selectedWeapon == SelectedWeapon.Boomerang;
@@ -123,7 +123,7 @@ public partial class Player
 
     _bread.TryEat();
     HeldWeapon &= ~HeldWeapon.Bread;
-    DeselectUnheldWeapon(); // An eaten, wasted, or dropped loaf can't stay in slot 7 (issue #209).
+    DeselectUnheldWeapon(); // An eaten, wasted, or dropped loaf can't stay selected (issue #209).
   }
 
   // Losing the stolen weapon ends the revenge window (CodeRabbit on #96): a fresh
@@ -139,7 +139,7 @@ public partial class Player
   private void UpdateWeaponVisibility()
   {
     if (_bananaLauncher == null || _boomerangHeld == null || _slingshotHeld == null || _airplaneHeld == null || _breadHeld == null || _blowgunHeld == null) return;
-    _breadHeld.Visible = IsBreadSelected && HasBread; // Slot 7 (issue #209): everyone sees the loaf in hand.
+    _breadHeld.Visible = IsBreadSelected && HasBread; // Key 0 / B (issues #209 & #223): everyone sees the loaf in hand.
     _energyWeapon.Visible = IsLaserSelected && HasLaser;
     _bananaLauncher.Visible = IsBananaSelected && HasBanana;
     _boomerangHeld.Visible = IsBoomerangSelected && HasBoomerang && !IsBoomerangOut; // Empty hand while it's out flying (issue #98).
@@ -161,7 +161,7 @@ public partial class Player
     if (Input.IsActionJustPressed ("weapon_4") && HasBoomerang) SelectedWeapon = SelectedWeapon.Boomerang; // Slot 4 (issue #98).
     if (Input.IsActionJustPressed ("weapon_5") && HasSlingshot) SelectedWeapon = SelectedWeapon.Slingshot; // Slot 5 (issue #99).
     if (Input.IsActionJustPressed ("weapon_6") && HasPaperAirplane) SelectedWeapon = SelectedWeapon.PaperAirplane; // Slot 6 (issue #102).
-    if (Input.IsActionJustPressed ("weapon_7") && HasBread) SelectedWeapon = SelectedWeapon.Bread; // Slot 7 (issue #209).
+    if (Input.IsActionJustPressed ("weapon_0") && HasBread) SelectedWeapon = SelectedWeapon.Bread; // Key 0 (or B): the loaf sits just left of fists (issues #209 & #223).
     if (Input.IsActionJustPressed ("weapon_8") && HasBlowgun) SelectedWeapon = SelectedWeapon.Blowgun; // Slot 8 (issue #194).
     // Cycling (issue #186): mouse wheel for mouse players, Q & E for trackpads -
     // reaching for 7 mid-fight to eat is not a real option.
@@ -191,21 +191,25 @@ public partial class Player
   public static SelectedWeapon NextCycleSlot (List <SelectedWeapon> carried, SelectedWeapon current, int step)
   {
     var index = carried.IndexOf (current);
-    var next = index < 0 ? 0 : ((index + step) % carried.Count + carried.Count) % carried.Count;
-    return carried[next];
+    if (index < 0) return SelectedWeapon.Fists; // The slot just left our hands mid-cycle: fists, never the loaf (issue #223).
+    return carried[((index + step) % carried.Count + carried.Count) % carried.Count];
   }
 
-  // Fists are always available; everything else only while it's in your hands.
+  // Fists are always available; everything else only while it's in your hands. Order
+  // = key order: 0 bread, 1 fists, 2-8 the guns.
   private List <SelectedWeapon> SelectableSlots()
   {
-    var slots = new List <SelectedWeapon> { SelectedWeapon.Fists };
+    // Bread leads the wheel (issue #223): it sits on key 0, just left of fists, so one
+    // notch back from fists is the loaf & the wrap from the last gun lands on it too.
+    var slots = new List <SelectedWeapon>();
+    if (HasBread) slots.Add (SelectedWeapon.Bread);
+    slots.Add (SelectedWeapon.Fists);
     if (HasLaser) slots.Add (SelectedWeapon.Laser);
     if (HasBanana) slots.Add (SelectedWeapon.Banana);
     if (HasBoomerang) slots.Add (SelectedWeapon.Boomerang);
     if (HasSlingshot) slots.Add (SelectedWeapon.Slingshot);
     if (HasPaperAirplane) slots.Add (SelectedWeapon.PaperAirplane);
-    if (HasBlowgun) slots.Add (SelectedWeapon.Blowgun); // Slot 8 rides with the guns (issue #194)...
-    if (HasBread) slots.Add (SelectedWeapon.Bread); // ...& the loaf stays the last stop on the wheel.
+    if (HasBlowgun) slots.Add (SelectedWeapon.Blowgun); // Slot 8 rides with the guns (issue #194).
     return slots;
   }
 
@@ -354,7 +358,7 @@ public partial class Player
     ApplyOverlayMaterials (_boomerangHeld);
     ApplyOverlayMaterials (_slingshotHeld); // Slot 5 (issue #99).
     ApplyOverlayMaterials (_airplaneHeld); // Slot 6 (issue #102).
-    ApplyOverlayMaterials (_breadHeld); // Slot 7 (issue #209).
+    ApplyOverlayMaterials (_breadHeld); // Key 0 / B (issues #209 & #223).
     ApplyOverlayMaterials (_blowgunHeld); // Slot 8 (issue #194).
   }
 

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -16,7 +16,7 @@ Current as of v0.8.15.
 
 ## Weapons
 
-Slot keys select what's in your hands. You spawn with fists **and bread** (B is a second key for bread - it is too important to fumble for); every gun is picked up in the arena (picking one up auto-equips it - bread is the one exception, so a loaf never swaps a weapon out of your hands mid-fight). Every slot uses the same primary button: left click acts with whatever slot is selected; right click scopes the blowgun (slot 8) & does nothing elsewhere.
+Slot keys select what's in your hands. You spawn with fists **and bread** (bread lives on 0 - or B - just left of fists, so one notch back on the wheel is always the loaf); every gun is picked up in the arena (picking one up auto-equips it - bread is the one exception, so a loaf never swaps a weapon out of your hands mid-fight). Every slot uses the same primary button: left click acts with whatever slot is selected; right click scopes the blowgun (slot 8) & does nothing elsewhere.
 
 | Key | Weapon | How it works |
 |---|---|---|
@@ -26,7 +26,7 @@ Slot keys select what's in your hands. You spawn with fists **and bread** (B is 
 | 4 | Boomerang | Left-click to throw. Curves out & returns; steals weapons from anyone it clips & scoops pickups it passes; auto-catches on return |
 | 5 | Slingshot | Hold left-click to draw, release to fling a stone. Longer draw = faster, flatter, harder (never a one-hit). A quick tap just relaxes the band - stones need a minimum draw, & a short cooldown separates shots. **Universal ammo**: see below |
 | 6 | Paper airplane | Left-click to throw. Locks onto whoever's under your crosshair & glides slowly after them; punch an incoming one (fists out) to catch it & throw it back. Only one exists in the whole game, & it is a personal hazard - see below |
-| 7 or B | Bread | Left-click to eat: a 3-second rooted ritual that heals you to full. One loaf per life - see below |
+| 0 or B | Bread | Left-click to eat: a 3-second rooted ritual that heals you to full. One loaf per life - see below |
 | 8 | Blowgun | The stealth weapon - with a scope, because of course it has a scope. Left-click puffs a poison dart, right-click (hold) zooms. The shot is nearly silent: only players within a few feet of you hear it, & everyone else only hears a dart that flies close by them. Darts do no impact damage - they stick in & poison: every 5 seconds the victim loses 10% health PER embedded dart, & their health bar turns green. Bread heals as normal but does NOT remove darts. On a zap-out the darts fall beside the body for 5 seconds - slingshot players can load one as ammo (a slung dart poisons identically) |
 
 ### Slingshot universal ammo
@@ -41,7 +41,7 @@ With the slingshot **out and empty**, walking onto any world item **loads it** i
 
 ### Eating bread
 
-Bread is slot 7 and you spawn carrying one loaf per life. **Left-click with it out to eat**, and then commit:
+Bread is on key 0 (or B) and you spawn carrying one loaf per life. **Left-click with it out to eat**, and then commit:
 
 - It takes **3 seconds**, drained on a reverse meter in the middle of your screen.
 - You must be **standing still** to start. Eating while walking, sliding, or in mid-air is refused with an error cue and a line above the meter. You *can* equip the loaf mid-slide or mid-jump - the ritual just waits until the slide ends and you land and stop.

--- a/project.godot
+++ b/project.godot
@@ -109,9 +109,9 @@ weapon_6={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":54,"key_label":0,"unicode":54,"location":0,"echo":false,"script":null)
 ]
 }
-weapon_7={
+weapon_0={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":55,"location":0,"echo":false,"script":null), Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":48,"key_label":0,"unicode":48,"location":0,"echo":false,"script":null), Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"location":0,"echo":false,"script":null)
 ]
 }
 weapon_8={

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -776,9 +776,9 @@ public partial class PlaytestDriver : Node
 
   private async Task SelectBreadSlot()
   {
-    PressAction ("weapon_7");
+    PressAction ("weapon_0");
     await Task.Delay (100);
-    ReleaseAction ("weapon_7");
+    ReleaseAction ("weapon_0");
     Assert (Self.SelectedWeapon == SelectedWeapon.Bread, "bread is selectable in its own slot (#209)");
   }
 

--- a/tests/unit/WeaponCycleTest.cs
+++ b/tests/unit/WeaponCycleTest.cs
@@ -12,26 +12,27 @@ namespace com.forerunnergames.energyshot;
 [TestSuite]
 public class WeaponCycleTest
 {
-  // Laser & bread held, banana/boomerang/slingshot/airplane slots empty.
+  // Bread & laser held (key order: 0 bread, 1 fists, 2 laser); the other slots empty.
   private static List <SelectedWeapon> Carried() =>
-    new() { SelectedWeapon.Fists, SelectedWeapon.Laser, SelectedWeapon.Bread };
+    new() { SelectedWeapon.Bread, SelectedWeapon.Fists, SelectedWeapon.Laser };
 
   [TestCase]
   public void ForwardStepsInSlotOrderSkippingEmptySlots()
   {
-    // Laser -> Bread skips the four empty slots between them.
+    // Laser -> Bread wraps past the six empty gun slots (issue #223: the loaf leads the wheel).
     AssertObject (Player.NextCycleSlot (Carried(), SelectedWeapon.Laser, 1)).IsEqual (SelectedWeapon.Bread);
   }
 
   [TestCase]
-  public void ForwardWrapsFromLastSlotToFists()
+  public void ForwardFromBreadLandsOnFists()
   {
     AssertObject (Player.NextCycleSlot (Carried(), SelectedWeapon.Bread, 1)).IsEqual (SelectedWeapon.Fists);
   }
 
   [TestCase]
-  public void ReverseWrapsFromFistsToLastSlot()
+  public void ReverseFromFistsLandsOnBread()
   {
+    // One notch back from fists is the loaf (issue #223).
     AssertObject (Player.NextCycleSlot (Carried(), SelectedWeapon.Fists, -1)).IsEqual (SelectedWeapon.Bread);
   }
 
@@ -47,13 +48,13 @@ public class WeaponCycleTest
   {
     var all = new List <SelectedWeapon>
     {
-      SelectedWeapon.Fists, SelectedWeapon.Laser, SelectedWeapon.Banana, SelectedWeapon.Boomerang,
-      SelectedWeapon.Slingshot, SelectedWeapon.PaperAirplane, SelectedWeapon.Blowgun, SelectedWeapon.Bread
+      SelectedWeapon.Bread, SelectedWeapon.Fists, SelectedWeapon.Laser, SelectedWeapon.Banana, SelectedWeapon.Boomerang,
+      SelectedWeapon.Slingshot, SelectedWeapon.PaperAirplane, SelectedWeapon.Blowgun
     };
-    var current = SelectedWeapon.Fists;
+    var current = SelectedWeapon.Bread;
     var visited = new List <SelectedWeapon>();
     for (var i = 0; i < all.Count; ++i) { current = Player.NextCycleSlot (all, current, 1); visited.Add (current); }
-    AssertObject (current).IsEqual (SelectedWeapon.Fists); // Full lap wraps home.
+    AssertObject (current).IsEqual (SelectedWeapon.Bread); // Full lap wraps home.
     AssertInt (visited.Count).IsEqual (8); // Blowgun joined the wheel (issue #194).
   }
 }


### PR DESCRIPTION
Aaron's follow-up to #223 / #225: **bread on 0**, B kept as the second key, and the **cycle order now matches the number row** — 0 bread, 1 fists, 2–8 the guns — so one notch back from fists is always the loaf and the wrap from the last gun lands on it too.

- `weapon_7` action renamed `weapon_0` (keys 0 & B); `SelectableSlots` puts bread first.
- `NextCycleSlot`'s fallback for a slot that just left your hands is now explicitly fists (it used to be "first in list", which would have become bread).
- `WeaponCycleTest` re-pinned for the new order; playtest driver & `docs/CONTROLS.md` follow.

Verification is CI's job: this box can't build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso