### PR TITLE
Drop items on purpose: X tosses what's in your hands out the way you're looking

### DIFF
--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -295,7 +295,7 @@ public partial class Player
     var type = PickEquippedStealable();
     if (type == HeldWeapon.None) return;
     // Request BEFORE clearing, same as DropHeldWeapon (CodeRabbit on #145).
-    Spawner.SendDropTossRequest (GlobalPosition, type, -_camera.GlobalTransform.Basis.Z);
+    Spawner.SendDropTossRequest (type, -_camera.GlobalTransform.Basis.Z);
     if (type == HeldWeapon.Bread) SetBreadHeld (isHeld: false);
     else HeldWeapon &= ~type;
     ForgetTheft (type);

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -284,6 +284,25 @@ public partial class Player
     GD.Print ($"{DisplayName}: That punch took my {type}!");
   }
 
+  // Drop what's in your hands on purpose (issue #242), Minecraft-style: X tosses the
+  // equipped item out the way you're looking, as a normal expiring pickup anyone can
+  // grab. Fists have nothing to drop; an out-flying boomerang or airplane isn't in hand.
+  private bool WantsToDrop() => _isInputEnabled && !Fallen && !Eating && Input.IsActionJustPressed ("drop");
+
+  private void UpdateDrop()
+  {
+    if (!WantsToDrop()) return;
+    var type = PickEquippedStealable();
+    if (type == HeldWeapon.None) return;
+    // Request BEFORE clearing, same as DropHeldWeapon (CodeRabbit on #145).
+    Spawner.SendDropTossRequest (GlobalPosition, type, -_camera.GlobalTransform.Basis.Z);
+    if (type == HeldWeapon.Bread) SetBreadHeld (isHeld: false);
+    else HeldWeapon &= ~type;
+    ForgetTheft (type);
+    DeselectUnheldWeapon();
+    GD.Print ($"{DisplayName}: I dropped my {type}.");
+  }
+
   // The thing actually in hand: slot -> flag, equipped bread included (issue #192).
   // A boomerang or airplane out flying isn't in the hand (issues #98 & #102), & fists
   // are nothing to steal.

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -443,6 +443,7 @@ public partial class Player : CharacterBody3D
     UpdateXrayReveal();
     UpdateViewToggle(); // Third-person toggle on V (issue #119).
     UpdateWeaponSelection();
+    UpdateDrop(); // X drops what's in your hands (issue #242).
     CancelStaleLaserCharge(); // Leaving the laser slot cancels the charge (issue #156).
     UpdateBananaLauncher();
     UpdateBoomerang();

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -821,17 +821,48 @@ public partial class WeaponSpawner : Node3D
   // origin so every peer plays the same arc, & fresh punched-loose drops use a longer
   // claim delay so the victim can't stand still & instantly re-grab what just left.
   private void SpawnPunchedLoose (HeldWeapon type, Vector3 from, Player? puncher, string previousOwner)
+    => SpawnTossed (type, from, puncher == null ? RandomHorizontal() : Horizontal (from - puncher.GlobalPosition), previousOwner);
+
+  // Any item leaving a player's hands on the fly (punched loose, #193; dropped on
+  // purpose, #242) lands 1.5-2.5m along 'away', ray-grounded, with the fly-out arc.
+  private void SpawnTossed (HeldWeapon type, Vector3 from, Vector3 away, string previousOwner)
   {
-    var away = puncher == null ? RandomHorizontal() : Horizontal (from - puncher.GlobalPosition);
     var target = from + away * (float)GD.RandRange (1.5, 2.5);
 
     if (!TryFindGround (target, out var spot))
     {
-      ServerLog.Event ($"punched-loose skip: no ground beneath {target}; [{type}] returns via the caps");
+      ServerLog.Event ($"toss skip: no ground beneath {target}; [{type}] returns via the caps");
       return;
     }
 
     Spawn (type, spot, expires: true, previousOwner, armed: false, tossFrom: from + Vector3.Up * 1.2f);
+  }
+
+  // Dropping on purpose (issue #242): Minecraft-style, the item in your hands flies
+  // out the way you're looking. Client -> server entry point, then the same
+  // validated single-flag path the punch theft uses.
+  public void SendDropTossRequest (Vector3 position, HeldWeapon dropped, Vector3 direction)
+  {
+    if (Multiplayer.IsServer()) { RequestDropToss (position, (int)dropped, direction); return; }
+    RpcId (1, MethodName.RequestDropToss, position, (int)dropped, direction);
+  }
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestDropToss (Vector3 position, int type, Vector3 direction)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var dropperId = SenderOrSelf();
+    var dropper = Players().FirstOrDefault (player => player.NetworkId == dropperId);
+    var dropped = FirstStealableFlag ((HeldWeapon)type & (dropper?.HeldOrRecentlyHeld ?? HeldWeapon.None));
+
+    if (dropped == HeldWeapon.None)
+    {
+      ServerLog.Event (dropperId, $"drop toss deny: mask [{(HeldWeapon)type}] not held by sender");
+      return;
+    }
+
+    ServerLog.Event (dropperId, $"drop toss: {dropped} thrown down by [{dropper!.DisplayName}]");
+    SpawnTossed (dropped, position, Horizontal (direction), dropper.DisplayName);
   }
 
   private static Vector3 Horizontal (Vector3 direction)

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -841,14 +841,16 @@ public partial class WeaponSpawner : Node3D
   // Dropping on purpose (issue #242): Minecraft-style, the item in your hands flies
   // out the way you're looking. Client -> server entry point, then the same
   // validated single-flag path the punch theft uses.
-  public void SendDropTossRequest (Vector3 position, HeldWeapon dropped, Vector3 direction)
+  public void SendDropTossRequest (HeldWeapon dropped, Vector3 direction)
   {
-    if (Multiplayer.IsServer()) { RequestDropToss (position, (int)dropped, direction); return; }
-    RpcId (1, MethodName.RequestDropToss, position, (int)dropped, direction);
+    if (Multiplayer.IsServer()) { RequestDropToss ((int)dropped, direction); return; }
+    RpcId (1, MethodName.RequestDropToss, (int)dropped, direction);
   }
 
+  // The toss starts from the server's own view of where the dropper stands (CodeRabbit
+  // on #243) - a client supplies only what it wants to drop & which way it's looking.
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void RequestDropToss (Vector3 position, int type, Vector3 direction)
+  private void RequestDropToss (int type, Vector3 direction)
   {
     if (!Multiplayer.IsServer()) return;
     var dropperId = SenderOrSelf();
@@ -862,7 +864,7 @@ public partial class WeaponSpawner : Node3D
     }
 
     ServerLog.Event (dropperId, $"drop toss: {dropped} thrown down by [{dropper!.DisplayName}]");
-    SpawnTossed (dropped, position, Horizontal (direction), dropper.DisplayName);
+    SpawnTossed (dropped, dropper.GlobalPosition, Horizontal (direction), dropper.DisplayName);
   }
 
   private static Vector3 Horizontal (Vector3 direction)

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -63,7 +63,7 @@ Bread is on key 0 (or B) and you spawn carrying one loaf per life. **Left-click 
 | Input | Action |
 |---|---|
 | Tab | Toggle message history (PageUp / PageDown to scroll; it never blocks your aim). Chat lines are archived here too, in the sender's color |
-| X | Drop what's in your hands (Minecraft-style): the item flies out the way you're looking and lands as a pickup anyone can grab. Fists have nothing to drop |
+| X | Drop what's in your hands (Minecraft-style): the item flies out the way you're looking and lands as a pickup anyone can grab. Fists have nothing to drop, and a boomerang or airplane that's out flying isn't in your hands to drop |
 | T | Open the chat line (bottom-left). Enter sends, Esc cancels; your character holds still while you type & the mouse stays captured. Lines show for ~9 s in the sender's color, max 120 characters, 2 per second |
 | . (period) | Thumbs-up the current music track |
 | , (comma) | Thumbs-down (enough downvotes skips the track) |

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -63,6 +63,7 @@ Bread is on key 0 (or B) and you spawn carrying one loaf per life. **Left-click 
 | Input | Action |
 |---|---|
 | Tab | Toggle message history (PageUp / PageDown to scroll; it never blocks your aim). Chat lines are archived here too, in the sender's color |
+| X | Drop what's in your hands (Minecraft-style): the item flies out the way you're looking and lands as a pickup anyone can grab. Fists have nothing to drop |
 | T | Open the chat line (bottom-left). Enter sends, Esc cancels; your character holds still while you type & the mouse stays captured. Lines show for ~9 s in the sender's color, max 120 characters, 2 per second |
 | . (period) | Thumbs-up the current music track |
 | , (comma) | Thumbs-down (enough downvotes skips the track) |

--- a/project.godot
+++ b/project.godot
@@ -171,6 +171,11 @@ chat={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":84,"key_label":0,"unicode":116,"location":0,"echo":false,"script":null)
 ]
 }
+drop={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":88,"key_label":0,"unicode":120,"location":0,"echo":false,"script":null)
+]
+}
 music_vote_up={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":46,"key_label":0,"unicode":46,"location":0,"echo":false,"script":null)


### PR DESCRIPTION
Implements #242 (Aaron: ship now; groundwork for hats #241).

- **X** drops the equipped item — a gun or the loaf — which flies out along your look direction & lands 1.5–2.5 m ahead as a normal expiring pickup anyone can grab. Fists have nothing to drop; an out-flying boomerang/airplane isn't in hand.
- Reuses the punch-theft fly-out: `SpawnPunchedLoose` is now a one-liner over a direction-agnostic `SpawnTossed`; the new `RequestDropToss` RPC validates exactly like the theft (single flag vs `HeldOrRecentlyHeld`, request before the local clear).
- Key choice: X (free, next to WASD) — say the word for another.

Verification is CI's job: this box can't build. Docs updated (controls table).

Closes #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Press **X** to drop the currently held stealable weapon in the direction you’re aiming.
  - Dropped weapons become pickups available to all players.
  - Fists and weapons already in motion cannot be dropped.
  - Dropping is unavailable while fallen or eating.
- **Documentation**
  - Updated the controls guide with the new drop action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->