### PR TITLE
Blowgun rework: a silenced sniper you look through, with a dart economy

### DIFF
--- a/core/players/Player.Blowgun.cs
+++ b/core/players/Player.Blowgun.cs
@@ -4,37 +4,68 @@ using Godot;
 
 namespace com.forerunnergames.energyshot.players;
 
-// The blowgun (issue #194): the game's stealth weapon, funny because it has a SCOPE.
-// Slot 8. Left click puffs a poison dart (no impact damage - the poison ticks are the
-// weapon, see Player.Poison.cs); right click scopes. Stealth audio: the muzzle pfft
-// is audible only within a few feet of the shooter, & everyone else only ever hears
-// the dart's own short-range whoosh as it passes them (BlowgunDart).
+// The blowgun (issues #194 & #236): the game's silenced sniper rifle, funny because a
+// blowgun has a scope. Slot 8. Right click looks THROUGH the scope (the HUD draws the
+// scope view); the wheel steps the zoom in & out, very far; the reticle drifts more
+// the further in you are & only settles for about a second between heartbeats - you
+// time the shot. Left click puffs a poison dart toward the reticle (no impact damage,
+// the poison is the weapon). Ammo: the gun starts EMPTY & fires from a replicated
+// dart count refilled by walking over darts while holding it (the dart economy). No
+// recoil. The shooter hears the shot locally; bystanders only within a few feet.
 public partial class Player
 {
-  [Export] public float BlowgunDartSpeed = 38.0f;
-  [Export] public float BlowgunCooldownSeconds = 1.1f;
-  [Export] public float ScopeFovDegrees = 30.0f;
+  [Export] public float BlowgunDartSpeed = 42.0f;
+  [Export] public float BlowgunCooldownSeconds = 1.5f;
+  [Export]
+  public int BlowgunDarts
+  {
+    get => _blowgunDarts;
+    set
+    {
+      if (_blowgunDarts != value) LogReplicatedChangeOnServer ($"blowgun darts: {DisplayName} {_blowgunDarts} -> {value}");
+      _blowgunDarts = value;
+    }
+  }
+
+  private int _blowgunDarts;
   private Node3D _blowgunHeld = null!;
   private AudioStreamPlayer3D _blowgunShotSound = null!;
+  private AudioStreamPlayer _blowgunOwnShotSound = null!;
+  private AudioStreamPlayer _heartbeatSound = null!;
+  private AudioStreamPlayer _emptyClickSound = null!;
   private float _blowgunCooldownLeft;
   private float _unscopedFovDegrees;
   private bool _isScoped;
+  private int _zoomStep;
+  private float _scopeTime;
+  private float _sinceBeat;
 
   public bool HasBlowgun => Holds (HeldWeapon.Blowgun);
   public bool IsBlowgunSelected => SelectedWeapon == SelectedWeapon.Blowgun;
+  public bool IsScoped => _isScoped;
+  public int ZoomStep => _zoomStep;
+  public bool IsScopeSettled => _isScoped && Scope.IsSettled (_sinceBeat);
+  // The reticle's offset from screen center as a fraction of the scope radius (HUD
+  // draws it there; the dart flies toward it).
+  public Vector2 ReticleDrift => _isScoped ? Scope.Wander (_scopeTime) * Scope.DriftFraction (_zoomStep) * Scope.BeatEnvelope (_sinceBeat) : Vector2.Zero;
 
   private void CreateBlowgunHeld()
   {
     _blowgunHeld = BlowgunDart.CreateBlowgunVisual();
     _blowgunHeld.Position = new Vector3 (0.32f, -0.22f, -0.55f);
-    // Fetched directly: the held-model creators run before _Ready assigns _camera.
-    var camera = GetNode <Camera3D> ("Camera3D");
+    var camera = GetNode <Camera3D> ("Camera3D"); // Fetched directly: held-model creators run before _Ready assigns _camera.
     camera.AddChild (_blowgunHeld);
-    _unscopedFovDegrees = camera.Fov; // Whatever the project default is - never hardcode it twice.
-    // The muzzle pfft (issue #194): tiny UnitSize + hard MaxDistance cutoff = the
-    // shooter & anyone within a few feet hear it; beyond that, silence.
+    _unscopedFovDegrees = camera.Fov;
+    // Bystanders hear the puff only within a few feet (the stealth rule, issue #194)...
     _blowgunShotSound = new AudioStreamPlayer3D { Stream = ProceduralSounds.DartPfft(), UnitSize = 1.2f, MaxDistance = 3.0f, MaxPolyphony = 3 };
     AddChild (_blowgunShotSound);
+    // ...while the shooter always hears their own shot, locally (issue #236).
+    _blowgunOwnShotSound = new AudioStreamPlayer { Stream = ProceduralSounds.DartPfft(), MaxPolyphony = 3 };
+    AddChild (_blowgunOwnShotSound);
+    _heartbeatSound = new AudioStreamPlayer { Stream = ProceduralSounds.Heartbeat(), VolumeDb = -4.0f };
+    AddChild (_heartbeatSound);
+    _emptyClickSound = new AudioStreamPlayer { Stream = ProceduralSounds.Denied(), VolumeDb = -6.0f };
+    AddChild (_emptyClickSound);
   }
 
   // Gated like every action predicate: input, stance, stun, & ritual states all block.
@@ -43,35 +74,74 @@ public partial class Player
   private void UpdateBlowgun (double delta)
   {
     _blowgunCooldownLeft = Mathf.Max (0.0f, _blowgunCooldownLeft - (float)delta);
-    UpdateScope();
+    UpdateScope ((float)delta);
     if (!CanFireBlowgun() || !Input.IsActionJustPressed ("shoot")) return;
+    if (BlowgunDarts <= 0) { _emptyClickSound.Play(); return; } // Empty: a denied click, no shot (issue #236).
     FireBlowgunDart();
   }
 
-  // Scope zoom on right click (issue #194; the button is free since #164 moved punch
-  // to left click). Local camera state only - nothing about scoping replicates.
-  private void UpdateScope()
+  // Scoping (issue #236): right click toggles the through-the-scope view; the wheel
+  // steps zoom while scoped (weapon cycling is suspended then, see UpdateWeaponSelection).
+  // Scoping forces first person - you can't look through a scope from behind yourself.
+  private void UpdateScope (float dt)
   {
-    var wantScope = _isInputEnabled && !Fallen && IsBlowgunSelected && HasBlowgun && Input.IsActionPressed ("scope");
-    if (wantScope == _isScoped) return;
-    _isScoped = wantScope;
-    _camera.Fov = wantScope ? ScopeFovDegrees : _unscopedFovDegrees;
+    var canScope = _isInputEnabled && !Fallen && IsBlowgunSelected && HasBlowgun;
+    if (!canScope && _isScoped) SetScoped (false);
+    if (canScope && Input.IsActionJustPressed ("scope")) SetScoped (!_isScoped);
+    if (!_isScoped) return;
+    _scopeTime += dt;
+    _sinceBeat += dt;
+    if (_sinceBeat >= Scope.BeatPeriodSeconds) { _sinceBeat = 0.0f; _heartbeatSound.Play(); }
+    if (Input.IsActionJustPressed ("cycle_weapon_next")) SetZoomStep (Scope.StepIn (_zoomStep));
+    if (Input.IsActionJustPressed ("cycle_weapon_previous")) SetZoomStep (Scope.StepOut (_zoomStep));
+  }
+
+  private void SetScoped (bool scoped)
+  {
+    _isScoped = scoped;
+    if (scoped && IsThirdPerson) SetThirdPerson (false);
+    _sinceBeat = 0.0f;
+    if (scoped) _heartbeatSound.Play();
+    SetZoomStep (scoped ? 0 : _zoomStep);
+    if (!scoped) _camera.Fov = _unscopedFovDegrees;
+    _blowgunHeld.Visible = !scoped && IsBlowgunSelected && HasBlowgun; // The gun is at your eye, not in view.
+    GetNode <Node3D> ("Camera3D/Crosshairs").Visible = !scoped; // The scope's reticle replaces the crosshair.
+  }
+
+  private void SetZoomStep (int step)
+  {
+    _zoomStep = step;
+    if (_isScoped) _camera.Fov = Scope.ZoomFovs[_zoomStep];
   }
 
   private void FireBlowgunDart()
   {
     _blowgunCooldownLeft = BlowgunCooldownSeconds;
     CancelSpawnArmorIfFired(); // Firing anything drops your spawn armor (issue #48).
+    BlowgunDarts -= 1;
+    Spawner.SendDartFiredRequest(); // The census counts it as in flight (issue #236).
     _blowgunShotSound.Play();
-    var direction = -_camera.GlobalTransform.Basis.Z;
+    _blowgunOwnShotSound.Play();
+    var direction = AimDirection();
     var sweepStart = _camera.GlobalPosition;
     var origin = sweepStart + direction * MuzzleOffsetMeters;
     SpawnDart (origin, sweepStart, direction, isLive: true);
     Rpc (MethodName.SpawnVisualDart, origin, sweepStart, direction);
   }
 
-  // Every peer flies a cosmetic copy, like SpawnVisualLaser & the visual stone: the
-  // whoosh has to pass NEAR each listener locally for the stealth audio to work.
+  // Where the reticle points, drift included: the scope view's offset is turned back
+  // into a world ray through the camera, so what you see wander is what you hit.
+  private Vector3 AimDirection()
+  {
+    if (!_isScoped) return -_camera.GlobalTransform.Basis.Z;
+    var viewport = GetViewport().GetVisibleRect().Size;
+    var radius = Mathf.Min (viewport.X, viewport.Y) * ScopeView.RadiusFraction; // The HUD's scope radius.
+    var screenPoint = viewport / 2.0f + ReticleDrift * radius;
+    return _camera.ProjectRayNormal (screenPoint);
+  }
+
+  // Every peer flies a cosmetic copy (the SpawnVisualLaser pattern): the whoosh has
+  // to pass NEAR each listener locally for the stealth audio to work.
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
   private void SpawnVisualDart (Vector3 origin, Vector3 sweepStart, Vector3 direction) => SpawnDart (origin, sweepStart, direction, isLive: false);
 
@@ -80,14 +150,38 @@ public partial class Player
     var dart = new BlowgunDart();
     GetParent().AddChild (dart);
     dart.Launch (origin, sweepStart, direction, BlowgunDartSpeed, isLive, this);
-    if (isLive) dart.HitPlayer += OnDartHitPlayer;
+    if (!isLive) return;
+    dart.HitPlayer += OnDartHitPlayer;
+    dart.Landed += position => Spawner.SendDartLandRequest (position); // A miss becomes a ground dart (issue #248).
   }
 
   // Victim-authoritative like every damage path: the shooter only reports the hit.
   private void OnDartHitPlayer (Player victim)
   {
-    _hitmarkerSound.Play();
+    PlayHitmarker (false);
     if (victim.NetworkId == Multiplayer.GetUniqueId()) return; // Can't dart yourself.
     victim.RpcId (victim.NetworkId, MethodName.ReceiveDartHit, DisplayName);
+  }
+
+  // Losing the blowgun (drop, theft, death) returns its darts to the level's census:
+  // the caps respawn them as floating pickups. Called from the HeldWeapon setter path.
+  private void SpillBlowgunDarts()
+  {
+    if (!IsMultiplayerAuthority()) return;
+    BlowgunDarts = 0;
+    if (_isScoped) SetScoped (false);
+  }
+
+  // The server confirmed a walk-over pickup of a ground dart while holding the blowgun.
+  // The host's own player gets the direct call (an RpcId to yourself is a no-op).
+  public void ConfirmDartAmmoSelf() => ConfirmDartAmmo();
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ConfirmDartAmmo()
+  {
+    if (Multiplayer.GetRemoteSenderId() != 1 && Multiplayer.GetRemoteSenderId() != 0) return;
+    if (!IsMultiplayerAuthority()) return;
+    ++BlowgunDarts;
+    _weaponPickupSound.Play();
   }
 }

--- a/core/players/Player.Poison.cs
+++ b/core/players/Player.Poison.cs
@@ -42,15 +42,30 @@ public partial class Player
   // A dart found us (issue #194). The impact itself does no damage - it plants the
   // next tick's problem. Runs only on the victim's own authority.
   [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
-  private void ReceiveDartHit (string shotByPlayerName)
+  private void ReceiveDartHit (string shotByPlayerName) => EmbedDart (Multiplayer.GetRemoteSenderId(), shotByPlayerName);
+
+  // Stepping on a landed (armed) dart without the blowgun (issues #236 & #248): the
+  // server despawned it & tells us to take it as if it hit us - ownerless, like a
+  // landmine, so nobody scores the eventual zap-out.
+  public void ConfirmDartStepSelf() => ConfirmDartStep(); // The host's own player (an RpcId to yourself is a no-op).
+
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void ConfirmDartStep()
+  {
+    var sender = Multiplayer.GetRemoteSenderId();
+    if (sender != 1 && sender != 0) return;
+    EmbedDart (0, "a dart on the ground");
+  }
+
+  private void EmbedDart (int attackerId, string attackerName)
   {
     if (!IsMultiplayerAuthority()) return;
     if (SpawnArmor) return; // Armor shrugs darts off like everything else (issue #48).
     if (Fallen) return; // A body mid-death-sequence is scenery (issue #152).
-    _dartOwners.Add ((Multiplayer.GetRemoteSenderId(), shotByPlayerName));
+    _dartOwners.Add ((attackerId, attackerName));
     PoisonDarts = _dartOwners.Count;
     _damageSound.Play(); // The sting is the victim's only impact feedback.
-    GD.Print ($"{DisplayName}: {shotByPlayerName}'s dart stuck in me! ({PoisonDarts} embedded)");
+    GD.Print ($"{DisplayName}: {attackerName}'s dart stuck in me! ({PoisonDarts} embedded)");
     StartPoisonTicksIfIdle();
   }
 
@@ -83,8 +98,8 @@ public partial class Player
     }
   }
 
-  // Death shakes the darts out (issue #194): they fall beside the body as 5s-expiry
-  // pickups a slingshot can load. Request BEFORE clearing (the #145 convention): the
+  // Death shakes the darts out (issues #194 & #236): they fall beside the body as
+  // ARMED ground darts - hazards to step on, ammo to anyone holding the blowgun. Request BEFORE clearing (the #145 convention): the
   // server validates the count against this player's replicated PoisonDarts.
   private void ScatterEmbeddedDarts()
   {

--- a/core/players/Player.Weapons.cs
+++ b/core/players/Player.Weapons.cs
@@ -55,6 +55,7 @@ public partial class Player
     // depend on it. So does bread (issue #190): the death drop clears the loaf right
     // after sending the drop RPC, so without the grace the server denies it.
     foreach (var flag in new[] { HeldWeapon.Laser, HeldWeapon.Banana, HeldWeapon.Boomerang, HeldWeapon.Slingshot, HeldWeapon.PaperAirplane, HeldWeapon.Bread, HeldWeapon.Blowgun }) { if ((removed & flag) != 0) _recentlyHeldUntilMs[flag] = until; }
+    if ((removed & HeldWeapon.Blowgun) != 0) SpillBlowgunDarts(); // Its darts go back to the level's census (issue #236).
   }
 
   // Which slot is out (issue #82). Replicated so every peer renders the right model
@@ -145,7 +146,7 @@ public partial class Player
     _boomerangHeld.Visible = IsBoomerangSelected && HasBoomerang && !IsBoomerangOut; // Empty hand while it's out flying (issue #98).
     _slingshotHeld.Visible = IsSlingshotSelected && HasSlingshot; // Slot 5 (issue #99).
     _airplaneHeld.Visible = IsPaperAirplaneSelected && HasPaperAirplane && !IsAirplaneOut; // Slot 6, empty hand mid-glide (issue #102).
-    _blowgunHeld.Visible = IsBlowgunSelected && HasBlowgun; // Slot 8 (issue #194).
+    _blowgunHeld.Visible = IsBlowgunSelected && HasBlowgun && !IsScoped; // Slot 8 (issue #194); at your eye while scoped (issue #236).
     UpdateHandsVisibility(); // Hands render only while fists are selected (issue #82).
   }
 
@@ -165,6 +166,7 @@ public partial class Player
     if (Input.IsActionJustPressed ("weapon_8") && HasBlowgun) SelectedWeapon = SelectedWeapon.Blowgun; // Slot 8 (issue #194).
     // Cycling (issue #186): mouse wheel for mouse players, Q & E for trackpads -
     // reaching for 7 mid-fight to eat is not a real option.
+    if (IsScoped) return; // While scoped the wheel is the zoom (issue #236), not the weapon cycle.
     if (Input.IsActionJustPressed ("cycle_weapon_next")) CycleSelectedWeapon (1);
     if (Input.IsActionJustPressed ("cycle_weapon_previous")) CycleSelectedWeapon (-1);
   }

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -138,6 +138,9 @@ properties/26/replication_mode = 2
 properties/27/path = NodePath(".:Assists")
 properties/27/spawn = true
 properties/27/replication_mode = 2
+properties/28/path = NodePath(".:BlowgunDarts")
+properties/28/spawn = true
+properties/28/replication_mode = 2
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 2

--- a/core/weapons/BlowgunDart.cs
+++ b/core/weapons/BlowgunDart.cs
@@ -4,19 +4,22 @@ using com.forerunnergames.energyshot.ui.hud;
 
 namespace com.forerunnergames.energyshot.weapons;
 
-// The blowgun's poison dart (issue #194): a small, quiet, swept-ray projectile
-// modeled on LaserBolt. The impact does no damage - the poison ticks do (see
-// Player.Poison.cs). Stealth audio model: the dart carries its own whoosh with a
-// tiny audible radius, so players only hear it when it flies near them; the muzzle
-// pfft lives on the shooter with an even smaller radius (Player.Blowgun.cs).
+// The blowgun's poison dart (issues #194 & #236): a swept-ray projectile that flies
+// fast but VISIBLY - you can watch it cross the arena - with next to no drop, a long
+// lifetime (it's the sniper), & a proper fletched dart body so it never reads as a
+// green ball. The impact does no damage; the poison does (Player.Poison.cs). Stealth
+// audio: the dart carries its own short-range whoosh, audible only to whoever it
+// passes close to. A miss that hits geometry LANDS as an armed ground dart (#248).
 public partial class BlowgunDart : Node3D
 {
   [Signal] public delegate void HitPlayerEventHandler (Player player);
-  private const float MaxLifetimeSeconds = 3.0f;
-  // Gentle arc: a dart is breath-powered, not a laser - the droop reads as funny.
-  private const float DropAcceleration = 6.0f;
-  private static readonly Color DartBody = new(0.35f, 0.25f, 0.15f);
-  private static readonly Color TuftGreen = new(0.4f, 0.8f, 0.3f);
+  [Signal] public delegate void LandedEventHandler (Vector3 position);
+  public const float ShaftLength = 0.7f;
+  private const float MaxLifetimeSeconds = 6.0f;
+  private const float DropAcceleration = 0.3f; // Near-zero: a sniper line, not a lob.
+  private static readonly Color DartBody = new(0.2f, 0.2f, 0.22f);
+  private static readonly Color Tip = new(0.85f, 0.85f, 0.9f);
+  private static readonly Color Fletch = new(1.0f, 0.25f, 0.15f);
   private Vector3 _velocity;
   private Vector3 _sweepStart;
   private bool _sweptFromStart;
@@ -27,16 +30,13 @@ public partial class BlowgunDart : Node3D
   public override void _Ready()
   {
     AddChild (CreateDartVisual());
-    // The fly-by whoosh (issue #194): positional & short-range, so it IS the stealth
-    // model - audible only to whoever the dart passes close to. Looped for the
-    // dart's whole flight, like the boomerang's whoosh (issue #98).
-    var whoosh = new AudioStreamPlayer3D { Stream = ProceduralSounds.DartWhoosh(), UnitSize = 1.5f, MaxDistance = 5.0f, Autoplay = true };
+    // The fly-by whoosh (issue #194): positional & short-range - hearing it means the
+    // dart is near YOU. Looped for the flight, like the boomerang's (issue #98).
+    var whoosh = new AudioStreamPlayer3D { Stream = ProceduralSounds.DartWhoosh(), UnitSize = 2.0f, MaxDistance = 7.0f, Autoplay = true };
     whoosh.Finished += () => whoosh.Play();
     AddChild (whoosh);
   }
 
-  // sweepStart is the shooter's camera position, same reasoning as LaserBolt (issue
-  // #112): the first sweep covers camera->muzzle so point-blank walls can't be skipped.
   public void Launch (Vector3 origin, Vector3 sweepStart, Vector3 direction, float speed, bool isLive, CharacterBody3D shooter)
   {
     GlobalPosition = origin;
@@ -44,6 +44,7 @@ public partial class BlowgunDart : Node3D
     _velocity = direction.Normalized() * speed;
     _isLive = isLive;
     _exclusions = new Godot.Collections.Array <Rid> { shooter.GetRid() };
+    if (shooter is Player own) _exclusions.Add (own.HeadRid);
     Orient();
   }
 
@@ -63,8 +64,8 @@ public partial class BlowgunDart : Node3D
     _velocity.Y -= DropAcceleration * dt;
     var to = GlobalPosition + _velocity * dt;
     var query = PhysicsRayQueryParameters3D.Create (from, to, exclude: _exclusions);
-    // Point-blank darts can start inside the target's collider (issue #52's lesson).
     query.HitFromInside = true;
+    query.CollideWithAreas = true; // Heads are Area3D hitboxes (issue #179) - a dart to the dome still only poisons.
     var hit = GetWorld3D().DirectSpaceState.IntersectRay (query);
 
     if (hit.Count > 0)
@@ -77,12 +78,15 @@ public partial class BlowgunDart : Node3D
     Orient();
   }
 
-  // Players stop the dart & (on the shooter's live copy) get poisoned; geometry just
-  // stops it - a dart in a wall is spent, no pierce, no pickup (only darts embedded
-  // in a player fall out on death & become loadable, issue #194).
+  // A player stops the dart & (on the live copy) gets poisoned; geometry stops it &
+  // (on the live copy) the server is told where it landed, so it becomes an armed
+  // ground dart instead of vanishing (issues #236 & #248).
   private void ResolveHit (Godot.Collections.Dictionary hit)
   {
-    if (_isLive && hit["collider"].AsGodotObject() is CharacterBody3D player && player is Player victim) EmitSignal (SignalName.HitPlayer, victim);
+    var collider = hit["collider"].AsGodotObject();
+    var victim = collider is HeadHitbox head ? head.Player : collider as Player;
+    if (victim != null && _isLive) EmitSignal (SignalName.HitPlayer, victim);
+    if (victim == null && _isLive) EmitSignal (SignalName.Landed, (Vector3)hit["position"] + (Vector3)hit["normal"] * 0.2f);
     QueueFree();
   }
 
@@ -92,19 +96,26 @@ public partial class BlowgunDart : Node3D
     LookAt (GlobalPosition + _velocity, Vector3.Up);
   }
 
-  // Code-built visuals, fresh materials per call so overlay tweaks can't bleed
-  // between held models, pickups, & projectiles (the SlingshotStone convention).
+  // Code-built, fresh materials per call (the SlingshotStone convention).
 
-  // The dart: a thin shaft with a bright tuft so victims can spot their pincushion.
+  // A real dart (issue #236): a long dark shaft along -Z (the flight direction after
+  // LookAt), a bright steel tip in front, & three red fletching fins at the back.
   public static Node3D CreateDartVisual()
   {
     var root = new Node3D();
-    root.AddChild (new MeshInstance3D { Mesh = new CylinderMesh { TopRadius = 0.012f, BottomRadius = 0.012f, Height = 0.28f }, RotationDegrees = new Vector3 (90.0f, 0.0f, 0.0f), MaterialOverride = new StandardMaterial3D { AlbedoColor = DartBody, Roughness = 0.7f } });
-    root.AddChild (new MeshInstance3D { Mesh = new SphereMesh { Radius = 0.03f, Height = 0.06f }, Position = new Vector3 (0.0f, 0.0f, 0.16f), MaterialOverride = new StandardMaterial3D { AlbedoColor = TuftGreen, Roughness = 0.4f } });
+    root.AddChild (new MeshInstance3D { Mesh = new CylinderMesh { TopRadius = 0.022f, BottomRadius = 0.022f, Height = ShaftLength }, RotationDegrees = new Vector3 (90.0f, 0.0f, 0.0f), MaterialOverride = new StandardMaterial3D { AlbedoColor = DartBody, Roughness = 0.6f } });
+    root.AddChild (new MeshInstance3D { Mesh = new CylinderMesh { TopRadius = 0.0f, BottomRadius = 0.03f, Height = 0.12f }, Position = new Vector3 (0.0f, 0.0f, -ShaftLength / 2.0f - 0.06f), RotationDegrees = new Vector3 (-90.0f, 0.0f, 0.0f), MaterialOverride = new StandardMaterial3D { AlbedoColor = Tip, Metallic = 0.8f, Roughness = 0.2f } });
+    for (var i = 0; i < 3; ++i)
+    {
+      var fin = new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.01f, 0.11f, 0.16f) }, Position = new Vector3 (0.0f, 0.055f, ShaftLength / 2.0f - 0.1f), MaterialOverride = new StandardMaterial3D { AlbedoColor = Fletch, Roughness = 0.5f } };
+      var pivot = new Node3D { RotationDegrees = new Vector3 (0.0f, 0.0f, 120.0f * i) };
+      pivot.AddChild (fin);
+      root.AddChild (pivot);
+    }
     return root;
   }
 
-  // The blowgun itself: a long tube - with a scope, which is the whole joke.
+  // The blowgun itself: a long tube with a scope - the whole joke.
   public static Node3D CreateBlowgunVisual()
   {
     var root = new Node3D();

--- a/core/weapons/Scope.cs
+++ b/core/weapons/Scope.cs
@@ -1,0 +1,40 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.weapons;
+
+// The blowgun's scope model (issue #236), pure & unit-tested: a zoom ladder you step
+// with the wheel, & the drift that makes aiming a skill - the reticle wanders with an
+// amplitude that grows with zoom, spiking on each heartbeat & settling for about a
+// second in between. The settled window is the shot window.
+public static class Scope
+{
+  // Camera FOVs per zoom step; the last is "very far".
+  public static readonly float[] ZoomFovs = { 40.0f, 25.0f, 14.0f, 7.0f, 3.5f };
+  public const float BeatPeriodSeconds = 2.0f;
+  // Drift, as a fraction of the scope radius, at the first & last zoom steps.
+  public const float MinDriftFraction = 0.08f;
+  public const float MaxDriftFraction = 0.45f;
+  // The thump spikes the drift; by SettleSeconds it's down to SettledFraction of the
+  // step's amplitude & stays there until the next beat - the window you shoot in.
+  public const float SettleSeconds = 0.9f;
+  public const float SettledFraction = 0.2f;
+
+  public static int StepIn (int step) => Mathf.Min (step + 1, ZoomFovs.Length - 1);
+  public static int StepOut (int step) => Mathf.Max (step - 1, 0);
+
+  // Amplitude for a zoom step, before the heartbeat envelope.
+  public static float DriftFraction (int step) => Mathf.Lerp (MinDriftFraction, MaxDriftFraction, ZoomFovs.Length <= 1 ? 0.0f : (float)step / (ZoomFovs.Length - 1));
+
+  // 1.0 at the beat, easing to SettledFraction by SettleSeconds, flat after.
+  public static float BeatEnvelope (float secondsSinceBeat)
+  {
+    if (secondsSinceBeat >= SettleSeconds) return SettledFraction;
+    var t = secondsSinceBeat / SettleSeconds;
+    return Mathf.Lerp (1.0f, SettledFraction, t * t);
+  }
+
+  public static bool IsSettled (float secondsSinceBeat) => secondsSinceBeat >= SettleSeconds;
+
+  // Smooth wander: two incommensurate sines per axis, so it never looks like a circle.
+  public static Vector2 Wander (float time) => new(Mathf.Sin (time * 1.7f) * 0.6f + Mathf.Sin (time * 2.9f + 1.3f) * 0.4f, Mathf.Sin (time * 1.3f + 0.7f) * 0.6f + Mathf.Sin (time * 3.7f + 2.1f) * 0.4f);
+}

--- a/core/weapons/WeaponPickup.cs
+++ b/core/weapons/WeaponPickup.cs
@@ -136,6 +136,13 @@ public partial class WeaponPickup : Area3D
     // An armed mine LIES on the ground (issue #204): it spawns at the standard
     // pickup hover like every other pickup, which left the airplane bobbing in
     // mid-air instead of sitting where it came down, waiting to be stepped on.
+    if (IsLandedDart)
+    {
+      _visual.Position = Vector3.Down * MineRestDrop;
+      _visual.Rotation = new Vector3 (0.0f, _visual.Rotation.Y, Mathf.DegToRad (90.0f)); // On its side, stuck in the ground.
+      return;
+    }
+
     if (IsArmedMine)
     {
       _visual.Position = Vector3.Down * MineRestDrop;
@@ -195,12 +202,19 @@ public partial class WeaponPickup : Area3D
   {
     if (collector.IsLoadingAmmo) { _spawner.SendAmmoLoadRequest (Name); return; }
     if (IsArmedMine) { _spawner.SendMineTriggerRequest (Name); return; }
+    // Darts (issues #236 & #248): ammo for a blowgun holder; a landed one is a hazard
+    // to anyone else; a floating one is nothing to anyone else (IsEligibleCollector).
+    if (Weapon == HeldWeapon.PoisonDart && collector.HasBlowgun) { _spawner.SendDartAmmoRequest (Name); return; }
+    if (Weapon == HeldWeapon.PoisonDart) { _spawner.SendDartStepRequest (Name); return; }
     _spawner.SendPickupRequest (Name, collector.NetworkId);
   }
 
   // An airplane that came down from flight (issue #191). Anything else - including a
   // fresh spawn-point airplane - is an ordinary pickup you can put in slot 6 (#102).
   private bool IsArmedMine => Weapon == HeldWeapon.PaperAirplane && Armed;
+  // A landed dart lies flat on the ground like a mine (issue #248) - the visual that
+  // says 'hazard', vs. the floating spin that says 'pickup'.
+  private bool IsLandedDart => Weapon == HeldWeapon.PoisonDart && Armed;
   // Pickups spawn a hover height up so they're reachable; a mine drops back to the
   // surface it landed on (issue #204).
   private const float MineRestDrop = 0.85f;
@@ -231,7 +245,10 @@ public partial class WeaponPickup : Area3D
   {
     if (!player.IsMultiplayerAuthority() || player.Fallen) return false;
     if (player.IsLoadingAmmo) return true;
-    if (Weapon == HeldWeapon.PoisonDart) return false; // A fallen dart is ammo, never a hand weapon (issue #194).
+    // Darts (issues #236 & #248): a blowgun holder collects any ground dart as ammo; a
+    // LANDED (armed) dart is a hazard anyone else can step on; a floating one is
+    // nothing to anyone else - you walk through it.
+    if (Weapon == HeldWeapon.PoisonDart) return player.HasBlowgun || (Armed && !player.SpawnArmor);
     if (IsArmedMine) return !player.SpawnArmor && !player.Burning;
     return !player.Holds (Weapon);
   }

--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -26,6 +26,12 @@ public partial class WeaponSpawner : Node3D
   [Export] public int MaxSlingshots = 1;
   [Export] public int MaxPaperAirplanes = 1;
   [Export] public int MaxBlowguns = 1; // The stealth weapon (issue #194).
+  // The dart economy (issue #236): exactly this many darts exist, ever - in blowguns,
+  // embedded in players, nocked in slingshots, flying, or on the ground. The census
+  // below spawns floating pickups until the count is whole again (the void eats some).
+  [Export] public int MaxDarts = 10;
+  private const float DartFlightGraceSeconds = 7.0f; // A fired dart counts until it lands or hits (max lifetime + margin).
+  private readonly List <ulong> _dartFlightsUntilMs = new();
   // Sanity bound on a death's dart scatter (issue #194): more embedded darts than
   // this is already a story, & the pickups expire in 5s anyway.
   private const int MaxScatteredDarts = 8;
@@ -200,7 +206,31 @@ public partial class WeaponSpawner : Node3D
     }
 
     SpawnSpecialsIfMissing (pickups, players, freePoints);
+    SpawnDartsIfMissing (pickups, players); // Issue #236.
     EnsurePlaytestPickups (pickups, players);
+  }
+
+  // ------------------------------------------------ dart census (issue #236)
+
+  private int CountDarts (List <WeaponPickup> pickups, List <Player> players)
+  {
+    _dartFlightsUntilMs.RemoveAll (until => Time.GetTicksMsec() > until);
+    return pickups.Count (pickup => pickup.Weapon == HeldWeapon.PoisonDart) + players.Sum (player => player.BlowgunDarts + player.PoisonDarts) + _ammoEscrow.Count (ammo => ammo.Type == HeldWeapon.PoisonDart) + _dartFlightsUntilMs.Count;
+  }
+
+  // Floating (spawned) darts scatter over the arena floor, not the weapon points: only
+  // a blowgun holder can collect them, so they're ammo to find, not loot to camp.
+  // Not in playtest runs: the harness asserts its pickups by position (CodeRabbit on #180).
+  private void SpawnDartsIfMissing (List <WeaponPickup> pickups, List <Player> players)
+  {
+    if (_isPlaytest) return;
+    var missing = MaxDarts - CountDarts (pickups, players);
+    for (var i = 0; i < missing; ++i)
+    {
+      var target = new Vector3 (_rng.RandfRange (-35.0f, 35.0f), 0.0f, _rng.RandfRange (-35.0f, 35.0f));
+      if (!TryFindGround (target, out var spot)) continue;
+      Spawn (HeldWeapon.PoisonDart, spot, expires: false);
+    }
   }
 
   // The banana, boomerang (issue #98), & slingshot (issue #99) respawn at random free
@@ -520,9 +550,97 @@ public partial class WeaponSpawner : Node3D
     {
       var angle = Mathf.Tau * i / Mathf.Max (1, scattered);
       var target = position + new Vector3 (Mathf.Cos (angle), 0.0f, Mathf.Sin (angle)) * 0.9f;
-      if (!TryFindGround (target, out var spot)) continue; // Over the void: that dart is simply gone.
-      Spawn (HeldWeapon.PoisonDart, spot, expires: true, victim.DisplayName);
+      if (!TryFindGround (target, out var spot)) continue; // Over the void: the census respawns it.
+      Spawn (HeldWeapon.PoisonDart, spot, expires: false, victim.DisplayName, armed: true); // A landed dart is a hazard (issue #248).
     }
+  }
+
+  // Client -> server entry points for the dart economy (issue #236).
+  public void SendDartFiredRequest()
+  {
+    if (Multiplayer.IsServer()) { RequestDartFired(); return; }
+    RpcId (1, MethodName.RequestDartFired);
+  }
+
+  public void SendDartLandRequest (Vector3 position)
+  {
+    if (Multiplayer.IsServer()) { RequestDartLand (position); return; }
+    RpcId (1, MethodName.RequestDartLand, position);
+  }
+
+  public void SendDartAmmoRequest (string pickupName)
+  {
+    if (Multiplayer.IsServer()) { RequestDartAmmo (pickupName); return; }
+    RpcId (1, MethodName.RequestDartAmmo, pickupName);
+  }
+
+  public void SendDartStepRequest (string pickupName)
+  {
+    if (Multiplayer.IsServer()) { RequestDartStep (pickupName); return; }
+    RpcId (1, MethodName.RequestDartStep, pickupName);
+  }
+
+  // A dart left a blowgun: it counts as in flight for a few seconds so the census
+  // never mints a replacement while it's still in the air.
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestDartFired()
+  {
+    if (!Multiplayer.IsServer()) return;
+    _dartFlightsUntilMs.Add (Time.GetTicksMsec() + (ulong)(DartFlightGraceSeconds * 1000.0f));
+  }
+
+  // A miss that hit geometry lands as an ARMED ground dart where it stopped (#248).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestDartLand (Vector3 position)
+  {
+    if (!Multiplayer.IsServer()) return;
+    if (!TryFindGround (position, out var spot)) { ServerLog.Event (SenderOrSelf(), "dart land skip: no ground; the census respawns it"); return; }
+    ServerLog.Event (SenderOrSelf(), $"dart land: armed at {spot}");
+    Spawn (HeldWeapon.PoisonDart, spot, expires: false, armed: true);
+  }
+
+  // Walking over a ground dart while HOLDING the blowgun loads it as ammo - floating
+  // or landed alike. Validated against the replicated HeldWeapon (#145 convention).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestDartAmmo (string pickupName)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var collectorId = SenderOrSelf();
+    var collector = Players().FirstOrDefault (player => player.NetworkId == collectorId);
+    var pickup = GetParent().GetNodeOrNull <WeaponPickup> (pickupName);
+
+    if (collector == null || (collector.HeldOrRecentlyHeld & HeldWeapon.Blowgun) == 0 || pickup == null || pickup.IsQueuedForDeletion() || pickup.Weapon != HeldWeapon.PoisonDart)
+    {
+      ServerLog.Event (collectorId, $"dart ammo deny: [{pickupName}] is not a dart or the sender holds no blowgun");
+      return;
+    }
+
+    pickup.QueueFree(); // Despawns on every peer via the MultiplayerSpawner.
+    ServerLog.Event (collectorId, $"dart ammo: [{collector.DisplayName}] loaded a dart from [{pickupName}]");
+    if (collectorId == Multiplayer.GetUniqueId()) { collector.ConfirmDartAmmoSelf(); return; }
+    collector.RpcId (collectorId, Player.MethodName.ConfirmDartAmmo);
+  }
+
+  // Stepping on a LANDED (armed) dart with no blowgun in hand: it's gone from the
+  // ground & into you, as if it hit you (issues #236 & #248).
+  [Rpc (MultiplayerApi.RpcMode.AnyPeer)]
+  private void RequestDartStep (string pickupName)
+  {
+    if (!Multiplayer.IsServer()) return;
+    var stepperId = SenderOrSelf();
+    var stepper = Players().FirstOrDefault (player => player.NetworkId == stepperId);
+    var pickup = GetParent().GetNodeOrNull <WeaponPickup> (pickupName);
+
+    if (stepper == null || stepper.SpawnArmor || stepper.Fallen || pickup == null || pickup.IsQueuedForDeletion() || pickup.Weapon != HeldWeapon.PoisonDart || !pickup.Armed)
+    {
+      ServerLog.Event (stepperId, $"dart step deny: [{pickupName}] is not an armed dart, or the sender is armored or down");
+      return;
+    }
+
+    pickup.QueueFree();
+    ServerLog.Event (stepperId, $"dart step: [{stepper.DisplayName}] stepped on a landed dart");
+    if (stepperId == Multiplayer.GetUniqueId()) { stepper.ConfirmDartStepSelf(); return; }
+    stepper.RpcId (stepperId, Player.MethodName.ConfirmDartStep);
   }
 
   // A slung dart connected (issue #194): consume the shooter's escrowed dart so it

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -27,7 +27,7 @@ Slot keys select what's in your hands. You spawn with fists **and bread** (bread
 | 5 | Slingshot | Hold left-click to draw, release to fling a stone. Longer draw = faster, flatter, harder (never a one-hit). A quick tap just relaxes the band - stones need a minimum draw, & a short cooldown separates shots. **Universal ammo**: see below |
 | 6 | Paper airplane | Left-click to throw. Locks onto whoever's under your crosshair & glides slowly after them; punch an incoming one (fists out) to catch it & throw it back. Only one exists in the whole game, & it is a personal hazard - see below |
 | 0 or B | Bread | Left-click to eat: a 3-second rooted ritual that heals you to full. One loaf per life - see below |
-| 8 | Blowgun | The stealth weapon - with a scope, because of course it has a scope. Left-click puffs a poison dart, right-click (hold) zooms. The shot is nearly silent: only players within a few feet of you hear it, & everyone else only hears a dart that flies close by them. Darts do no impact damage - they stick in & poison: every 5 seconds the victim loses 10% health PER embedded dart, & their health bar turns green. Bread heals as normal but does NOT remove darts. On a zap-out the darts fall beside the body for 5 seconds - slingshot players can load one as ammo (a slung dart poisons identically) |
+| 8 | Blowgun | The silenced sniper - with a scope, because of course. Right-click to look THROUGH the scope (mouse wheel zooms in and out, very far); the reticle drifts - more the further you zoom - and only settles for about a second between heartbeats: time the shot into the settled (green) window. Left-click puffs a poison dart: fast but visible, nearly no drop, very long range, no recoil. Darts do no impact damage - they stick in and poison: 10% health per dart every 5 seconds, health bar turns green; bread heals but doesn't remove darts. **The gun starts empty**: there are 10 darts in the whole level - find them. See "Darts" below |
 
 ### Slingshot universal ammo
 
@@ -88,6 +88,10 @@ The spawn box is a boxing ring: its walls are rubber ropes. Run, slide, or get p
 ## Headshots
 
 Every player has a floating sensor dome above the body. A laser bolt or a slingshot stone (or slung item) that hits the dome is a headshot: a flat 300 damage that ignores the difficulty handicap - one zaps an Expert or Intermediate outright, a Beginner takes exactly two. Punches, bananas, boomerangs, airplanes & darts don't care where they land. Your hitmarker rings higher on a dome hit.
+
+## Darts
+
+Ten darts exist in the level, no more, no less. A **floating, spinning** dart is a spawned pickup: harmless, and only a player holding the blowgun can collect it (walk over it). A dart **lying flat** on the ground has landed - off a zapped-out victim, or a miss that hit a wall - and it's a hazard: step on it without the blowgun and it poisons you as if it hit you; with the blowgun in hand you pick it up as ammo. Slingshot players can load either kind and fire it; a slung dart poisons the same. Drop or lose the blowgun and its darts go back into the level. Darts that fall off the stage respawn.
 
 ## Good to know
 

--- a/tests/unit/ScopeTest.cs
+++ b/tests/unit/ScopeTest.cs
@@ -1,0 +1,42 @@
+using com.forerunnergames.energyshot.weapons;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// The blowgun's scope model (issue #236): the zoom ladder has ends, drift grows with
+// zoom, & the heartbeat envelope spikes on the beat & settles into the shot window.
+[TestSuite]
+public class ScopeTest
+{
+  [TestCase]
+  public void ZoomLadderClampsAtBothEnds()
+  {
+    AssertInt (Scope.StepOut (0)).IsEqual (0);
+    AssertInt (Scope.StepIn (Scope.ZoomFovs.Length - 1)).IsEqual (Scope.ZoomFovs.Length - 1);
+    AssertInt (Scope.StepIn (0)).IsEqual (1);
+  }
+
+  [TestCase]
+  public void FovsShrinkEveryStep()
+  {
+    for (var i = 1; i < Scope.ZoomFovs.Length; ++i) AssertFloat (Scope.ZoomFovs[i]).IsLess (Scope.ZoomFovs[i - 1]);
+  }
+
+  [TestCase]
+  public void DriftGrowsWithZoomAndIsNeverZero()
+  {
+    AssertFloat (Scope.DriftFraction (0)).IsGreater (0.0f); // Aiming is never free, even at the lowest zoom (Aaron).
+    AssertFloat (Scope.DriftFraction (Scope.ZoomFovs.Length - 1)).IsGreater (Scope.DriftFraction (0));
+  }
+
+  [TestCase]
+  public void HeartbeatSpikesThenSettlesForAboutASecond()
+  {
+    AssertFloat (Scope.BeatEnvelope (0.0f)).IsEqual (1.0f);
+    AssertFloat (Scope.BeatEnvelope (Scope.SettleSeconds)).IsEqual (Scope.SettledFraction);
+    AssertBool (Scope.IsSettled (Scope.SettleSeconds - 0.01f)).IsFalse();
+    AssertBool (Scope.IsSettled (Scope.SettleSeconds)).IsTrue();
+    AssertFloat (Scope.BeatPeriodSeconds - Scope.SettleSeconds).IsGreaterEqual (1.0f); // The settled window lasts at least a second.
+  }
+}

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -19,6 +19,8 @@ public partial class Hud : Control
   private World _world = null!;
   private ProgressBar _healthBar = null!;
   private Label _roundClock = null!; // Issue #153.
+  private ScopeView _scopeView = null!; // Issue #236.
+  private Label _dartAmmo = null!;
   private ColorRect _roundOverlay = null!;
   private RichTextLabel _roundBoard = null!;
   private StyleBoxFlat? _poisonFill; // Green fill swapped in while poisoned (issue #194).
@@ -174,6 +176,7 @@ public partial class Hud : Control
     _world.RoundEnded += OnRoundEnded;
     _world.RoundStarted += OnRoundStarted;
     CreateRoundUi();
+    CreateScopeUi(); // Issue #236.
     _world.ChatReceived += OnChatReceived; // Issue #188.
     CreateChatBox();
     _world.PlayerScored += OnPlayerScored;
@@ -209,6 +212,32 @@ public partial class Hud : Control
     _deathCountdown.AddThemeFontSizeOverride ("font_size", 48);
     _deathCountdown.SetAnchorsPreset (LayoutPreset.FullRect);
     _deathOverlay.AddChild (_deathCountdown);
+  }
+
+  // The blowgun's scope view & dart count (issue #236): the scope draws over
+  // everything while scoped; the ammo readout sits under the crosshair whenever the
+  // blowgun is out. Both poll the local player, like the bread icon.
+  private void CreateScopeUi()
+  {
+    _scopeView = new ScopeView();
+    AddChild (_scopeView);
+    _dartAmmo = new Label { HorizontalAlignment = HorizontalAlignment.Center, MouseFilter = MouseFilterEnum.Ignore, Visible = false };
+    _dartAmmo.AddThemeFontSizeOverride ("font_size", 34);
+    _dartAmmo.SetAnchorsPreset (LayoutPreset.Center);
+    _dartAmmo.GrowHorizontal = GrowDirection.Both;
+    _dartAmmo.OffsetTop = 48.0f;
+    AddChild (_dartAmmo);
+  }
+
+  private void UpdateDartAmmo()
+  {
+    var self = _world.SelfPlayer;
+    _scopeView.Track (self);
+    var show = self != null && Visible && self.IsBlowgunSelected && self.HasBlowgun;
+    _dartAmmo.Visible = show;
+    if (!show) return;
+    _dartAmmo.Text = self!.BlowgunDarts > 0 ? $"darts: {self.BlowgunDarts}" : "darts: 0 - find ammo";
+    _dartAmmo.Modulate = self.BlowgunDarts > 0 ? Colors.White : new Color (1.0f, 0.5f, 0.4f);
   }
 
   // Rounds (issue #153), code-built like the death overlay: a top-center clock while
@@ -312,6 +341,7 @@ public partial class Hud : Control
     UpdateCooldownMeters();
     UpdateBreadIcon();
     UpdatePoisonTint(); // Issue #194.
+    UpdateDartAmmo(); // Issue #236.
     UpdateBreadNotice();
     UpdateDeathOverlay();
     UpdateTargetRing();

--- a/ui/hud/ProceduralSounds.cs
+++ b/ui/hud/ProceduralSounds.cs
@@ -13,9 +13,20 @@ public static class ProceduralSounds
   // on purpose, & its emitter clamps the audible radius to a few feet.
   public static AudioStreamWav DartPfft()
   {
-    var samples = new float[(int)(SampleRate * 0.18f)];
-    AddCrunch (samples, startSeconds: 0.0f, brightness: 0.12f);
-    AddChime (samples, startSeconds: 0.02f, fromHz: 220.0f, toHz: 140.0f, seconds: 0.12f, amplitude: 0.08f);
+    var samples = new float[(int)(SampleRate * 0.2f)];
+    AddCrunch (samples, startSeconds: 0.0f, brightness: 0.15f);
+    AddCrunch (samples, startSeconds: 0.03f, brightness: 0.1f);
+    AddChime (samples, startSeconds: 0.01f, fromHz: 260.0f, toHz: 120.0f, seconds: 0.16f, amplitude: 0.35f);
+    return FromSamples (samples);
+  }
+
+  // The scoped heartbeat (issue #236): a low double thump - lub, dub - the shooter
+  // times the settled window against.
+  public static AudioStreamWav Heartbeat()
+  {
+    var samples = new float[(int)(SampleRate * 0.35f)];
+    AddChime (samples, startSeconds: 0.0f, fromHz: 70.0f, toHz: 45.0f, seconds: 0.12f, amplitude: 0.6f);
+    AddChime (samples, startSeconds: 0.16f, fromHz: 60.0f, toHz: 40.0f, seconds: 0.14f, amplitude: 0.45f);
     return FromSamples (samples);
   }
 

--- a/ui/hud/ScopeView.cs
+++ b/ui/hud/ScopeView.cs
@@ -1,0 +1,73 @@
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.weapons;
+using Godot;
+
+namespace com.forerunnergames.energyshot.ui.hud;
+
+// Looking THROUGH the blowgun's scope (issue #236): a full-screen black mask with a
+// circular window, a thin rim, & a reticle that drifts with the player's scope model
+// (Player.ReticleDrift) - green when the heartbeat has settled, that's the window to
+// shoot. Pure cosmetics; the aim math lives in Player.AimDirection.
+public partial class ScopeView : Control
+{
+  public const float RadiusFraction = 0.42f; // Of the shorter screen side; Player.AimDirection assumes the same.
+  private static readonly Color Rim = new(0.1f, 0.1f, 0.1f);
+  private static readonly Color Wandering = new(1.0f, 0.35f, 0.25f);
+  private static readonly Color Settled = new(0.4f, 1.0f, 0.4f);
+  private const string MaskShader = @"
+shader_type canvas_item;
+uniform vec2 center;
+uniform float radius;
+void fragment() {
+  float d = distance(FRAGCOORD.xy, center);
+  float a = d > radius ? 1.0 : 0.0;
+  if (abs(d - radius) < 6.0) a = 1.0;
+  COLOR = vec4(0.0, 0.0, 0.0, a);
+}";
+  private ColorRect _mask = null!;
+  private ShaderMaterial _material = null!;
+  private Player? _player;
+
+  public override void _Ready()
+  {
+    MouseFilter = MouseFilterEnum.Ignore;
+    SetAnchorsPreset (LayoutPreset.FullRect);
+    _material = new ShaderMaterial { Shader = new Shader { Code = MaskShader } };
+    _mask = new ColorRect { Material = _material, MouseFilter = MouseFilterEnum.Ignore };
+    _mask.SetAnchorsPreset (LayoutPreset.FullRect);
+    AddChild (_mask);
+    Visible = false;
+  }
+
+  public void Track (Player? player) => _player = player;
+
+  public override void _Process (double delta)
+  {
+    var scoped = _player != null && _player.IsScoped;
+    Visible = scoped;
+    if (!scoped) return;
+    var size = GetViewportRect().Size;
+    _material.SetShaderParameter ("center", size / 2.0f);
+    _material.SetShaderParameter ("radius", Radius (size));
+    QueueRedraw();
+  }
+
+  private static float Radius (Vector2 size) => Mathf.Min (size.X, size.Y) * RadiusFraction;
+
+  public override void _Draw()
+  {
+    if (_player == null || !_player.IsScoped) return;
+    var size = GetViewportRect().Size;
+    var radius = Radius (size);
+    var reticle = size / 2.0f + _player.ReticleDrift * radius;
+    var color = _player.IsScopeSettled ? Settled : Wandering;
+    DrawArc (size / 2.0f, radius, 0.0f, Mathf.Tau, 96, Rim, 3.0f);
+    DrawLine (reticle + Vector2.Left * 28.0f, reticle + Vector2.Left * 8.0f, color, 2.0f);
+    DrawLine (reticle + Vector2.Right * 8.0f, reticle + Vector2.Right * 28.0f, color, 2.0f);
+    DrawLine (reticle + Vector2.Up * 28.0f, reticle + Vector2.Up * 8.0f, color, 2.0f);
+    DrawLine (reticle + Vector2.Down * 8.0f, reticle + Vector2.Down * 28.0f, color, 2.0f);
+    DrawCircle (reticle, 2.0f, color);
+    var zoom = $"{Scope.ZoomFovs[0] / Scope.ZoomFovs[_player.ZoomStep]:0.#}x";
+    DrawString (ThemeDB.FallbackFont, new Vector2 (size.X / 2.0f - 24.0f, size.Y / 2.0f + radius - 16.0f), zoom, HorizontalAlignment.Center, -1, 28, color);
+  }
+}


### PR DESCRIPTION
Implements the #236 rework of #194 — today's rulings supersede the shipped feel; where nothing was ruled today, #194 stands (poison-only damage, 10%/dart/5 s, green bars, bread doesn't cure, slingshot loads darts).

**Scope.** Right click opens a **through-the-scope view** (`ScopeView`: shader mask with a circular window, rim, drifting reticle). The wheel steps a five-stop zoom ladder (40° → 3.5° FOV — very far). The reticle **drifts** more the further in you are, **spikes on each heartbeat** and settles for ~1 s between beats (reticle turns green) — that's the shot window; aiming is never free, even at the lowest zoom. Scoping forces first person and hides the held gun/crosshair. Darts fly toward the *drifted* reticle (`Player.AimDirection` projects it back through the camera). No recoil. The model is pure (`Scope.cs`) and pinned in `ScopeTest`.

**Darts.** A real fletched dart body (shaft, steel tip, three red fins); 42 m/s — fast but you can watch it fly; near-zero drop; 6 s lifetime. A miss that hits geometry **lands as an armed ground dart**.

**Dart economy (#248 lifecycle).** Exactly `MaxDarts` (10) exist. The blowgun **starts empty** and fires from a replicated `BlowgunDarts` count (Player.tscn index 28, appended). Walking over any ground dart while holding the blowgun loads it (`RequestDartAmmo`). A *floating* (spawned) dart is harmless and uncollectible to anyone else; a *landed* (armed, lying flat) dart poisons whoever else steps on it, ownerless like a mine (`RequestDartStep` → `ConfirmDartStep`). Losing the blowgun returns its darts to the census; the census (`CountDarts`: ground + in blowguns + embedded + nocked + a 7 s in-flight grace) respawns floating darts over the arena floor — not in `--playtest`. Death-scattered darts are armed and never expire.

**Audio.** Shooter hears the puff locally (louder sample); bystanders only within a few feet (unchanged stealth rule); heartbeat while scoped; denied click on empty. HUD: `darts: N` under the crosshair.

Touches: BlowgunDart, Player.Blowgun/Poison/Weapons, WeaponSpawner, WeaponPickup, Hud + ScopeView, ProceduralSounds, Scope, docs (blowgun row + a Darts section).

Verification is CI's job: this box can't build. Needs human eyes next playtest: scope feel (drift amplitude, settle window), dart visibility in flight, and the landed-dart pose.

Closes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso