### PR TITLE
Boxing ring: rope tops trampoline you & the ropes fling much harder

### DIFF
--- a/core/players/Player.BoxingRing.cs
+++ b/core/players/Player.BoxingRing.cs
@@ -8,10 +8,18 @@ namespace com.forerunnergames.energyshot.players;
 // The room's spawn-protection job (spawn armor, layout) is untouched.
 public partial class Player
 {
-  [Export] public float RopeRestitution = 0.9f;
-  [Export] public float RopeShove = 6.0f;
-  [Export] public float RopeBounceSeconds = 0.35f;
+  // Much bouncier (issue #240, Caleb): jumping into the ropes should fling you hard
+  // enough to nearly knock you out of the ring - restitution over 1 & a shove that
+  // scales with how fast you hit them.
+  [Export] public float RopeRestitution = 1.3f;
+  [Export] public float RopeShove = 9.0f;
+  [Export] public float RopeShovePerImpactSpeed = 0.6f;
+  [Export] public float RopeBounceSeconds = 0.45f;
   [Export] public float HeadBounceVelocity = 26.0f;
+  // The rope tops are trampolines too (issue #240): landing on one springs you up,
+  // scaled by how fast you came down, & even a standing hop still bounces.
+  [Export] public float RopeTopBounceMin = 14.0f;
+  [Export] public float RopeTopBouncePerFallSpeed = 1.1f;
   private const float MinRopeImpactSpeed = 1.0f;
   private Vector3 _preMoveVelocity;
 
@@ -25,11 +33,20 @@ public partial class Player
   {
     if (!IsRope (collision.GetCollider())) return false;
     var normal = collision.GetNormal();
-    if (Mathf.Abs (normal.Y) > 0.5f) return false; // The top edge isn't a rope.
-    if (-_preMoveVelocity.Dot (normal) < MinRopeImpactSpeed) return false; // Leaning on it, not hitting it.
-    var bounced = _preMoveVelocity.Bounce (normal) * RopeRestitution + normal * RopeShove;
+    if (normal.Y > 0.5f) return TryRopeTopBounce();
+    var impact = -_preMoveVelocity.Dot (normal);
+    if (impact < MinRopeImpactSpeed) return false; // Leaning on it, not hitting it.
+    var bounced = _preMoveVelocity.Bounce (normal) * RopeRestitution + normal * (RopeShove + impact * RopeShovePerImpactSpeed);
     Velocity = new Vector3 (bounced.X, Velocity.Y, bounced.Z);
     _stickyFlightSecondsLeft = Mathf.Max (_stickyFlightSecondsLeft, RopeBounceSeconds);
+    return true;
+  }
+
+  private bool TryRopeTopBounce()
+  {
+    var fallSpeed = Mathf.Max (0.0f, -_preMoveVelocity.Y);
+    Velocity = new Vector3 (Velocity.X, Mathf.Max (RopeTopBounceMin, fallSpeed * RopeTopBouncePerFallSpeed), Velocity.Z);
+    _jumpSound.Play();
     return true;
   }
 

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -83,7 +83,7 @@ There is exactly **one** paper airplane in the arena. It's a slot-6 weapon like 
 
 ## The boxing ring
 
-The spawn box is a boxing ring: its walls are rubber ropes. Run, slide, or get punched into one and you bounce back the way you came with a shove - knock someone into the ropes and they come right back to you. Land on top of another player's head and you spring high into the air. Spawn armor & the room's protection work exactly as before.
+The spawn box is a boxing ring: its walls are rubber ropes. Run, slide, or get punched into one and you bounce back the way you came with a big shove - the harder you hit, the harder it flings you; jump into the ropes and you can be thrown clean across the ring. Stand or jump on top of a rope and it trampolines you up. Land on top of another player's head and you spring high into the air. Spawn armor & the room's protection work exactly as before.
 
 ## Headshots
 


### PR DESCRIPTION
Closes #240.

- **Rope tops bounce**: a collision with an upward normal on a ring wall now springs you up — at least `RopeTopBounceMin` (14), or 1.1× your fall speed if that's more — so a standing hop still bounces and a big drop launches you.
- **Much bouncier ropes**: restitution 0.9→1.3 and the shove grows with impact speed (9 + 0.6×impact m/s), so jumping into them nearly throws you out of the ring. All exports, easy to retune.

Verification is CI's job: this box can't build; the playtest's short spawn-room walks don't touch the walls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso