### PR TITLE
Rounded boomerang & a third-person pitch ceiling against floor flicker

### DIFF
--- a/core/players/Player.View.cs
+++ b/core/players/Player.View.cs
@@ -63,7 +63,7 @@ public partial class Player
   // slide camera heights, camera kick, & aim pitch for free.
   private void CreateThirdPersonRig()
   {
-    _thirdPersonArm = new SpringArm3D { Position = ChaseViewOffset(), SpringLength = ThirdPersonBackMeters, CollisionMask = 1, Margin = 0.3f };
+    _thirdPersonArm = new SpringArm3D { Position = ChaseViewOffset(), SpringLength = ThirdPersonBackMeters, CollisionMask = 1, Margin = 0.6f }; // Wider margin (issue #234): the near plane never grazes a surface.
     _thirdPersonArm.AddExcludedObject (GetRid());
     _camera.AddChild (_thirdPersonArm);
     _thirdPersonCamera = new Camera3D { Rotation = ChaseViewAim (ThirdPersonBackMeters) };

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -188,6 +188,7 @@ public partial class Player : CharacterBody3D
 
   [Export] public float SpawnArmorSeconds = 5.0f;
   [Export] public float MouseSensitivity = 0.0025f;
+  [Export] public float ThirdPersonMaxPitchUpDegrees = 60.0f; // Issue #234.
   [Export] public float FullAutoDurationSeconds = 3.0f;
   [Export] public float FullAutoCooldownSeconds = 15.0f;
   [Export] public float FullAutoShotIntervalSeconds = 0.15f;
@@ -485,6 +486,10 @@ public partial class Player : CharacterBody3D
     if (@event is not InputEventMouseMotion motionEvent) return;
     RotateY (-motionEvent.Relative.X * MouseSensitivity);
     _camera.RotateX (-motionEvent.Relative.Y * MouseSensitivity);
-    _camera.Rotation = new Vector3 (Mathf.Clamp (_camera.Rotation.X, -Mathf.Pi / 2.0f, Mathf.Pi / 2.0f), _camera.Rotation.Y, _camera.Rotation.Z);
+    // Third person can't pitch all the way up (issue #234): the chase arm hangs behind
+    // the head camera, so looking straight up swung it down into the floor, where the
+    // camera z-fought the ground texture. The ceiling keeps the arm above your feet.
+    var maxUp = _thirdPerson ? Mathf.DegToRad (ThirdPersonMaxPitchUpDegrees) : Mathf.Pi / 2.0f;
+    _camera.Rotation = new Vector3 (Mathf.Clamp (_camera.Rotation.X, -Mathf.Pi / 2.0f, maxUp), _camera.Rotation.Y, _camera.Rotation.Z);
   }
 }

--- a/core/weapons/BoomerangProjectile.cs
+++ b/core/weapons/BoomerangProjectile.cs
@@ -44,14 +44,44 @@ public partial class BoomerangProjectile : Node3D
   // Shared look for the projectile, the world pickup, & the held model (issue #98):
   // two bright crossed arms built from primitive boxes. Fresh materials per call so
   // the first-person overlay tweak (issue #124) can't bleed into pickups.
+  // A curved boomerang (issue #245): a smooth swept V traced along a quadratic Bezier
+  // from one rounded tip through the elbow to the other, built from short capsules so
+  // every edge is round - no boxes, no hard angles. Shared by projectile, held model,
+  // pickup, & the slingshot nock.
   public static Node3D CreateVisual()
   {
     var material = new StandardMaterial3D { AlbedoColor = BoomerangOrange, EmissionEnabled = true, Emission = BoomerangOrange * 0.6f, Roughness = 0.4f };
     var visual = new Node3D();
-    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.85f, 0.06f, 0.18f) }, MaterialOverride = material, Position = new Vector3 (0.28f, 0.0f, 0.0f) });
-    visual.AddChild (new MeshInstance3D { Mesh = new BoxMesh { Size = new Vector3 (0.18f, 0.06f, 0.85f) }, MaterialOverride = material, Position = new Vector3 (0.0f, 0.0f, 0.28f) });
+    var tipA = new Vector3 (0.62f, 0.0f, 0.0f);
+    var elbow = new Vector3 (-0.08f, 0.0f, -0.08f);
+    var tipB = new Vector3 (0.0f, 0.0f, 0.62f);
+    const int segments = 10;
+    var previous = Bezier (tipA, elbow, tipB, 0.0f);
+
+    for (var i = 1; i <= segments; ++i)
+    {
+      var point = Bezier (tipA, elbow, tipB, (float)i / segments);
+      var along = point - previous;
+      var taper = 0.085f - 0.03f * Mathf.Abs ((float)i / segments - 0.5f) * 2.0f; // Fat elbow, slimmer tips.
+      var capsule = new MeshInstance3D { Mesh = new CapsuleMesh { Radius = taper, Height = along.Length() + taper * 2.0f }, MaterialOverride = material, Position = (previous + point) / 2.0f };
+      capsule.Basis = AlongY (along); // A capsule stands along Y; lay it along the segment (no LookAt: not in the tree yet).
+      visual.AddChild (capsule);
+      previous = point;
+    }
+
     return visual;
   }
+
+  private static Basis AlongY (Vector3 direction)
+  {
+    var y = direction.Normalized();
+    var x = Vector3.Up.Cross (y);
+    if (x.LengthSquared() < 0.001f) x = Vector3.Right;
+    x = x.Normalized();
+    return new Basis (x, y, x.Cross (y));
+  }
+
+  private static Vector3 Bezier (Vector3 a, Vector3 control, Vector3 b, float t) => a * (1.0f - t) * (1.0f - t) + control * 2.0f * (1.0f - t) * t + b * t * t;
 
   public override void _Ready()
   {


### PR DESCRIPTION
Closes #245 & #234.

- **Boomerang**: a smooth swept V — ten capsules traced along a quadratic Bezier tip→elbow→tip, fat at the elbow & slimmer toward rounded tips. Same `CreateVisual` factory, so projectile, held model, pickup & slingshot nock all change together. Bases are set directly (no `LookAt`; the nodes aren't in the tree yet).
- **Third-person floor flicker**: the chase `SpringArm3D` hangs behind the head camera, so pitching straight up swung it into the floor and the near plane z-fought the ground. Third person now tops out at 60° up (`ThirdPersonMaxPitchUpDegrees`, first person unchanged) and the arm margin is 0.3→0.6.

Verification is CI's job: this box can't build; the boomerang shape wants a human look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso