### PR TITLE
Double the arena floor & fill the new ring: 5 buildings, 6 pillars, 6 platforms

### DIFF
--- a/core/weapons/WeaponSpawner.cs
+++ b/core/weapons/WeaponSpawner.cs
@@ -134,8 +134,9 @@ public partial class WeaponSpawner : Node3D
   {
     _rng.Randomize();
     _pickupScene = ResourceLoader.Load <PackedScene> ("res://core/weapons/WeaponPickup.tscn");
-    // Laser spawn points: on top of the 5 low buildings; banana: the high platform.
-    for (var i = 1; i <= 5; ++i) _laserPoints.Add (TopOf (GetNode <CsgBox3D> ($"../Building{i}"), PickupHoverHeight));
+    // Laser spawn points: on top of EVERY low building - new buildings become spawn
+    // points automatically (issue #293); banana: the high platform.
+    for (var i = 1; GetNodeOrNull <CsgBox3D> ($"../Building{i}") is { } building; ++i) _laserPoints.Add (TopOf (building, PickupHoverHeight));
     _bananaPoint = TopOf (GetNode <CsgBox3D> ("../BananaPlatform"), PickupHoverHeight);
     _isPlaytest = OS.GetCmdlineUserArgs().Contains ("--playtest");
   }
@@ -227,7 +228,7 @@ public partial class WeaponSpawner : Node3D
     var missing = MaxDarts - CountDarts (pickups, players);
     for (var i = 0; i < missing; ++i)
     {
-      var target = new Vector3 (_rng.RandfRange (-35.0f, 35.0f), 0.0f, _rng.RandfRange (-35.0f, 35.0f));
+      var target = new Vector3 (_rng.RandfRange (-85.0f, 85.0f), 0.0f, _rng.RandfRange (-85.0f, 85.0f)); // The doubled floor (issue #293), with an edge margin.
       if (!TryFindGround (target, out var spot)) continue;
       Spawn (HeldWeapon.PoisonDart, spot, expires: false);
     }

--- a/core/world/World.tscn
+++ b/core/world/World.tscn
@@ -132,9 +132,94 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 28, 11)
 use_collision = true
 size = Vector3(6, 0.5, 6)
 
+[node name="Building6" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 62, 1, -40)
+use_collision = true
+size = Vector3(5, 2, 5)
+
+[node name="Building7" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -58, 1, 45)
+use_collision = true
+size = Vector3(5, 2, 5)
+
+[node name="Building8" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 75, 1, 30)
+use_collision = true
+size = Vector3(5, 2, 5)
+
+[node name="Building9" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -70, 1, -60)
+use_collision = true
+size = Vector3(5, 2, 5)
+
+[node name="Building10" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 40, 1, 70)
+use_collision = true
+size = Vector3(5, 2, 5)
+
+[node name="Pillar7" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 55, 3, 60)
+use_collision = true
+size = Vector3(2, 6, 2)
+
+[node name="Pillar8" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -65, 3, -15)
+use_collision = true
+size = Vector3(2, 6, 2)
+
+[node name="Pillar9" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 80, 3, -70)
+use_collision = true
+size = Vector3(2, 6, 2)
+
+[node name="Pillar10" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -45, 3, 75)
+use_collision = true
+size = Vector3(2, 6, 2)
+
+[node name="Pillar11" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12, 3, -75)
+use_collision = true
+size = Vector3(2, 6, 2)
+
+[node name="Pillar12" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -80, 3, 8)
+use_collision = true
+size = Vector3(2, 6, 2)
+
+[node name="Platform5" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 5, -65)
+use_collision = true
+size = Vector3(8, 0.5, 8)
+
+[node name="Platform6" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -62, 7, 60)
+use_collision = true
+size = Vector3(8, 0.5, 8)
+
+[node name="Platform7" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 78, 9, -8)
+use_collision = true
+size = Vector3(8, 0.5, 8)
+
+[node name="Platform8" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -15, 6, 80)
+use_collision = true
+size = Vector3(8, 0.5, 8)
+
+[node name="HighPlatform1" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -60, 26, -60)
+use_collision = true
+size = Vector3(6, 0.5, 6)
+
+[node name="HighPlatform2" type="CSGBox3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 65, 30, 65)
+use_collision = true
+size = Vector3(6, 0.5, 6)
+
 [node name="Ground" type="CSGBox3D" parent="."]
 use_collision = true
-size = Vector3(100, 0.002, 100)
+size = Vector3(200, 0.002, 200)
 material = SubResource("StandardMaterial3D_bx300")
 
 [node name="SpawnRoom" type="Node3D" parent="."]


### PR DESCRIPTION
Closes #293 (Aaron): the original level doubles - ground 100x100 → 200x200 - and the new outer ring gets **Building6-10**, **Pillar7-12**, **Platform5-8**, plus **two new hard-to-reach high platforms** (26m and 30m: rocket-jump/slide-chain territory, and the KOTH zone candidates for #294).

- Item spawn points scale automatically now: the laser/free-point loop discovers every `BuildingN` instead of a hardcoded 1-5 - ten laser spots instead of five, and the specials' free-point pool grows with them.
- The dart census scatters across the doubled floor (±85 with an edge margin).
- All existing playtest fixture positions and the spawn room are untouched (everything sits inside the old ±50 footprint, which is unchanged).

#294 (KOTH hill picking among the banana platform + the two new high platforms) follows after #260 lands, to avoid rewriting `Hill.Spot` twice.

Verification is CI's job: this box can't build. The playtest runs entirely inside the unchanged inner footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso