### PR TITLE
Force exclusive fullscreen at boot on Windows

### DIFF
--- a/ui/menus/main/MainMenu.cs
+++ b/ui/menus/main/MainMenu.cs
@@ -17,6 +17,12 @@ public partial class MainMenu : Control
 
   public override void _Ready()
   {
+#if GODOT_WINDOWS
+    // The Windows fullscreen fix (issue #302), ported from another Forerunner title:
+    // Windows needs the mode FORCED at boot - ugly but proven; without it the window
+    // comes up in a state players can't play in.
+    DisplayServer.WindowSetMode (DisplayServer.WindowMode.ExclusiveFullscreen);
+#endif
     _world = GetNode <World> ("/root/World");
     _hostButton = GetNode <Button> ("PanelContainer/MarginContainer/VBoxContainer/Buttons/VBoxContainer/HostButton");
     _joinButton = GetNode <Button> ("PanelContainer/MarginContainer/VBoxContainer/Buttons/VBoxContainer/JoinButton");


### PR DESCRIPTION
Closes #302 (Dillyo): fullscreen wasn't playable on Windows. This ports the proven boot-time fix from another Forerunner title: `DisplayServer.WindowSetMode(ExclusiveFullscreen)` forced in the first client `_Ready`, under `#if GODOT_WINDOWS` - ugly but known-good in production there. Linux server & macOS untouched by the compile guard.

Verification: this box can't build, and CI runs on Linux - the real proof is a Windows playtester on the next release; flagged as such. Spec-coverage note: not machine-verifiable in our Linux CI harness; Dillyo is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso