### PR TITLE
The held blowgun moves outside the body capsule - visible in third person

### DIFF
--- a/core/players/Player.Blowgun.cs
+++ b/core/players/Player.Blowgun.cs
@@ -51,7 +51,10 @@ public partial class Player
   private void CreateBlowgunHeld()
   {
     _blowgunHeld = BlowgunDart.CreateBlowgunVisual();
-    _blowgunHeld.Position = new Vector3 (0.32f, -0.22f, -0.55f);
+    // Outside the body capsule (issue #303, Escendrix): x 0.32 sat inside the 0.5m
+    // radius, so in third person the body mesh swallowed the whole gun. Same shelf as
+    // the slingshot now - visible from every angle, still framed right in first person.
+    _blowgunHeld.Position = new Vector3 (0.5f, -0.35f, -0.75f);
     var camera = GetNode <Camera3D> ("Camera3D"); // Fetched directly: held-model creators run before _Ready assigns _camera.
     camera.AddChild (_blowgunHeld);
     _unscopedFovDegrees = camera.Fov;


### PR DESCRIPTION
Closes #303 (Escendrix): the dart gun was invisible in third person. The held model sat at x 0.32 - inside the body capsule's 0.5m radius - so the chase camera saw it swallowed by the player mesh; the slingshot at (0.5, -0.5, -0.9) never had the problem. The blowgun now sits on the same shelf: (0.5, -0.35, -0.75), outside the capsule from every angle and still framed right in first person (the scope view hides it while scoped, unchanged).

Verification is CI's job: this box can't build; visibility is a cosmetic judgment for the next playtest - flagged for Escendrix to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the blowgun’s held visual position for improved in-game alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->