### PR TITLE
The slow playtest waits for CodeRabbit approval; superseded runs cancel

### DIFF
--- a/.github/workflows/playtest.yml
+++ b/.github/workflows/playtest.yml
@@ -40,7 +40,7 @@ jobs:
           if [ "${{ github.event_name }}" != "pull_request" ]; then echo "run=true" >> "$GITHUB_OUTPUT"; exit 0; fi
           # Latest state per reviewer, all pages, dismissals excluded (CodeRabbit): a
           # stale approval superseded by CHANGES_REQUESTED must not open the gate.
-          approved=$(gh api --paginate --slurp "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --jq 'add | map(select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")) | group_by(.user.login) | map(last) | map(select(.state=="APPROVED")) | length')
+          approved=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" | jq -s 'add | map(select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")) | group_by(.user.login) | map(last) | map(select(.state=="APPROVED")) | length')
           if [ "$approved" -gt 0 ]; then echo "run=true" >> "$GITHUB_OUTPUT"; else echo "run=false" >> "$GITHUB_OUTPUT"; echo "Playtest deferred: no approved review yet."; fi
 
   playtest:

--- a/.github/workflows/playtest.yml
+++ b/.github/workflows/playtest.yml
@@ -12,9 +12,36 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
+
+# A force-push storm during review supersedes older runs: cancel them.
+concurrency:
+  group: playtest-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # The slow playtest waits for CodeRabbit (Aaron, 2026-08-22): review back-&-forth
+  # pushes skip it; once the PR carries an APPROVED review, every push runs it - &
+  # after the approval the ops box reruns the skipped run, which re-evaluates this
+  # gate. Pushes to main & manual dispatch always run. NOTE: a skipped required
+  # check counts as satisfied, so the merge discipline stays approval-first,
+  # green-playtest-second, merge-third.
+  approval-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then echo "run=true" >> "$GITHUB_OUTPUT"; exit 0; fi
+          approved=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --jq '[.[] | select(.state=="APPROVED")] | length')
+          if [ "$approved" -gt 0 ]; then echo "run=true" >> "$GITHUB_OUTPUT"; else echo "run=false" >> "$GITHUB_OUTPUT"; echo "Playtest deferred: no approved review yet."; fi
+
   playtest:
+    needs: approval-gate
+    if: needs.approval-gate.outputs.run == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/playtest.yml
+++ b/.github/workflows/playtest.yml
@@ -28,6 +28,8 @@ jobs:
   # green-playtest-second, merge-third.
   approval-gate:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # The reviews API needs it explicitly (CodeRabbit).
     outputs:
       run: ${{ steps.check.outputs.run }}
     steps:
@@ -36,7 +38,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then echo "run=true" >> "$GITHUB_OUTPUT"; exit 0; fi
-          approved=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --jq '[.[] | select(.state=="APPROVED")] | length')
+          # Latest state per reviewer, all pages, dismissals excluded (CodeRabbit): a
+          # stale approval superseded by CHANGES_REQUESTED must not open the gate.
+          approved=$(gh api --paginate --slurp "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" --jq 'add | map(select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")) | group_by(.user.login) | map(last) | map(select(.state=="APPROVED")) | length')
           if [ "$approved" -gt 0 ]; then echo "run=true" >> "$GITHUB_OUTPUT"; else echo "run=false" >> "$GITHUB_OUTPUT"; echo "Playtest deferred: no approved review yet."; fi
 
   playtest:


### PR DESCRIPTION
Aaron's call: the ~6-minute playtest shouldn't burn on every CodeRabbit back-and-forth push. Now:

- **Before approval**: PR pushes run only `run-tests` + CodeRabbit; the playtest job skips via an `approval-gate` job (loudly, in the run log).
- **After approval**: every push playtests; the approval itself is followed by the ops box rerunning the last skipped run, which re-evaluates the gate on the same head SHA.
- **Force-push storms**: a per-PR concurrency group cancels superseded in-flight playtests.
- **Unchanged**: pushes to main and manual dispatch always playtest.

Caveat handled by process: GitHub counts a skipped required check as satisfied, so the merge discipline stays approval-first → green playtest on the final SHA → merge. This PR demonstrates the gate on itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manually triggered playtest runs.
  * Improved pull-request playtest handling by canceling outdated runs.
  * Added an approval requirement before pull-request playtests begin.
  * Allowed non-pull-request playtests to run directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->