### PR TITLE
Playtest: the club phase needs an unpoisoned host, not a pristine one

### DIFF
--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1606,7 +1606,12 @@ public partial class PlaytestDriver : Node
     Assert (Self.SelectedWeapon == SelectedWeapon.Blowgun, "empty blowgun equipped for the club swing (#269)");
     // The clean-target precondition (CodeRabbit): a stray dart in the host would
     // alias the club's damage - fail loudly here rather than flake there.
-    Assert (host.PoisonDarts == 0 && host.Health == host.MaxHealth, $"host is clean & full-health before the club (#316), health {host.Health}, darts {host.PoisonDarts}");
+    // Zero darts is the ONLY real precondition (a poison tick costs what a club
+    // does & would alias the measurement) - the empirical punch-then-club design
+    // measures its own fresh baselines, so earlier phases legitimately splashing
+    // the host (the re-enabled theft & headshot phases can - main went red on a
+    // 140/200 host) must not fail the run.
+    Assert (host.PoisonDarts == 0, $"host is unpoisoned before the club (#316), darts {host.PoisonDarts}");
     Self.Position = host.GlobalPosition + new Vector3 (0.0f, 0.3f, 2.0f);
     await Task.Delay (400);
     AimAt (host.GlobalPosition + Vector3.Up);


### PR DESCRIPTION
Main went red on v0.8.98: the club phase's precondition demanded a full-health host, but the newly re-enabled theft & headshot phases can legitimately splash the host earlier in the run (140/200 observed). The empirical punch-then-club design measures its own fresh baselines, so the only real precondition is zero darts (a poison tick costs exactly a club & would alias the measurement). Driver-only, one assert relaxed.

@coderabbitai approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso