### PR TITLE
Hands hold the weapons - visible grips in first & third person (#351)

### DIFF
--- a/core/players/Player.Hands.cs
+++ b/core/players/Player.Hands.cs
@@ -1,3 +1,4 @@
+using com.forerunnergames.energyshot.weapons;
 using Godot;
 
 namespace com.forerunnergames.energyshot.players;

--- a/core/players/Player.Hands.cs
+++ b/core/players/Player.Hands.cs
@@ -2,10 +2,11 @@ using Godot;
 
 namespace com.forerunnergames.energyshot.players;
 
-// Fists (issues #71 & #82): two big player-colored sphere hands at the bottom screen
-// edges, one left & one right, rendered only while fists are the selected weapon.
-// They bob up & down while moving & throw a boxer-style punch that peers replay only
-// when it actually connects.
+// Fists (issues #71 & #82): two big player-colored sphere hands, one left & one
+// right. They bob up & down while moving & throw a boxer-style punch that peers
+// replay only when it actually connects. With issue #351 the hands stay out for
+// EVERY selected weapon, parked on per-weapon grip points, so first & third
+// person both show the weapon actually held.
 public partial class Player
 {
   [Export] public float HandRadius = 0.22f;
@@ -22,6 +23,27 @@ public partial class Player
   private float _handBobPhase;
   private int ChooseRandomPunchHand() => _rng.Randf() < 0.5f ? 0 : 1;
   private Vector3 HandRestOffset (int hand) => hand == 0 ? LeftHandRestOffset : RightHandRestOffset;
+
+  // Per-weapon grip points, camera-local like the held visuals they hold (issue
+  // #351): trigger + foregrip on the guns, both palms along the blowgun's tube,
+  // frame + pouch on the slingshot, cradling the loaf. Hand 0 is the left. Pure
+  // & static like NextCycleSlot, so the mapping is unit-testable without a scene.
+  public static Vector3 GripOffset (SelectedWeapon weapon, int hand, Vector3 leftRest, Vector3 rightRest) => weapon switch
+  {
+    SelectedWeapon.Laser => hand == 0 ? new Vector3 (0.55f, 0.18f, -1.3f) : new Vector3 (0.42f, 0.12f, -0.95f),
+    SelectedWeapon.Banana => hand == 0 ? new Vector3 (0.52f, -0.38f, -1.1f) : new Vector3 (0.38f, -0.42f, -0.75f),
+    SelectedWeapon.Boomerang => hand == 0 ? leftRest : new Vector3 (0.48f, -0.45f, -0.85f),
+    SelectedWeapon.Slingshot => hand == 0 ? new Vector3 (0.5f, -0.5f, -0.55f) : new Vector3 (0.5f, -0.58f, -0.85f),
+    SelectedWeapon.PaperAirplane => hand == 0 ? leftRest : new Vector3 (0.45f, -0.47f, -0.8f),
+    SelectedWeapon.Bread => hand == 0 ? new Vector3 (0.35f, -0.5f, -0.8f) : new Vector3 (0.55f, -0.5f, -0.8f),
+    SelectedWeapon.Blowgun => hand == 0 ? new Vector3 (0.5f, -0.38f, -0.95f) : new Vector3 (0.5f, -0.4f, -0.65f),
+    _ => hand == 0 ? leftRest : rightRest,
+  };
+
+  private Vector3 HandGripOffset (int hand) => GripOffset (_selectedWeapon, hand, LeftHandRestOffset, RightHandRestOffset);
+
+  // The playtest driver's window into the grip (issue #351).
+  public bool HandsVisible => _hands[0]?.Visible ?? false;
   // The fists follow the chosen body color too (issue #43).
   private void UpdateHandColor() { if (_handsMaterial != null) _handsMaterial.AlbedoColor = new Color (BaseColor, HandAlpha); }
 
@@ -43,20 +65,22 @@ public partial class Player
     return mesh;
   }
 
-  // Hands render only while fists are the selected weapon (issue #82) - except while
-  // dancing, when both hands wave regardless of the selected weapon (issue #103).
+  // The hands are out for every weapon, gripping it (issue #351); dancing waves
+  // them regardless (issue #103). The one exception is our OWN scoped view: the
+  // zoomed sight must stay clear, while other peers still see us holding the tube.
   private void UpdateHandsVisibility()
   {
     foreach (var hand in _hands)
     {
       if (hand == null) continue;
-      hand.Visible = IsFistsSelected || Dancing;
+      hand.Visible = !(IsScoped && IsMultiplayerAuthority());
     }
   }
 
   // Moving bobs the resting hands up & down (issue #82); a hand mid-punch is left alone.
   private void UpdateHandBob (double delta)
   {
+    UpdateHandsVisibility(); // Scoping in & out must hide/show the own hands the same frame (issue #351).
     if (Dancing) return; // The dance owns the hands (issue #103).
     var speed = new Vector2 (Velocity.X, Velocity.Z).Length();
     _handBobPhase += speed * HandBobFrequency * (float)delta;
@@ -67,7 +91,7 @@ public partial class Player
   private void ApplyHandRest (int hand, Vector3 bob)
   {
     if (_hands[hand] == null || _handTweens[hand]?.IsRunning() == true) return;
-    _hands[hand]!.Position = HandRestOffset (hand) + bob;
+    _hands[hand]!.Position = HandGripOffset (hand) + bob;
   }
 
   // Boxer-style swing: the chosen hand visibly shoots forward & back.

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1579,6 +1579,7 @@ public partial class PlaytestDriver : Node
     await Task.Delay (60);
     ReleaseAction ("scope");
     await WaitUntil (() => Self.IsScoped, 10, "right click opened the scope view (#236)");
+    await WaitUntil (() => !Self.HandsVisible, 5, "own hands hide in the scoped view (#351)");
     Assert (Self.ZoomStep == 0, "the scope opens at its first zoom stop (#236)");
     PressAction ("cycle_weapon_next");
     await Task.Delay (60);
@@ -1590,6 +1591,7 @@ public partial class PlaytestDriver : Node
     await Task.Delay (60);
     ReleaseAction ("scope");
     await WaitUntil (() => !Self.IsScoped, 10, "right click closed the scope (#236)");
+    await WaitUntil (() => Self.HandsVisible, 5, "hands return when the scope closes (#351)");
 
     // Poison the parked victim with the loaded dart.
     await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f && victim.PoisonDarts == 0 && victim.Health == victim.MaxHealth, 120, "victim parked & clean for the dart (#236)");
@@ -1709,6 +1711,7 @@ public partial class PlaytestDriver : Node
     await Task.Delay (100);
     ReleaseAction ("weapon_8");
     Assert (Self.SelectedWeapon == SelectedWeapon.Blowgun, "empty blowgun equipped for the club swing (#269)");
+    await WaitUntil (() => Self.HandsVisible, 5, "hands grip the held blowgun (#351)");
     // Sweep the shove zone (the v0.8.102-era red run's lesson): earlier phases
     // scatter ARMED darts around the host park spot, & the calibration punch
     // SHOVES the host (issue #269's 2.5x knockback) onto them - embedded darts
@@ -1785,6 +1788,7 @@ public partial class PlaytestDriver : Node
     await Task.Delay (100);
     ReleaseAction ("weapon_2");
     Assert (Self.SelectedWeapon == SelectedWeapon.Laser && Self.Holds (HeldWeapon.Laser), "laser in hand for the drop phase (#242)");
+    await WaitUntil (() => Self.HandsVisible, 5, "hands grip the held laser (#351)");
     var ahead = ShooterParkSpot + new Vector3 (0.0f, 0.0f, -2.0f);
     AimAt (ahead + Vector3.Up);
     PressAction ("drop");

--- a/tests/unit/HandsTest.cs
+++ b/tests/unit/HandsTest.cs
@@ -1,0 +1,65 @@
+using System;
+using com.forerunnergames.energyshot.players;
+using com.forerunnergames.energyshot.weapons;
+using GdUnit4;
+using Godot;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Hands hold the weapons (issue #351): the per-weapon grip table parks both
+// sphere hands on the held visual, in first & third person alike.
+[TestSuite]
+public class HandsTest
+{
+  private static readonly Vector3 LeftRest = new(-0.55f, -0.45f, -0.85f);
+  private static readonly Vector3 RightRest = new(0.55f, -0.45f, -0.85f);
+
+  [TestCase]
+  public void FistsKeepBothHandsAtRest()
+  {
+    AssertObject (Player.GripOffset (SelectedWeapon.Fists, 0, LeftRest, RightRest)).IsEqual (LeftRest);
+    AssertObject (Player.GripOffset (SelectedWeapon.Fists, 1, LeftRest, RightRest)).IsEqual (RightRest);
+  }
+
+  [TestCase]
+  public void TwoHandedWeaponsMoveBothHandsOffRest()
+  {
+    foreach (var weapon in new[] { SelectedWeapon.Laser, SelectedWeapon.Banana, SelectedWeapon.Slingshot, SelectedWeapon.Bread, SelectedWeapon.Blowgun })
+    {
+      AssertObject (Player.GripOffset (weapon, 0, LeftRest, RightRest)).IsNotEqual (LeftRest);
+      AssertObject (Player.GripOffset (weapon, 1, LeftRest, RightRest)).IsNotEqual (RightRest);
+    }
+  }
+
+  [TestCase]
+  public void OneHandedWeaponsGripWithTheRightHandOnly()
+  {
+    foreach (var weapon in new[] { SelectedWeapon.Boomerang, SelectedWeapon.PaperAirplane })
+    {
+      AssertObject (Player.GripOffset (weapon, 0, LeftRest, RightRest)).IsEqual (LeftRest);
+      AssertObject (Player.GripOffset (weapon, 1, LeftRest, RightRest)).IsNotEqual (RightRest);
+    }
+  }
+
+  [TestCase]
+  public void EveryWeaponsGrippingHandIsInFrontOfTheCamera()
+  {
+    // Camera-local -Z is forward: a grip behind the camera would be invisible.
+    foreach (SelectedWeapon weapon in Enum.GetValues <SelectedWeapon>())
+    {
+      AssertFloat (Player.GripOffset (weapon, 0, LeftRest, RightRest).Z).IsLess (0.0f);
+      AssertFloat (Player.GripOffset (weapon, 1, LeftRest, RightRest).Z).IsLess (0.0f);
+    }
+  }
+
+  [TestCase]
+  public void GripsAreDistinctPerWeapon()
+  {
+    // The right (gripping) hand must sit somewhere unique per weapon - identical
+    // grips would mean a copy-paste row in the table.
+    var seen = new System.Collections.Generic.HashSet <Vector3>();
+    foreach (var weapon in new[] { SelectedWeapon.Laser, SelectedWeapon.Banana, SelectedWeapon.Boomerang, SelectedWeapon.Slingshot, SelectedWeapon.PaperAirplane, SelectedWeapon.Bread, SelectedWeapon.Blowgun })
+      AssertBool (seen.Add (Player.GripOffset (weapon, 1, LeftRest, RightRest))).IsTrue();
+  }
+}


### PR DESCRIPTION
The other half of the heads ruling: *"we want to see hands holding the weapons, in first and third person view."* (#351)

- The two player-colored sphere hands no longer vanish when a weapon is selected: they park on **per-weapon grip points** - trigger + foregrip on the laser & banana launcher, both palms along the blowgun's tube, frame + pouch on the slingshot, cradling the loaf; boomerang & paper airplane are one-handed (off hand rests).
- Both views come free: the hands are camera-children replicated on every peer, so first & third person show the same grip.
- The grip table is a pure static (`Player.GripOffset`, the `NextCycleSlot` precedent) - unit-tested for shape: fists rest, two-handed weapons move both hands, one-handed grip right-only, every grip in front of the camera, no copy-paste rows.
- Own-view exception: while SCOPED the own hands hide so the zoomed sight stays clear - peers still see the tube held. Visibility refreshes every frame, so scoping in & out is instant.
- Bob, dance override, punch animation, overlay material (#124), & color tint (#43) all carry over untouched.

Playtest coverage: grips asserted on the held laser (drop phase) & blowgun (club phase); the scope section proves the own-view hide & return.

Grip offsets are first-pass numbers, exported-adjacent & trivially tunable - visual fine-tuning lands after Aaron sees them in game. Verification is CI's - this box can't build or run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso