### PR TITLE
Recoil re-lands as a camera offset - bursts climb, recovery never drags the aim (#237)

### DIFF
--- a/core/players/Player.Banana.cs
+++ b/core/players/Player.Banana.cs
@@ -45,8 +45,7 @@ public partial class Player
   private void ApplyBananaFiringFeel (Vector3 aimDirection)
   {
     Velocity -= aimDirection * BananaShooterKnockbackSpeed;
-    _camera.RotateX (BananaRecoilRadians);
-    _cameraKickRemaining += BananaRecoilRadians;
+    Kick (BananaRecoilRadians); // The same accumulating ledger as the laser (issue #237).
     AnimateLauncherRecoil();
   }
 

--- a/core/players/Player.Combat.cs
+++ b/core/players/Player.Combat.cs
@@ -183,12 +183,29 @@ public partial class Player
     EmitSignal (SignalName.HealthChanged, Health);
   }
 
+  private ulong _lastKickMs;
+
+  // The recoil ledger, pure for the unit tests (issue #237): one shot's climb,
+  // capped so a long burst can't wrap you into the sky; & the per-shot kick size.
+  public static float NextRecoil (float current, float kick, float max) => Mathf.Min (current + Mathf.Max (0.0f, kick), max);
+  public static float ShotKick (bool isFullAuto, float energy, float fullAutoKick, float tapFloor, float perEnergy) => isFullAuto ? fullAutoKick : Mathf.Max (tapFloor, energy * perEnergy);
+
+  // Recovery waits out a short pause after the last shot, so a burst climbs
+  // instead of jolting & snapping back between rounds; then it settles fast. Only
+  // the OFFSET decays - the aim accumulator is never touched (the #309 lesson).
   private void UpdateCameraKick (double delta)
   {
-    if (_cameraKickRemaining <= 0.0f) return;
-    var recover = Mathf.Min (_cameraKickRemaining, CameraKickRecoverySpeed * (float)delta);
-    SetCameraPitch (_cameraPitch - recover); // Through the one writer (issue #322).
-    _cameraKickRemaining -= recover;
+    if (_recoilPitch <= 0.0f) return;
+    if (Time.GetTicksMsec() - _lastKickMs < (ulong)(RecoilRecoveryDelaySeconds * 1000.0f)) return;
+    _recoilPitch = Mathf.Max (0.0f, _recoilPitch - CameraKickRecoverySpeed * (float)delta);
+    ApplyCameraRotation();
+  }
+
+  private void Kick (float radians)
+  {
+    _recoilPitch = NextRecoil (_recoilPitch, radians, MaxRecoilRadians);
+    _lastKickMs = Time.GetTicksMsec();
+    ApplyCameraRotation();
   }
 
   private void OnWeaponShotFired (float energy, bool isFullAuto)
@@ -196,9 +213,7 @@ public partial class Player
     CancelSpawnArmorIfFired();
     // Aim direction is captured before the camera kick so the kick is purely visual.
     var direction = ShotDirection(); // Converged in third person (issue #338).
-    var kick = energy * CameraKickRadians;
-    SetCameraPitch (_cameraPitch + kick); // Through the one writer (issue #322).
-    _cameraKickRemaining += kick;
+    Kick (ShotKick (isFullAuto, energy, FullAutoKickRadians, LaserTapKickMinRadians, CameraKickRadians)); // Issue #237.
     TryRocketBoost (direction, energy);
     var sweepStart = _camera.GlobalPosition;
     var origin = sweepStart + direction * MuzzleOffsetMeters;

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -217,7 +217,18 @@ public partial class Player : CharacterBody3D
   // 200 damage: one-hit-kills an Expert, bypassing the survivable clamp (issue #83).
   [Export] public float StickyBananaEnergy = 2.0f;
   [Export] public float CameraKickRadians = 0.06f;
-  [Export] public float CameraKickRecoverySpeed = 0.4f;
+  // The recoil model (issue #237, re-landed after the #309 revert): every gun
+  // climbs the crosshair & the climb ACCUMULATES while you keep firing - recovery
+  // begins only after a pause. A laser tap has a floor so a quick shot still
+  // kicks; full-auto kicks small per shot but twenty of them stack; the banana
+  // launcher's big kick rides the same ledger. The climb lives in _recoilPitch, a
+  // decaying OFFSET summed by the one camera writer - it NEVER touches the aim
+  // accumulator, so recovery can't drag a set aim off target (the #309 miss).
+  [Export] public float LaserTapKickMinRadians = 0.03f;
+  [Export] public float FullAutoKickRadians = 0.014f;
+  [Export] public float MaxRecoilRadians = 0.5f;
+  [Export] public float RecoilRecoveryDelaySeconds = 0.3f;
+  [Export] public float CameraKickRecoverySpeed = 1.2f;
   [Export] public float Speed = 7.0f;
   [Export] public float SlideSpeedMultiplier = 2.0f;
   // 7s -> 3.5s (issue #148, reversing the earlier lengthening): the duration cap is
@@ -304,7 +315,8 @@ public partial class Player : CharacterBody3D
   private float _fullAutoCooldownLeft;
   private float _nextAutoShotIn;
   private float _punchCooldownLeft;
-  private float _cameraKickRemaining;
+  private float _recoilPitch;
+  public float RecoilPitch => _recoilPitch; // The playtest driver watches the climb & the settle (issue #237).
   private AudioStreamPlayer _punchSound = null!;
   private AudioStreamPlayer _punchWhiffSound = null!;
   private AudioStreamPlayer _punchThudSound = null!;
@@ -512,6 +524,6 @@ public partial class Player : CharacterBody3D
   private void ApplyCameraRotation()
   {
     var maxUp = _thirdPerson ? Mathf.DegToRad (ThirdPersonMaxPitchUpDegrees) : PitchLimitRadians;
-    _camera.Rotation = new Vector3 (Mathf.Clamp (_cameraPitch + _swayPitch, -PitchLimitRadians, maxUp), _swayYaw, 0.0f);
+    _camera.Rotation = new Vector3 (Mathf.Clamp (_cameraPitch + _swayPitch + _recoilPitch, -PitchLimitRadians, maxUp), _swayYaw, 0.0f);
   }
 }

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -104,6 +104,10 @@ Press Esc for the pause dialog, then **SETTINGS**: hold-to-crouch, hold-to-scope
 
 Dropping more than about 10 m hurts: 5 health per extra metre, never an instant zap-out. The respawn drop-in from the spawn room is free while your spawn armor is up; stay up there dithering and the 30 m trip costs you.
 
+## Recoil
+
+Every gun climbs your crosshair when it fires, and the climb stacks while you keep firing - recovery only starts after a short pause, then your view settles back to where you were aiming. A quick laser tap kicks a little, a full-auto burst walks the crosshair up over the burst, the banana launcher kicks hard. The slingshot, the boomerang and the blowgun don't kick.
+
 ## Good to know
 
 - White glow = spawn armor (5s of invulnerability after spawning; firing or punching cancels it).

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -475,14 +475,18 @@ public partial class PlaytestDriver : Node
 
     // Full-auto: after cooldown, ability + held trigger must fire a burst of bolts.
     await Task.Delay (1200);
+    Assert (Self.RecoilPitch == 0.0f, $"the spam taps' recoil settled before the burst (#237), offset {Self.RecoilPitch}");
     boltsBefore = _boltsSpawned;
     PressAction ("ability");
     await Task.Delay (50);
     ReleaseAction ("ability");
     PressAction ("shoot");
     await Task.Delay (1300);
+    Assert (Self.RecoilPitch > Self.LaserTapKickMinRadians, $"the burst's recoil ACCUMULATED past a single tap (#237), offset {Self.RecoilPitch}");
+    Assert (Self.RecoilPitch <= Self.MaxRecoilRadians, $"the burst's recoil stayed under the cap (#237), offset {Self.RecoilPitch}");
     ReleaseAction ("shoot");
     Assert (_boltsSpawned - boltsBefore >= 3, $"full-auto fired a burst, got {_boltsSpawned - boltsBefore} bolts");
+    await WaitUntil (() => Self.RecoilPitch == 0.0f, 5, "recoil recovered fully after the burst paused (#237)");
 
     // Slide cancels (#131): with the slide key still held (simulating a wedged
     // pressed state), switch weapons mid-slide, then press crouch - the crouch must

--- a/tests/unit/RecoilTest.cs
+++ b/tests/unit/RecoilTest.cs
@@ -1,0 +1,59 @@
+using com.forerunnergames.energyshot.players;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// The recoil model (issue #237, re-landed after the #309 revert): a tap kicks at
+// least its floor, full-auto stacks small kicks across a burst, & the ledger caps
+// so a long burst can't wrap the view into the sky.
+[TestSuite]
+public class RecoilTest
+{
+  private const float TapFloor = 0.03f;
+  private const float FullAutoKick = 0.014f;
+  private const float PerEnergy = 0.06f;
+  private const float Max = 0.5f;
+
+  [TestCase]
+  public void AQuickTapKicksAtLeastTheFloor()
+  {
+    AssertFloat (Player.ShotKick (isFullAuto: false, energy: 0.1f, FullAutoKick, TapFloor, PerEnergy)).IsEqual (TapFloor);
+  }
+
+  [TestCase]
+  public void AChargedShotKicksByItsEnergy()
+  {
+    AssertFloat (Player.ShotKick (isFullAuto: false, energy: 1.0f, FullAutoKick, TapFloor, PerEnergy)).IsEqual (PerEnergy);
+  }
+
+  [TestCase]
+  public void ATwentyRoundBurstClimbsWellPastATapButUnderTheCap()
+  {
+    var recoil = 0.0f;
+    for (var shot = 0; shot < 20; ++shot) recoil = Player.NextRecoil (recoil, Player.ShotKick (isFullAuto: true, energy: 0.1f, FullAutoKick, TapFloor, PerEnergy), Max);
+    AssertFloat (recoil).IsGreater (TapFloor * 2.0f);
+    AssertFloat (recoil).IsLessEqual (Max);
+  }
+
+  [TestCase]
+  public void TheLedgerCapsNoMatterHowLongTheBurst()
+  {
+    var recoil = 0.0f;
+    for (var shot = 0; shot < 1000; ++shot) recoil = Player.NextRecoil (recoil, FullAutoKick, Max);
+    AssertFloat (recoil).IsEqual (Max);
+  }
+
+  [TestCase]
+  public void TheBananaKickFitsUnderTheCap()
+  {
+    var player = AutoFree (new Player())!;
+    AssertFloat (Player.NextRecoil (0.0f, player.BananaRecoilRadians, player.MaxRecoilRadians)).IsLess (player.MaxRecoilRadians);
+  }
+
+  [TestCase]
+  public void ANegativeKickNeverLowersTheLedger()
+  {
+    AssertFloat (Player.NextRecoil (0.2f, -1.0f, Max)).IsEqual (0.2f);
+  }
+}


### PR DESCRIPTION
Re-land of the reverted #268, with the #309 miss diagnosed & designed out:

**The diagnosis.** The old kick & recovery mutated the aim accumulator itself (`SetCameraPitch`) - so after the driver (or any player) set an exact aim, the pending recovery dragged the view off target between shots. Main went red with 9 partial hits where the full-charge one-hit kill belonged.

**The fix by construction.** The climb now lives in `_recoilPitch`, a decaying OFFSET summed by the one camera writer (#322) alongside the scope sway. It never touches `_cameraPitch`, so recovery converges the view back to the player's true aim & can never corrupt a set aim. Follow-up shots still fire where the crosshair points (the offset is in the camera basis), so a burst genuinely walks up - exactly Caleb's ask.

**The model** returns unchanged from #268: tap floor 0.03 rad, full-auto 0.014 rad/shot stacking, recovery waits 0.3s then settles at 1.2 rad/s, ledger cap 0.5 rad; banana launcher rides the same ledger (its old raw `RotateX` was dead code under the one-writer model); slingshot, boomerang & blowgun kick nothing. All exports.

**Proof:** `NextRecoil`/`ShotKick` are pure statics with unit tests (floor, energy scale, burst climb, cap, banana fit, negative-kick guard); the existing full-auto playtest phase now asserts settle-before-burst, accumulated climb, the cap, & full recovery - a REAL pre-merge playtest this time, per the #309 checklist.

Controls doc regains its Recoil section. Verification is CI's - this box can't build or run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso