### PR TITLE
Playtest: hard process exit after the verdict - no more teardown aborts (#354)

### DIFF
--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -128,7 +128,7 @@ public partial class PlaytestDriver : Node
       // is unbuffered - it's why FAIL lines always land - so PASS echoes there too.
       GD.PrintErr ($"PLAYTEST PASS [{_role}]");
       await Task.Delay (500); // Let final packets flush before quitting.
-      GetTree().Quit (0);
+      HardExit (0);
     }
     catch (Exception e)
     {
@@ -139,8 +139,14 @@ public partial class PlaytestDriver : Node
   private void Fail (string reason)
   {
     GD.PrintErr ($"PLAYTEST FAIL [{_role}]: {reason}");
-    GetTree().Quit (1);
+    HardExit (1);
   }
+
+  // The verdict is printed & flushed: exit the PROCESS before Godot's engine
+  // teardown runs (issue #354) - the mono finalizer race there aborts with exit
+  // 134 & turns fully-green runs red. The verdict lines are the source of truth
+  // & the harness's verify_log still proves the run actually happened.
+  private static void HardExit (int code) => System.Environment.Exit (code);
 
   // ---------------------------------------------------------------- roles
 


### PR DESCRIPTION
Closes #354. Twice today (#350's & #353's final runs) an instance completed every phase, printed PLAYTEST PASS, then SIGABRTed inside Godot's engine teardown (mono finalizer race, 'Leaked unsafe reference' spam, exit 134) - & the harness rightly failed the run on the nonzero exit.

The verdict rides both streams & flushes 500ms before quitting (the #140-era hardening), so it is already the source of truth by quit time. The driver now calls `Environment.Exit` there instead of `GetTree().Quit`: the process ends before the leaky teardown can run, on both the PASS & FAIL paths. `verify_log` still proves each role actually ran.

Driver-only change. Verification is CI's - this box can't run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playtest runs now terminate reliably with the appropriate success or failure status.
  * Improved process exit handling for automated playtest completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->