### PR TITLE
Playtest: verdicts ride .NET's Console - the hard exit starved the Godot logger

### DIFF
--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -127,6 +127,12 @@ public partial class PlaytestDriver : Node
       // stdout tail vanished at quit & the run failed as 'never finished'): stderr
       // is unbuffered - it's why FAIL lines always land - so PASS echoes there too.
       GD.PrintErr ($"PLAYTEST PASS [{_role}]");
+      // AND through .NET's own Console (v0.8.108's lesson): the hard exit skips
+      // Godot's logger flush, so GD-printed verdicts died in the buffer & every
+      // run failed as 'no PASS marker'. Console.Out/Error auto-flush per line &
+      // write the process fds directly - immune to the logger & the teardown.
+      System.Console.WriteLine ($"PLAYTEST PASS [{_role}]");
+      System.Console.Error.WriteLine ($"PLAYTEST PASS [{_role}]");
       await Task.Delay (500); // Let final packets flush before quitting.
       HardExit (0);
     }
@@ -139,6 +145,7 @@ public partial class PlaytestDriver : Node
   private void Fail (string reason)
   {
     GD.PrintErr ($"PLAYTEST FAIL [{_role}]: {reason}");
+    System.Console.Error.WriteLine ($"PLAYTEST FAIL [{_role}]: {reason}"); // Past the Godot logger (v0.8.108's lesson).
     HardExit (1);
   }
 


### PR DESCRIPTION
Urgent fix-forward for v0.8.108 (#355): the hard process exit fixed the teardown aborts but ALSO skips Godot's logger flush - GD-printed verdict lines die in the buffer, so every playtest since fails as **'no PASS marker - the role never finished'** (#356's red run is this, & main's next post-merge run will be too).

The verdict now ALSO prints through .NET's `Console.Out`/`Console.Error`, which auto-flush per line & write the process file descriptors directly - immune to the Godot logger's buffering & to the teardown, & exactly what `verify_log` greps for. The GD prints stay for in-engine visibility.

Driver-only, tiny. Verification is CI's - this box can't run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso