### PR TITLE
Playtest coverage matrix: every weapon x mode audited against the driver (#316)

### DIFF
--- a/docs/PLAYTEST-COVERAGE.md
+++ b/docs/PLAYTEST-COVERAGE.md
@@ -1,0 +1,156 @@
+# Playtest coverage matrix (issue #316)
+
+Every weapon x every mode it supports, mapped onto the CI playtest driver's actual
+asserts (`tests/playtest/PlaytestDriver.cs`). Hand-audited at v0.8.112; **kept
+current per feature PR** - a new weapon or mode lands with its row/cells updated
+in the same PR (the feature-tests-required rule).
+
+Legend: ✅ covered (a driver assert proves it) · 🟡 partial (some of the cell is
+proven, the named remainder is not) · ❌ missing (no driver assert; unit tests
+alone don't count as playtest coverage) · — n/a (the weapon has no such mode).
+Evidence cells quote the assert's issue refs.
+
+## Fists
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned / loose / projectile | — | Fists are never a pickup |
+| equipped firing (punch) | ✅ | calibration punch (#269), theft punch (#193), punch-cancels-eat (#192), wall self-damage is unit-tested |
+| punch theft | ✅ | direct steal & the already-holding fly-out (#193) |
+| punch knockback | ❌ | The 2.5x shove (#335) moves bodies in other phases' logs but no assert measures it |
+| punch stun & cooldown | ❌ | Stacking slow (#68/#71) & the punch cooldown gate are unasserted |
+| blunt hit | ✅ | The punch IS the fists' blunt; club comparisons calibrate against it (#269) |
+
+## Laser
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned | ✅ | spot restock (#72), pickup auto-equip (#128) |
+| loose safe | ✅ | X-drop tossed pickup (#242), slung laser re-lands as pickup (#190) |
+| loose armed | — | A grounded laser is never dangerous |
+| projectile (bolt) | ✅ | bolt lands on the victim (#179), headshot exact-damage (#179) |
+| equipped charging / charged | 🟡 | Full-charge one-hit kill is asserted (#93, the assert that caught the #268 recoil break); the charge LADDER (partial-charge damage scaling #67) is not |
+| equipped firing | ✅ | fire-rate cap under spam, full-auto burst (#218), recoil climb & settle (#237/#351-era asserts) |
+| equipped cooldown | ✅ | full-auto long cooldown (#299), respawn resets every cooldown (#299) |
+| as slingshot ammo | ✅ | walk-load, slingshot-emptying shot, slung spray re-land (#190) |
+| blunt | — | No club mode |
+
+## Banana launcher
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned | ✅ | playtest banana collected pre-kill (#169) |
+| loose safe | ✅ | victim's dropped banana claimable at the death spot (#169) |
+| projectile (lobbed banana) | ❌ | No assert fires the launcher & proves the arc, the splat, or the blast |
+| sticky banana & fuse | ❌ | The sticky fuse & delayed blast (#83) are unasserted |
+| survivable-at-full-health blast | ❌ | The never-one-shots rule (#61) is unasserted in the driver |
+| banana-grenade catch | ❌ | The drawn-slingshot catch with the fuse ticking (#251, shipped v0.8.78) is unit-tested (BananaCatchTest) but has no driver phase |
+| equipped firing feel | 🟡 | The launcher kick rides the recoil ledger (#237, unit-tested); the shooter knockback shove is unasserted |
+| blunt | — | No club mode |
+
+## Boomerang
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned | ✅ | pickup collected, slot 4 select (#98) |
+| loose safe | ✅ | nocked boomerang drops as its OWN pickup at the death spot (#212) |
+| projectile (throw & return) | ✅ | thrown, returned & auto-caught (#98) |
+| steal-on-hit | ❌ | The victim's held-item theft on a boomerang clip (#98/#106) is unasserted |
+| as slingshot ammo | ✅ | nocked in the slingshot pre-kill, escrow drop (#212) |
+| equipped cooldown | ❌ | The one-out-at-a-time gate is unasserted |
+| blunt | — | No club mode |
+
+## Slingshot
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned | ✅ | pickup collect & auto-equip (#99, #128) |
+| loose safe | ✅ | drops at the death spot (#212), respawn auto-claim ditch (#128) |
+| equipped empty | ✅ | starts empty (#190), open-empty pouch is the armed-pickup loader (#286/#325) |
+| equipped loaded | ✅ | laser load (#190), boomerang nock (#212), ARMED airplane load with fuse-window proof (#286/#325) |
+| equipped charging (draw) | 🟡 | draw & release fires (#99); the full-draw LOCK-IN cue & tremble are #288 (pending feature - lands with its cells) |
+| stone projectile | ✅ | long-flight & wall-stop stones (#163), full-draw stone flies 4s |
+| slung-gun ammo spray | ❌ | Every slung gun sprays its own ammo (#229/#270) - shipped, unasserted |
+| equipped cooldown | 🟡 | respawn reset covers it generically (#299); no slingshot-specific gate assert |
+| blunt | — | No club mode |
+
+## Paper airplane
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned | ✅ | exactly-one census & restock (#102/#191) |
+| loose safe (landed from a throw) | ✅ | landed airplane becomes a grounded pickup (#102) |
+| loose armed (come-down mine) | ✅ | come-down is ARMED (#191), warning ring raise/pin/clear (#191), fuse ignite, burn ticks, pop, fire-out (#191) |
+| projectile (glide) | 🟡 | thrown & replicated as a flying copy (#102); the homing lock (#191 targeting) is exercised (the mine-phase lane exists because gliders home) but never asserted directly |
+| punch-catch | ✅ | catch confirmed by signal, catcher never ignites, warning clears (#102/#191) |
+| as slingshot ammo (armed!) | ✅ | the OPEN slingshot loads the ARMED airplane, no detonation through the fuse window (#286/#325) |
+| equipped | ✅ | slot 6 select (#102), equip for the mine-load phase (#325) |
+| blunt | — | No club mode |
+
+## Bread
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned (per-life loaf) | ✅ | spawn carry, per-life restock (#62/#190) |
+| loose safe | ✅ | uneaten loaf drops at the death spot (#190) |
+| equipped | ✅ | own slot select, emptied slot falls back to fists (#209) |
+| the eat ritual | ✅ | full-stop precondition, three-second ritual, no input escapes, completion consumes & heals (#192/#190) |
+| eat interrupts | ✅ | punch cancels (attacker & victim sides), interrupted loaf wasted, rejected attempt costs nothing (#192) |
+| theft target | ✅ | the loaf is the canonical theft item (#193) |
+| as slingshot ammo (slung crumbs) | ❌ | Slung bread plasters the victim in crumbs - shipped, unasserted |
+| blunt | — | No club mode |
+
+## Blowgun
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned | ✅ | auto-equip into slot 8 (#128/#236), starts EMPTY (#236) |
+| loose safe | ✅ | X-drop rests as a pickup, chase-park re-collect (#242/#316) |
+| equipped empty | ✅ | fires nothing (#236), IS the club (#269) |
+| equipped loaded | ✅ | floating-dart walk-load, fixture reload (#236) |
+| equipped firing | ✅ | firing spends a dart (#236), dart sticks & count replicates (#194/#236) |
+| equipped cooldown | 🟡 | club-phase retries exist BECAUSE of the fire cooldown; no direct gate assert |
+| scope | ✅ | open/close, zoom ladder step, cycling suspended, reticle drift, own-hands hide (#236/#351) |
+| blunt swing & hit | ✅ | club == exactly 2x the observed punch, gun never leaves the hands (#269) |
+| drop scatter | ✅ | losing the blowgun returns its darts to the level (#236) |
+
+## Poison darts (sub-item)
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| spawned (floating, unarmed) | ✅ | floating dart is blowgun ammo on walk-over (#236); hover height is unit-tested (#340) |
+| loose armed (landed) | ✅ | floor hit lands ARMED (#236/#248), bystander-aware step phase (#248/#316) |
+| embed & poison | ✅ | stick & replicate (#194), 10% tick with exact number (#194/#236), armor shrugs it off (#48 waits) |
+| scatter on death | ✅ | dart scatter observed & asserted via the litter phases (#236) |
+| drunk-walk, inverted steer, green vignette | ❌ | Poison's movement effects (#261/#277) are unit-tested (PoisonSteer) but have no driver assert |
+
+## Banana chunks (sub-item)
+
+| Mode | Status | Evidence / gap |
+|---|---|---|
+| all modes | ❌ | The chunk lifecycle (#284-#287 family) has no driver asserts at all - the emptiest row in the matrix |
+
+## Cross-mechanic combos (the crazy-combinations doctrine)
+
+Shipped combos with asserts: armed-airplane-into-open-pouch (#286/#325), punch-catch
+of a wild airplane mid-flight (#102/#274), theft-during-eat (#192/#193), club on a
+poisoned-then-cured host (#269/#316).
+
+Queued combos, unasserted (each becomes a phase when its cell's weapon PR lands):
+
+- A slung banana gun fired AT a jumping player must HIT them, not be picked up (Aaron's canonical example).
+- Punch-catching an airplane while poisoned (wobble aim vs the 4m catch window).
+- Scoped blowgun shot at a sliding player.
+- Full-auto burst while riding a ring-rope bounce (recoil + rally physics).
+- Eating bread inside the KOTH ring while under dart fire.
+
+## Gap queue (risk-ordered, one weapon per PR, per the #316 plan)
+
+1. **Banana launcher** - the emptiest real-weapon row: lob arc, sticky fuse, survivable blast, grenade catch.
+2. **Slingshot spray & Bread crumbs** - the slung-gun ammo spray family (#229/#270), shipped but never proven.
+3. **Boomerang steal-on-hit & cooldown** (#98/#106).
+4. **Laser charge ladder** (#67).
+5. **Fists knockback, stun & cooldown** (#68/#71/#335).
+6. **Poison movement effects** (#261/#277).
+7. **Banana chunks** (#284-#287) - lands with that epic.
+8. **Combo phases** - one per queued combo above.


### PR DESCRIPTION
The #316 plan's step 1, the audit PR: `docs/PLAYTEST-COVERAGE.md` maps every weapon x mode cell onto the driver assert that proves it - ✅ covered / 🟡 partial (with the named remainder) / ❌ missing / — n/a - hand-audited at v0.8.112 from the driver's ~209 assert strings plus the interpolated damage/charge asserts.

Highlights of the audit:

- **Banana launcher is the emptiest real-weapon row**: lob, sticky fuse, survivable blast & the grenade catch are all driver-unproven (the catch has only a unit test).
- The slung-gun ammo spray family (#229/#270) & slung-bread crumbs shipped without asserts.
- Blowgun & paper airplane are the strongest rows (this week's flake war paid for them).
- The queued cross-mechanic combos are listed, starting with Aaron's canonical slung-banana-vs-jumping-player.
- Risk-ordered gap queue matches the #316 plan: one weapon per PR, each cell's phase asserting EVIDENCE, merged only on a real green.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso