### PR TITLE
Playtest: the catch's shooter-side signal is the draw releasing, not the pouch

### DIFF
--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1494,8 +1494,14 @@ public partial class PlaytestDriver : Node
     PressLeftClick();
     await Task.Delay (60);
     ReleaseLeftClick();
-    await WaitUntil (() => victim.SlingshotAmmo == HeldWeapon.BananaGrenade, 15, "the drawn slingshot caught the live banana (#251)");
-    await WaitUntil (() => victim.SlingshotAmmo == HeldWeapon.None, 15, "the hot potato left the victim's pouch (#251)");
+    // The DURABLE signal, not the transient pouch (main's v0.8.114 red: the victim
+    // caught & threw back inside one sync interval - 1.2s fuse - so the shooter's
+    // replica never saw BananaGrenade at all). The victim holds its draw until a
+    // successful catch & releases ONLY then: the draw dropping is the catch, & the
+    // victim's own authoritative asserts still prove the pouch states.
+    await WaitUntil (() => !victim.DrawingSlingshot, 20, "the victim's draw released - it caught & threw the banana back (#251)");
+    await Task.Delay (2500); // Their fired grenade pops far away.
+    Assert (!victim.Fallen, "the catcher lived through the whole exchange (#251)");
     Self.Position = ShooterParkSpot;
     await Task.Delay (300);
   }


### PR DESCRIPTION
Fix-forward for main's v0.8.114 red: the victim CAUGHT the lobbed banana (its log prints '1.2s on the fuse' & every victim-side assert passed) but fired it back out within one replication interval - the transient `BananaGrenade` pouch state never reached the shooter's replica, so the shooter's wait starved & timed out.

The victim holds its slingshot draw until a successful catch & releases ONLY then, so the replicated `DrawingSlingshot` dropping is the durable shooter-side signal. The victim's own authoritative asserts still prove the pouch states (nock, fire-out, survival) end to end; the shooter now confirms the release & that the catcher lived.

Driver-only. Verification is CI's - this box can't run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso