### PR TITLE
Playtest: the slung laser provably sprays bolts mid-flight (#316)

### DIFF
--- a/docs/PLAYTEST-COVERAGE.md
+++ b/docs/PLAYTEST-COVERAGE.md
@@ -70,7 +70,7 @@ Evidence cells quote the assert's issue refs.
 | equipped loaded | ✅ | laser load (#190), boomerang nock (#212), ARMED airplane load with fuse-window proof (#286/#325) |
 | equipped charging (draw) | 🟡 | draw & release fires (#99); the full-draw LOCK-IN cue & tremble are #288 (pending feature - lands with its cells) |
 | stone projectile | ✅ | long-flight & wall-stop stones (#163), full-draw stone flies 4s |
-| slung-gun ammo spray | ❌ | Every slung gun sprays its own ammo (#229/#270) - shipped, unasserted |
+| slung-gun ammo spray | 🟡 | the slung LASER provably sprays bolts mid-flight (#208/#244); the launcher lob & stone spree remain unasserted |
 | equipped cooldown | 🟡 | respawn reset covers it generically (#299); no slingshot-specific gate assert |
 | blunt | — | No club mode |
 
@@ -146,7 +146,7 @@ Queued combos, unasserted (each becomes a phase when its cell's weapon PR lands)
 
 ## Gap queue (risk-ordered, one weapon per PR, per the #316 plan)
 
-1. **Slingshot spray & Bread crumbs** - the slung-gun ammo spray family (#229/#270), shipped but never proven.
+1. **Slung launcher-lob & stone sprees, & Bread crumbs** - the laser spray is proven; the rest of the slung family (#229/#270) is not.
 2. **Boomerang steal-on-hit & cooldown** (#98/#106).
 3. **Laser charge ladder** (#67).
 4. **Fists knockback, stun & cooldown** (#68/#71/#335).

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1078,6 +1078,7 @@ public partial class PlaytestDriver : Node
     AimAt (Self.GlobalPosition + new Vector3 (0.0f, -1.0f, -6.0f));
     var lasersBefore = LaserPickupNames();
     var ammoStonesBefore = _stonesSpawned;
+    var boltsBeforeSling = _boltsSpawned;
     // A soft lob, NOT a full draw (issue #272): now that the draw is engine-time
     // honest, a 900ms draw punches the stone clean through the paper-thin spawn-room
     // slab & it falls off-world - the server correctly skips the landing ("no ground
@@ -1085,6 +1086,9 @@ public partial class PlaytestDriver : Node
     await SlingAStone (drawMs: 300, "loaded-ammo shot (#190)");
     Assert (_stonesSpawned > ammoStonesBefore, "fired the loaded laser out of the slingshot (#190)");
     await WaitUntil (() => Self.SlingshotAmmo == HeldWeapon.None, 10, "firing emptied the slingshot (#190)");
+    // The spray itself (#208/#244, the matrix gap): a slung laser goes berserk in
+    // flight - real bolt nodes enter the tree & the monotonic counter proves it.
+    await WaitUntil (() => _boltsSpawned > boltsBeforeSling, 10, "the slung laser sprayed bolts as it tumbled (#208/#244)");
     // Nothing may vanish: the slung laser has to come back as an ordinary pickup.
     // Capture the name INSIDE the wait (CodeRabbit): re-querying afterwards could
     // find the pickup already claimed or expired & throw an opaque First() instead


### PR DESCRIPTION
The next #316 matrix gap, taken with one assert in the right place: the existing #190 slung-laser step now records the monotonic LaserBolt counter before the sling & waits for it to grow - real bolt nodes entering the tree prove the mid-flight spray (#208/#244), with no timing race.

Matrix updated honestly to 🟡: the slung LAUNCHER's banana lobs & the slung SLINGSHOT's stone spree remain unasserted (they need their own aim-and-observe setups; queued).

Driver + matrix only. Verification is CI's - this box can't run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso