### PR TITLE
Playtest: the slung loaf hits like a punch - the bread row completes (#316)

### DIFF
--- a/docs/PLAYTEST-COVERAGE.md
+++ b/docs/PLAYTEST-COVERAGE.md
@@ -97,7 +97,7 @@ Evidence cells quote the assert's issue refs.
 | the eat ritual | ✅ | full-stop precondition, three-second ritual, no input escapes, completion consumes & heals (#192/#190) |
 | eat interrupts | ✅ | punch cancels (attacker & victim sides), interrupted loaf wasted, rejected attempt costs nothing (#192) |
 | theft target | ✅ | the loaf is the canonical theft item (#193) |
-| as slingshot ammo (slung loaf) | ✅ | the pouch loads the X-dropped loaf & the slung hit lands like a punch, never a zap (#190/#229/#247) |
+| as slingshot ammo (slung loaf) | ✅ | the pouch loads the victim's death-dropped loaf (own loaf blocks the normal collect, #190) & the slung hit lands like a punch, never a zap (#229/#247) |
 | blunt | — | No club mode |
 
 ## Blowgun

--- a/docs/PLAYTEST-COVERAGE.md
+++ b/docs/PLAYTEST-COVERAGE.md
@@ -97,7 +97,7 @@ Evidence cells quote the assert's issue refs.
 | the eat ritual | ✅ | full-stop precondition, three-second ritual, no input escapes, completion consumes & heals (#192/#190) |
 | eat interrupts | ✅ | punch cancels (attacker & victim sides), interrupted loaf wasted, rejected attempt costs nothing (#192) |
 | theft target | ✅ | the loaf is the canonical theft item (#193) |
-| as slingshot ammo (slung crumbs) | ❌ | Slung bread plasters the victim in crumbs - shipped, unasserted |
+| as slingshot ammo (slung loaf) | ✅ | the pouch loads the X-dropped loaf & the slung hit lands like a punch, never a zap (#190/#229/#247) |
 | blunt | — | No club mode |
 
 ## Blowgun
@@ -146,7 +146,7 @@ Queued combos, unasserted (each becomes a phase when its cell's weapon PR lands)
 
 ## Gap queue (risk-ordered, one weapon per PR, per the #316 plan)
 
-1. **Slung launcher-lob & stone sprees, & Bread crumbs** - the laser spray is proven; the rest of the slung family (#229/#270) is not.
+1. **Slung launcher-lob & stone sprees** - the laser spray & slung loaf are proven; the launcher & slingshot payloads (#229/#270) are not.
 2. **Boomerang steal-on-hit & cooldown** (#98/#106).
 3. **Laser charge ladder** (#67).
 4. **Fists knockback, stun & cooldown** (#68/#71/#335).

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1474,12 +1474,15 @@ public partial class PlaytestDriver : Node
     // BLAST (#61/#83): the banana lands at the parked victim's feet - the blast
     // hurts & stuns but NEVER zaps a full-health player.
     await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f && victim.Health == victim.MaxHealth, 120, "victim parked & clean for the blast (#316)");
-    Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 6.0f);
+    // CLOSE & STEEP (round 5's lesson: from 6m out the flat-ish lob bounced &
+    // skidded meters away - it blasted the HOST at the radius edge & the victim
+    // took nothing). From 3m, plunging at the offset point, the plop stays put.
+    Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 3.0f);
     await Task.Delay (400);
-    // BESIDE them, not at their feet (the first run's lesson: the low line to the
-    // feet clips the body en route & the shot becomes the STICKY) - 2.5m out is
-    // clear of the capsule & still deep inside the 6m blast radius.
-    AimAt (new Vector3 (victim.GlobalPosition.X + 2.5f, 30.4f, victim.GlobalPosition.Z));
+    // BESIDE them, not at their feet (the first run's lesson: a line to the feet
+    // clips the body en route & the shot becomes the STICKY) - 2m out is clear
+    // of the capsule & deep inside the 6m blast radius.
+    AimAt (new Vector3 (victim.GlobalPosition.X + 2.0f, 30.4f, victim.GlobalPosition.Z));
     PressLeftClick();
     await Task.Delay (60);
     ReleaseLeftClick();

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1536,6 +1536,11 @@ public partial class PlaytestDriver : Node
     await Task.Delay (60);
     ReleaseAction ("drop");
     await WaitUntil (() => !Self.Holds (HeldWeapon.Bread), 10, "X dropped the loaf as the payload (#242/#316)");
+    // RETREAT before the drop-grace expires (round 2's lesson: the toss landed
+    // inside claim range & the loaf went straight back into the pack during the
+    // weapon-switch window) - the pouch must be out BEFORE we go near it again.
+    Self.Position = ShooterParkSpot + new Vector3 (0.0f, 0.0f, 4.0f);
+    await Task.Delay (300);
     PressAction ("weapon_5");
     await Task.Delay (100);
     ReleaseAction ("weapon_5");
@@ -1545,7 +1550,8 @@ public partial class PlaytestDriver : Node
 
     while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)
     {
-      var loaf = DroppedNear (HeldWeapon.Bread, ShooterParkSpot, 6.0f);
+      if (Self.Holds (HeldWeapon.Bread)) { Assert (false, "the loaf went back into the pack instead of the pouch (#190/#316)"); }
+      var loaf = DroppedNear (HeldWeapon.Bread, ShooterParkSpot, 8.0f);
       if (loaf != null) Self.Position = new Vector3 (loaf.GlobalPosition.X, 31.3f, loaf.GlobalPosition.Z);
       await Task.Delay (1000);
     }

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1497,6 +1497,9 @@ public partial class PlaytestDriver : Node
     await Task.Delay (60);
     ReleaseLeftClick();
     await WaitUntil (() => victim.Fallen, 15, "the sticky banana zapped the victim after its ride (#83)");
+    // The loaf drops WHERE THEY FELL (CodeRabbit): the launch carried them far
+    // from the park, & the body's spot is gone once their reset teleports them.
+    var stickyDeathSpot = victim.GlobalPosition;
 
     // SLUNG LOAF (#229/#247/#270, rounds 1-3's lessons distilled): a pouch-load
     // only wins when a normal collect CANNOT (the #190 rule - you already hold
@@ -1512,7 +1515,7 @@ public partial class PlaytestDriver : Node
 
     while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)
     {
-      var loaf = DroppedNear (HeldWeapon.Bread, VictimParkSpot, 8.0f);
+      var loaf = DroppedNear (HeldWeapon.Bread, stickyDeathSpot, 12.0f);
       if (loaf != null) Self.Position = new Vector3 (loaf.GlobalPosition.X, 31.3f, loaf.GlobalPosition.Z);
       await Task.Delay (800);
     }

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1384,7 +1384,6 @@ public partial class PlaytestDriver : Node
     await RunRingPhase();
     await RunArmedMineLoadPhase();
     await RunBananaPhases (victim);
-    await RunSlungBreadPhase (victim);
   }
 
   // Aaron's report (issue #325): an OPEN slingshot - selected, never drawn - must
@@ -1453,6 +1452,14 @@ public partial class PlaytestDriver : Node
   // drawn-slingshot grenade catch (#251) - each proven on the parked victim.
   private async Task RunBananaPhases (Player victim)
   {
+    // The slung-loaf section needs a slingshot IN THE PACK before the sticky kill
+    // (its 15s window is too short to go shopping): stock up first.
+    if (!Self.Holds (HeldWeapon.Slingshot))
+    {
+      Self.Position = WeaponSpawner.PlaytestSlingshotPosition + Vector3.Up * 0.5f;
+      await WaitUntil (() => Self.Holds (HeldWeapon.Slingshot), 30, "stocked a slingshot for the slung loaf (#316)");
+    }
+
     if (!Self.Holds (HeldWeapon.Banana))
     {
       Self.Position = WeaponSpawner.PlaytestBananaPosition + Vector3.Up * 0.5f;
@@ -1491,6 +1498,38 @@ public partial class PlaytestDriver : Node
     ReleaseLeftClick();
     await WaitUntil (() => victim.Fallen, 15, "the sticky banana zapped the victim after its ride (#83)");
 
+    // SLUNG LOAF (#229/#247/#270, rounds 1-3's lessons distilled): a pouch-load
+    // only wins when a normal collect CANNOT (the #190 rule - you already hold
+    // one), so the payload is the victim's death-dropped loaf from the sticky
+    // kill, chased with our OWN loaf still in the pack & the pouch out - the
+    // field-realistic way anyone slings bread.
+    Assert (Self.Holds (HeldWeapon.Bread), "our own loaf still in the pack for the pouch-load rule (#190/#316)");
+    PressAction ("weapon_5");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_5");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Slingshot, "pouch out for the victim's dropped loaf (#316)");
+    var loafDeadline = Time.GetTicksMsec() + 14_000; // The unclaimed drop expires at ~15s.
+
+    while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)
+    {
+      var loaf = DroppedNear (HeldWeapon.Bread, VictimParkSpot, 8.0f);
+      if (loaf != null) Self.Position = new Vector3 (loaf.GlobalPosition.X, 31.3f, loaf.GlobalPosition.Z);
+      await Task.Delay (800);
+    }
+
+    Assert (Self.SlingshotAmmo == HeldWeapon.Bread, "the pouch loaded the victim's dropped loaf (#190/#316)");
+    await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f && victim.Health == victim.MaxHealth, 120, "victim parked & clean for the slung loaf (#316)");
+    Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 6.0f);
+    await Task.Delay (400);
+    AimAt (victim.GlobalPosition + Vector3.Up);
+    await SlingAStone (drawMs: 400, "slung the loaf at the victim (#229/#270)");
+    await WaitUntil (() => victim.Health < victim.MaxHealth, 15, "the slung loaf hit the victim like a punch (#229/#247)");
+    Assert (!victim.Fallen, "a slung loaf never zaps anyone out (#247)");
+    PressAction ("weapon_3");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_3");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Banana, "launcher back out for the catch lob (#316)");
+
     // CATCH (#251): the victim re-parks DRAWING an empty slingshot; the lobbed
     // banana meets the drawn pouch & nocks as a live grenade; they fire it away.
     await WaitUntil (() => victim.DrawingSlingshot && !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f, 120, "victim drawing at its mark for the catch (#251)");
@@ -1511,63 +1550,6 @@ public partial class PlaytestDriver : Node
     await Task.Delay (300);
   }
 
-  // The bread row's last gap (#316): the universal pouch slings the LOAF & the
-  // slung hit lands like a punch (#229/#247/#270) - never a zap-out.
-  private async Task RunSlungBreadPhase (Player victim)
-  {
-    if (!Self.Holds (HeldWeapon.Slingshot))
-    {
-      Self.Position = WeaponSpawner.PlaytestSlingshotPosition + Vector3.Up * 0.5f;
-      await WaitUntil (() => Self.Holds (HeldWeapon.Slingshot), 30, "collected a slingshot for the slung loaf (#316)");
-    }
-
-    Self.Position = ShooterParkSpot;
-    await Task.Delay (300);
-    // Our own spawn loaf becomes the payload - & X drops what's IN YOUR HANDS
-    // (the first run's lesson: with the slingshot selected, X dropped the
-    // slingshot & the loaf never left the pack). Bring the loaf OUT first.
-    Assert (Self.Holds (HeldWeapon.Bread), "still carrying this life's loaf to sling (#190/#316)");
-    PressAction ("weapon_0");
-    await Task.Delay (100);
-    ReleaseAction ("weapon_0");
-    Assert (Self.SelectedWeapon == SelectedWeapon.Bread, "loaf out for the payload drop (#209/#316)");
-    AimAt (ShooterParkSpot + new Vector3 (0.0f, 1.0f, -3.0f));
-    PressAction ("drop");
-    await Task.Delay (60);
-    ReleaseAction ("drop");
-    await WaitUntil (() => !Self.Holds (HeldWeapon.Bread), 10, "X dropped the loaf as the payload (#242/#316)");
-    // RETREAT before the drop-grace expires (round 2's lesson: the toss landed
-    // inside claim range & the loaf went straight back into the pack during the
-    // weapon-switch window) - the pouch must be out BEFORE we go near it again.
-    Self.Position = ShooterParkSpot + new Vector3 (0.0f, 0.0f, 4.0f);
-    await Task.Delay (300);
-    PressAction ("weapon_5");
-    await Task.Delay (100);
-    ReleaseAction ("weapon_5");
-    Assert (Self.SelectedWeapon == SelectedWeapon.Slingshot, "pouch out to load the payload (#316)");
-    await EmptySlingshot();
-    var loafDeadline = Time.GetTicksMsec() + 30_000;
-
-    while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)
-    {
-      if (Self.Holds (HeldWeapon.Bread)) { Assert (false, "the loaf went back into the pack instead of the pouch (#190/#316)"); }
-      var loaf = DroppedNear (HeldWeapon.Bread, ShooterParkSpot, 8.0f);
-      if (loaf != null) Self.Position = new Vector3 (loaf.GlobalPosition.X, 31.3f, loaf.GlobalPosition.Z);
-      await Task.Delay (1000);
-    }
-
-    Assert (Self.SlingshotAmmo == HeldWeapon.Bread, "the open pouch loaded the dropped loaf (#190/#316)");
-    await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f && victim.Health == victim.MaxHealth, 120, "victim parked & clean for the slung loaf (#316)");
-    Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 6.0f);
-    await Task.Delay (400);
-    AimAt (victim.GlobalPosition + Vector3.Up);
-    await SlingAStone (drawMs: 400, "slung the loaf at the victim (#229/#270)");
-    await WaitUntil (() => victim.Health < victim.MaxHealth, 15, "the slung loaf hit the victim like a punch (#229/#247)");
-    Assert (!victim.Fallen, "a slung loaf never zaps anyone out (#247)");
-    Self.Position = ShooterParkSpot;
-    await Task.Delay (300);
-  }
-
   private async Task RunEndOfRunVictimPhases()
   {
     await ResetLifeAndPark();
@@ -1581,9 +1563,9 @@ public partial class PlaytestDriver : Node
     await ResetLifeAndPark();
     await BeTheStickyTarget();
     await ResetLifeAndPark();
-    await BeTheCatchTarget();
-    await ResetLifeAndPark();
     await BeTheSlungBreadTarget();
+    await ResetLifeAndPark();
+    await BeTheCatchTarget();
   }
 
   // A fresh life on demand: the off-world fall respawns us (#108) with full health, a

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1514,16 +1514,22 @@ public partial class PlaytestDriver : Node
     await Task.Delay (100);
     ReleaseAction ("weapon_5");
     Assert (Self.SelectedWeapon == SelectedWeapon.Slingshot, "pouch out for the victim's dropped loaf (#316)");
-    var loafDeadline = Time.GetTicksMsec() + 14_000; // The unclaimed drop expires at ~15s.
+    // Round 6's two facts: a dropped loaf expires in ~5 SECONDS, & the sticky
+    // launch can hurl the victim clean off the deck - they died at ground level
+    // 56m away & the old deck-height teleport hovered 30m above the loaf. Chase
+    // fast, at the loaf's OWN height, wherever the body came down.
+    var loafDeadline = Time.GetTicksMsec() + 10_000;
 
     while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)
     {
-      var loaf = DroppedNear (HeldWeapon.Bread, stickyDeathSpot, 12.0f);
-      if (loaf != null) Self.Position = new Vector3 (loaf.GlobalPosition.X, 31.3f, loaf.GlobalPosition.Z);
-      await Task.Delay (800);
+      var loaf = DroppedNear (HeldWeapon.Bread, stickyDeathSpot, 15.0f);
+      if (loaf != null) Self.Position = loaf.GlobalPosition + Vector3.Up * 0.4f;
+      await Task.Delay (300);
     }
 
     Assert (Self.SlingshotAmmo == HeldWeapon.Bread, "the pouch loaded the victim's dropped loaf (#190/#316)");
+    Self.Position = ShooterParkSpot; // The chase may end at ground level far away - come home before the next mark.
+    await Task.Delay (300);
     await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f && victim.Health == victim.MaxHealth, 120, "victim parked & clean for the slung loaf (#316)");
     Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 6.0f);
     await Task.Delay (400);

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1384,6 +1384,7 @@ public partial class PlaytestDriver : Node
     await RunRingPhase();
     await RunArmedMineLoadPhase();
     await RunBananaPhases (victim);
+    await RunSlungBreadPhase (victim);
   }
 
   // Aaron's report (issue #325): an OPEN slingshot - selected, never drawn - must
@@ -1510,6 +1511,51 @@ public partial class PlaytestDriver : Node
     await Task.Delay (300);
   }
 
+  // The bread row's last gap (#316): the universal pouch slings the LOAF & the
+  // slung hit lands like a punch (#229/#247/#270) - never a zap-out.
+  private async Task RunSlungBreadPhase (Player victim)
+  {
+    if (!Self.Holds (HeldWeapon.Slingshot))
+    {
+      Self.Position = WeaponSpawner.PlaytestSlingshotPosition + Vector3.Up * 0.5f;
+      await WaitUntil (() => Self.Holds (HeldWeapon.Slingshot), 30, "collected a slingshot for the slung loaf (#316)");
+    }
+
+    Self.Position = ShooterParkSpot;
+    await Task.Delay (300);
+    PressAction ("weapon_5");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_5");
+    await EmptySlingshot();
+    // Our own spawn loaf becomes the payload: X-drop it ahead, then walk back onto
+    // it with the pouch open - the universal load (#190) makes anything ammo.
+    Assert (Self.Holds (HeldWeapon.Bread), "still carrying this life's loaf to sling (#190/#316)");
+    AimAt (ShooterParkSpot + new Vector3 (0.0f, 1.0f, -3.0f));
+    PressAction ("drop");
+    await Task.Delay (60);
+    ReleaseAction ("drop");
+    await WaitUntil (() => !Self.Holds (HeldWeapon.Bread), 10, "X dropped the loaf as the payload (#242/#316)");
+    var loafDeadline = Time.GetTicksMsec() + 30_000;
+
+    while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)
+    {
+      var loaf = DroppedNear (HeldWeapon.Bread, ShooterParkSpot, 6.0f);
+      if (loaf != null) Self.Position = new Vector3 (loaf.GlobalPosition.X, 31.3f, loaf.GlobalPosition.Z);
+      await Task.Delay (1000);
+    }
+
+    Assert (Self.SlingshotAmmo == HeldWeapon.Bread, "the open pouch loaded the dropped loaf (#190/#316)");
+    await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f && victim.Health == victim.MaxHealth, 120, "victim parked & clean for the slung loaf (#316)");
+    Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 6.0f);
+    await Task.Delay (400);
+    AimAt (victim.GlobalPosition + Vector3.Up);
+    await SlingAStone (drawMs: 400, "slung the loaf at the victim (#229/#270)");
+    await WaitUntil (() => victim.Health < victim.MaxHealth, 15, "the slung loaf hit the victim like a punch (#229/#247)");
+    Assert (!victim.Fallen, "a slung loaf never zaps anyone out (#247)");
+    Self.Position = ShooterParkSpot;
+    await Task.Delay (300);
+  }
+
   private async Task RunEndOfRunVictimPhases()
   {
     await ResetLifeAndPark();
@@ -1524,6 +1570,8 @@ public partial class PlaytestDriver : Node
     await BeTheStickyTarget();
     await ResetLifeAndPark();
     await BeTheCatchTarget();
+    await ResetLifeAndPark();
+    await BeTheSlungBreadTarget();
   }
 
   // A fresh life on demand: the off-world fall respawns us (#108) with full health, a
@@ -1686,6 +1734,16 @@ public partial class PlaytestDriver : Node
     await WaitUntil (() => Self.SlingshotAmmo == HeldWeapon.None, 10, "the hot potato left our pouch (#251)");
     await Task.Delay (2500); // Its fuse pops far away, not on us.
     Assert (!Self.Fallen && Self.Health > 0, "fired it back out in time & lived (#251)");
+  }
+
+  // The slung-loaf target (#229/#247): parked at full health, the loaf lands like
+  // a punch - it hurts, it never zaps.
+  private async Task BeTheSlungBreadTarget()
+  {
+    await WaitUntil (() => !Self.SpawnArmor, 20, "spawn armor expired before the slung loaf (#48/#316)");
+    var healthBefore = Self.Health;
+    await WaitUntil (() => Self.Health < healthBefore, 120, "the slung loaf reached us (#229/#247)");
+    Assert (!Self.Fallen && Self.Health > 0, $"the slung loaf hurt like a punch, never a zap-out (#247), health {Self.Health}");
   }
 
   private async Task BeThePoisonTarget()

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1500,35 +1500,53 @@ public partial class PlaytestDriver : Node
     await Task.Delay (60);
     ReleaseLeftClick();
     await WaitUntil (() => victim.Fallen, 15, "the sticky banana zapped the victim after its ride (#83)");
-    // The loaf drops WHERE THEY FELL (CodeRabbit): the launch carried them far
-    // from the park, & the body's spot is gone once their reset teleports them.
-    var stickyDeathSpot = victim.GlobalPosition;
 
-    // SLUNG LOAF (#229/#247/#270, rounds 1-3's lessons distilled): a pouch-load
-    // only wins when a normal collect CANNOT (the #190 rule - you already hold
-    // one), so the payload is the victim's death-dropped loaf from the sticky
-    // kill, chased with our OWN loaf still in the pack & the pouch out - the
-    // field-realistic way anyone slings bread.
+    // SLUNG LOAF (#229/#247/#270): a pouch-load only wins when a normal collect
+    // CANNOT (the #190 rule - you already hold one), so the payload is the
+    // victim's death-dropped loaf. Rounds 5-7's verdict: the sticky's launch
+    // scatters death spots across the whole map & the loaf's ~5 SECOND expiry
+    // wins every race - so the drop comes from a CONTROLLED kill instead: a
+    // full-charge zap on the parked victim puts the loaf right beside the mark.
+    await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f, 120, "victim parked for the loaf-drop zap (#316)");
+
+    if (!Self.Holds (HeldWeapon.Laser))
+    {
+      Self.Position = WeaponSpawner.PlaytestLaserPosition + Vector3.Up * 0.5f;
+      await WaitUntil (() => Self.Holds (HeldWeapon.Laser), 30, "re-collected a laser for the loaf-drop zap (#316)");
+    }
+
+    PressAction ("weapon_2");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_2");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Laser, "laser out for the loaf-drop zap (#316)");
+    Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 6.0f);
+    await Task.Delay (400);
+
+    for (var attempt = 0; attempt < 10 && !victim.Fallen; ++attempt)
+    {
+      AimAt (victim.GlobalPosition + Vector3.Up);
+      await ChargeAndFire (chargeSeconds: 2.3f);
+      await TryWaitUntil (() => victim.Fallen, 3);
+    }
+
+    Assert (victim.Fallen, "the full-charge zap dropped the victim's loaf at the mark (#93/#316)");
+    var loafSpot = victim.GlobalPosition; // Died AT the park - no launch, no scatter.
     Assert (Self.Holds (HeldWeapon.Bread), "our own loaf still in the pack for the pouch-load rule (#190/#316)");
     PressAction ("weapon_5");
     await Task.Delay (100);
     ReleaseAction ("weapon_5");
     Assert (Self.SelectedWeapon == SelectedWeapon.Slingshot, "pouch out for the victim's dropped loaf (#316)");
-    // Round 6's two facts: a dropped loaf expires in ~5 SECONDS, & the sticky
-    // launch can hurl the victim clean off the deck - they died at ground level
-    // 56m away & the old deck-height teleport hovered 30m above the loaf. Chase
-    // fast, at the loaf's OWN height, wherever the body came down.
-    var loafDeadline = Time.GetTicksMsec() + 10_000;
+    var loafDeadline = Time.GetTicksMsec() + 8_000; // The unclaimed drop expires in ~5s - chase fast.
 
     while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)
     {
-      var loaf = DroppedNear (HeldWeapon.Bread, stickyDeathSpot, 15.0f);
+      var loaf = DroppedNear (HeldWeapon.Bread, loafSpot, 8.0f);
       if (loaf != null) Self.Position = loaf.GlobalPosition + Vector3.Up * 0.4f;
       await Task.Delay (300);
     }
 
     Assert (Self.SlingshotAmmo == HeldWeapon.Bread, "the pouch loaded the victim's dropped loaf (#190/#316)");
-    Self.Position = ShooterParkSpot; // The chase may end at ground level far away - come home before the next mark.
+    Self.Position = ShooterParkSpot;
     await Task.Delay (300);
     await WaitUntil (() => !victim.SpawnArmor && FlatDistance (victim.GlobalPosition, VictimParkSpot) < 2.0f && victim.Health == victim.MaxHealth, 120, "victim parked & clean for the slung loaf (#316)");
     Self.Position = VictimParkSpot + new Vector3 (0.0f, 0.3f, 6.0f);
@@ -1746,6 +1764,14 @@ public partial class PlaytestDriver : Node
   // a punch - it hurts, it never zaps.
   private async Task BeTheSlungBreadTarget()
   {
+    // First we DIE at the park - the controlled full-charge zap drops our loaf
+    // beside the mark (the launch-kill's wild death spots lost the 5s expiry
+    // race every time) - then a fresh life takes the slung loaf like a punch.
+    await WaitUntil (() => !Self.SpawnArmor, 20, "spawn armor expired before the loaf-drop zap (#48/#316)");
+    await WaitUntil (() => Self.Fallen, 120, "the zap dropped our loaf at the mark (#93/#316)");
+    await WaitUntil (() => !Self.Fallen && Self.Health == Self.MaxHealth, 30, "respawned fresh after the loaf drop (#316)");
+    Self.Position = VictimParkSpot;
+    await Task.Delay (300);
     await WaitUntil (() => !Self.SpawnArmor, 20, "spawn armor expired before the slung loaf (#48/#316)");
     var healthBefore = Self.Health;
     await WaitUntil (() => Self.Health < healthBefore, 120, "the slung loaf reached us (#229/#247)");

--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -1523,18 +1523,24 @@ public partial class PlaytestDriver : Node
 
     Self.Position = ShooterParkSpot;
     await Task.Delay (300);
-    PressAction ("weapon_5");
-    await Task.Delay (100);
-    ReleaseAction ("weapon_5");
-    await EmptySlingshot();
-    // Our own spawn loaf becomes the payload: X-drop it ahead, then walk back onto
-    // it with the pouch open - the universal load (#190) makes anything ammo.
+    // Our own spawn loaf becomes the payload - & X drops what's IN YOUR HANDS
+    // (the first run's lesson: with the slingshot selected, X dropped the
+    // slingshot & the loaf never left the pack). Bring the loaf OUT first.
     Assert (Self.Holds (HeldWeapon.Bread), "still carrying this life's loaf to sling (#190/#316)");
+    PressAction ("weapon_0");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_0");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Bread, "loaf out for the payload drop (#209/#316)");
     AimAt (ShooterParkSpot + new Vector3 (0.0f, 1.0f, -3.0f));
     PressAction ("drop");
     await Task.Delay (60);
     ReleaseAction ("drop");
     await WaitUntil (() => !Self.Holds (HeldWeapon.Bread), 10, "X dropped the loaf as the payload (#242/#316)");
+    PressAction ("weapon_5");
+    await Task.Delay (100);
+    ReleaseAction ("weapon_5");
+    Assert (Self.SelectedWeapon == SelectedWeapon.Slingshot, "pouch out to load the payload (#316)");
+    await EmptySlingshot();
     var loafDeadline = Time.GetTicksMsec() + 30_000;
 
     while (Self.SlingshotAmmo != HeldWeapon.Bread && Time.GetTicksMsec() < loafDeadline)


### PR DESCRIPTION
The bread row's last matrix gap: the shooter X-drops its own spawn loaf, chase-parks onto it with the open pouch (the universal load, #190), & slings it at the parked victim. Asserts demand the hit's health drop on both sides & that a slung loaf never zaps anyone out (#229/#247/#270) - evidence, not absence of error. Matrix updated in the same PR; the remaining slung-family gap (launcher-lob & stone sprees) stays queued.

Driver + matrix only. Verification is CI's - this box can't run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-of-run playtest coverage for slingshot-loaded bread.
  * Verified that slung bread damages a target without causing a knockout.
  * Confirmed the banana launcher remains available after the slingshot test.

* **Documentation**
  * Updated coverage tracking to reflect slung-loaf ammunition support.
  * Clarified remaining gaps for launcher and slingshot payload coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->