### PR TITLE
Playtest: the host gets a leash - re-park while idling out the clients' phases

### DIFF
--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -222,7 +222,21 @@ public partial class PlaytestDriver : Node
     // watchdog kills at 600s from process launch, so the tail budget is whatever is
     // left of 570 engine-seconds - a stall still fails by name, never by SIGKILL.
     var tailBudgetSeconds = Mathf.Max (30, 570 - (int)(Time.GetTicksMsec() / 1000));
-    await WaitUntil (() => _world.GetPlayers().Count() == 1, tailBudgetSeconds, "clients disconnected");
+    // The LEASH (today's recurring villain: the idle host, shoved around by the
+    // club calibration & every knockback - now carried 6m+ by #334's momentum
+    // window - kept wandering onto dart litter, mines & the airplane FIXTURE,
+    // where it stole the restock & starved the shooter's census wait): while
+    // idling out the clients' phases, re-park every few seconds if displaced.
+    var anchor = Self.GlobalPosition;
+    var leashDeadline = Time.GetTicksMsec() + (ulong)(tailBudgetSeconds * 1000);
+
+    while (_world.GetPlayers().Count() > 1 && Time.GetTicksMsec() < leashDeadline)
+    {
+      if (!Self.Fallen && FlatDistance (Self.GlobalPosition, anchor) > 3.0f) Self.Position = anchor;
+      await Task.Delay (3000);
+    }
+
+    Assert (_world.GetPlayers().Count() == 1, "clients disconnected");
     // The version line goes only to joining clients, never broadcast (#158), so the
     // host must never have seen one.
     Assert (_adminMessages.All (message => !message.Contains ("Running")), "version line was not broadcast to the host (#158)");


### PR DESCRIPTION
Today's recurring chaos agent, systemically fixed: the idle host - shoved around by the club calibration & every knockback (now carried 6m+ by #370's momentum window) - kept wandering onto dart litter, mines & the airplane FIXTURE, where it stole the restock (`[peer 1] weapon award: PaperAirplane`) & starved the shooter's census wait for 75s.

While idling out the clients' phases, the host now re-parks onto its anchor every few seconds whenever displaced more than 3m (a mid-death body is left alone). The clients-disconnected proof & tail budget are unchanged.

Driver-only. Verification is CI's - this box can't run the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso