### PR TITLE
The poisoned player's overhead bar is actually green now

### DIFF
--- a/core/players/Player.Poison.cs
+++ b/core/players/Player.Poison.cs
@@ -167,10 +167,23 @@ public partial class Player
     }
   }
 
+  private StyleBoxFlat? _healthFill;
+
+  // Our OWN fill box (Aaron, 2026-08-23: the green never showed from a distance):
+  // GetThemeStylebox returns a resource SHARED across every player's bar, & the
+  // ALWAYS-mode sync setters made every unpoisoned player's tick stomp the shared
+  // color back to red - last writer wins, the green never survived a frame. A
+  // per-instance override ends the fight.
   private void UpdateOverheadBarPoisonTint()
   {
     if (_healthBar == null) return;
-    if (_healthBar.GetThemeStylebox ("fill") is not StyleBoxFlat fill) return;
-    fill.BgColor = IsPoisoned ? PoisonGreen : new Color (0.756863f, 0.0f, 0.0f);
+
+    if (_healthFill == null)
+    {
+      _healthFill = _healthBar.GetThemeStylebox ("fill") is StyleBoxFlat shared ? (StyleBoxFlat)shared.Duplicate() : new StyleBoxFlat();
+      _healthBar.AddThemeStyleboxOverride ("fill", _healthFill);
+    }
+
+    _healthFill.BgColor = IsPoisoned ? PoisonGreen : new Color (0.756863f, 0.0f, 0.0f);
   }
 }


### PR DESCRIPTION
Aaron's live feedback: a poisoned player's distance-visible health bar should read green - the tint code existed (#194) but never showed. The bug: `GetThemeStylebox(\"fill\")` returns a stylebox SHARED across every player's bar, & the ALWAYS-mode sync setters made every unpoisoned player's replication tick stomp the shared color back to red - last writer wins, the green never survived a frame. Each bar now owns a per-instance fill override (duplicated once, lazily), so the poisoned player's bar reads sickly green from across the arena while everyone else's stays red.

Joins the current feedback-tuning release cluster per the release-gating rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso