### PR TITLE
Emote hold vs toggle is a setting

### DIFF
--- a/core/players/Player.Dance.cs
+++ b/core/players/Player.Dance.cs
@@ -73,7 +73,9 @@ public partial class Player
     || Input.IsActionJustPressed ("crouch")
     || Input.IsActionJustPressed ("punch")
     || Input.IsActionJustPressed ("ability")
-    || Input.IsActionJustPressed ("dance");
+    // Hold mode (Aaron, 2026-08-23): release G to stop; toggle mode (default) ends
+    // on another G press, as always.
+    || (_holdToDance ? !Input.IsActionPressed ("dance") : Input.IsActionJustPressed ("dance"));
 
   // Runs on every peer via the replicated Dancing property; ALWAYS-mode sync re-fires
   // the setter every tick, so start/stop exactly once per state flip.

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -347,6 +347,8 @@ public partial class Player : CharacterBody3D
   public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
   // Re-reads the persisted crouch mode (issue #147); the pause-dialog toggle calls this.
   public void RefreshCrouchMode() => _holdToCrouch = Settings.HoldToCrouch;
+  public void RefreshDanceMode() => _holdToDance = Settings.HoldToDance;
+  private bool _holdToDance;
   // Guards against "The multiplayer instance isn't currently active" error spam from
   // IsMultiplayerAuthority() after the session ends but before player nodes are freed (see issue #22).
   private bool IsMultiplayerActive() => Multiplayer.MultiplayerPeer != null && Multiplayer.MultiplayerPeer.GetConnectionStatus() == MultiplayerPeer.ConnectionStatus.Connected;
@@ -427,6 +429,7 @@ public partial class Player : CharacterBody3D
     _isInputEnabled = true;
     _holdToCrouch = Settings.HoldToCrouch; // Toggle-vs-hold crouch preference (issue #147).
     _holdToScope = Settings.HoldToScope; // Toggle-vs-hold scope preference (issue #290).
+    _holdToDance = Settings.HoldToDance; // Toggle-vs-hold emote preference (Aaron, 2026-08-23).
     Input.MouseMode = Input.MouseModeEnum.Captured;
     Position = CalculateRandomSpawnPosition();
     SetBreadHeld (isHeld: true); // The starting loaf rides the HeldWeapon mask (issue #190).

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -308,6 +308,7 @@ public partial class Hud : Control
     rows.AddChild (column);
     column.AddChild (SettingToggle ("Hold to crouch", Settings.HoldToCrouch, isEnabled => { Settings.HoldToCrouch = isEnabled; Player.Local?.RefreshCrouchMode(); }));
     column.AddChild (SettingToggle ("Hold to scope", Settings.HoldToScope, isEnabled => { Settings.HoldToScope = isEnabled; Player.Local?.RefreshScopeMode(); }));
+    column.AddChild (SettingToggle ("Hold to emote", Settings.HoldToDance, isEnabled => { Settings.HoldToDance = isEnabled; Player.Local?.RefreshDanceMode(); }));
     column.AddChild (SettingToggle ("Show music player", Settings.ShowMusicPlayer, isEnabled => { Settings.ShowMusicPlayer = isEnabled; GetNode <MusicPlayer> ("MusicPlayer").ApplyVisibilitySetting(); }));
     column.AddChild (SettingToggle ("Show chat", Settings.ShowChat, isEnabled => Settings.ShowChat = isEnabled));
     column.AddChild (SettingToggle ("Show game messages", Settings.ShowMessages, isEnabled => { Settings.ShowMessages = isEnabled; _messageScroller.ApplyVisibilitySetting(); }));

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -105,6 +105,14 @@ public static class Settings
     set => Set ("hold_to_scope", value);
   }
 
+  // Emote as hold-while-pressed instead of the default toggle (Aaron, 2026-08-23):
+  // hold G to groove, release to stop; toggle mode stays the default.
+  public static bool HoldToDance
+  {
+    get => GetBool ("hold_to_dance", false);
+    set => Set ("hold_to_dance", value);
+  }
+
   // Chat box visibility (issue #297): hiding it never blocks receiving - lines
   // still land in the Tab history; T just won't open the input line.
   public static bool ShowChat


### PR DESCRIPTION
Aaron's ask: emote hold-vs-toggle as a setting. 'Hold to emote' in the Settings dialog: G grooves while held & stops on release; toggle mode (today's behavior) stays the default. Same knob pattern as hold-to-crouch (#147) & hold-to-scope (#290), applies immediately from the pause menu. Joins the feedback-tuning release cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso