### PR TITLE
Live-feedback tuning cluster: darts 2x, green poison bar, emote setting, crouch stealth, tags above the head

### DIFF
--- a/core/players/Player.Blowgun.cs
+++ b/core/players/Player.Blowgun.cs
@@ -15,7 +15,7 @@ namespace com.forerunnergames.energyshot.players;
 // of darts it swings as a club (Player.Blunt, issue #249). No recoil. The shooter hears the shot locally; bystanders only within a few feet.
 public partial class Player
 {
-  [Export] public float BlowgunDartSpeed = 84.0f; // Doubled (Aaron, 2026-08-22: still WAY too slow at 42) - fast but visible, per the sniper spec (issues #236/#259).
+  [Export] public float BlowgunDartSpeed = 168.0f; // Doubled AGAIN (Aaron, 2026-08-23; the v0.8.84 doubling was still too slow): a dart is nearly hitscan now. // Doubled (Aaron, 2026-08-22: still WAY too slow at 42) - fast but visible, per the sniper spec (issues #236/#259).
   [Export] public float BlowgunCooldownSeconds = 1.5f;
   [Export]
   public int BlowgunDarts

--- a/core/players/Player.Dance.cs
+++ b/core/players/Player.Dance.cs
@@ -73,7 +73,9 @@ public partial class Player
     || Input.IsActionJustPressed ("crouch")
     || Input.IsActionJustPressed ("punch")
     || Input.IsActionJustPressed ("ability")
-    || Input.IsActionJustPressed ("dance");
+    // Hold mode (Aaron, 2026-08-23): release G to stop; toggle mode (default) ends
+    // on another G press, as always.
+    || (_holdToDance ? !Input.IsActionPressed ("dance") : Input.IsActionJustPressed ("dance"));
 
   // Runs on every peer via the replicated Dancing property; ALWAYS-mode sync re-fires
   // the setter every tick, so start/stop exactly once per state flip.

--- a/core/players/Player.Poison.cs
+++ b/core/players/Player.Poison.cs
@@ -167,10 +167,23 @@ public partial class Player
     }
   }
 
+  private StyleBoxFlat? _healthFill;
+
+  // Our OWN fill box (Aaron, 2026-08-23: the green never showed from a distance):
+  // GetThemeStylebox returns a resource SHARED across every player's bar, & the
+  // ALWAYS-mode sync setters made every unpoisoned player's tick stomp the shared
+  // color back to red - last writer wins, the green never survived a frame. A
+  // per-instance override ends the fight.
   private void UpdateOverheadBarPoisonTint()
   {
     if (_healthBar == null) return;
-    if (_healthBar.GetThemeStylebox ("fill") is not StyleBoxFlat fill) return;
-    fill.BgColor = IsPoisoned ? PoisonGreen : new Color (0.756863f, 0.0f, 0.0f);
+
+    if (_healthFill == null)
+    {
+      _healthFill = _healthBar.GetThemeStylebox ("fill") is StyleBoxFlat shared ? (StyleBoxFlat)shared.Duplicate() : new StyleBoxFlat();
+      _healthBar.AddThemeStyleboxOverride ("fill", _healthFill);
+    }
+
+    _healthFill.BgColor = IsPoisoned ? PoisonGreen : new Color (0.756863f, 0.0f, 0.0f);
   }
 }

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -347,6 +347,8 @@ public partial class Player : CharacterBody3D
   public void SetInputEnabled (bool isEnabled) => _isInputEnabled = isEnabled;
   // Re-reads the persisted crouch mode (issue #147); the pause-dialog toggle calls this.
   public void RefreshCrouchMode() => _holdToCrouch = Settings.HoldToCrouch;
+  public void RefreshDanceMode() => _holdToDance = Settings.HoldToDance;
+  private bool _holdToDance;
   // Guards against "The multiplayer instance isn't currently active" error spam from
   // IsMultiplayerAuthority() after the session ends but before player nodes are freed (see issue #22).
   private bool IsMultiplayerActive() => Multiplayer.MultiplayerPeer != null && Multiplayer.MultiplayerPeer.GetConnectionStatus() == MultiplayerPeer.ConnectionStatus.Connected;
@@ -427,6 +429,7 @@ public partial class Player : CharacterBody3D
     _isInputEnabled = true;
     _holdToCrouch = Settings.HoldToCrouch; // Toggle-vs-hold crouch preference (issue #147).
     _holdToScope = Settings.HoldToScope; // Toggle-vs-hold scope preference (issue #290).
+    _holdToDance = Settings.HoldToDance; // Toggle-vs-hold emote preference (Aaron, 2026-08-23).
     Input.MouseMode = Input.MouseModeEnum.Captured;
     Position = CalculateRandomSpawnPosition();
     SetBreadHeld (isHeld: true); // The starting loaf rides the HeldWeapon mask (issue #190).

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -167,7 +167,18 @@ public partial class Player : CharacterBody3D
     {
       _crouching = value;
       ApplyCrouchScale();
+      ApplyCrouchStealth();
     }
+  }
+
+  // Crouching hides your overhead nametag & health indicator on every OTHER peer
+  // (Aaron, 2026-08-23): sneaking is real - the floating giveaway goes away until
+  // you stand. Own tags are always hidden locally, so the authority skips.
+  private void ApplyCrouchStealth()
+  {
+    if (IsMultiplayerAuthority()) return;
+    if (_nameTag != null) _nameTag.Visible = !_crouching;
+    if (_healthTag != null) _healthTag.Visible = !_crouching;
   }
 
   // Current zap streak, replicated so every peer can render the "on fire" glow &
@@ -267,7 +278,11 @@ public partial class Player : CharacterBody3D
   [Export] public float TagScaleStopDistance = 200.0f;
   [Export] public float HealthTagNameTagMinSpacing = 0.2f;
   [Export] public float HealthTagNameTagMaxSpacing = 3.0f;
-  [Export] public float NameTagBaseHeight = 2.3f;
+  // 3.4, up from 2.3 (Aaron, 2026-08-23: a 'white box' covered every bar at round
+  // start): the #333 head spans y 2.05-2.95 & the tags sat INSIDE it - a fresh
+  // round's armor turns every head white & the sphere filled the tag's
+  // transparent background. Tags now float clear above the head.
+  [Export] public float NameTagBaseHeight = 3.4f;
   public int NetworkId => Name.ToString().ToInt();
   // Whether the one-per-life loaf is still in hand: the HUD bread icon (issue #160) &
   // the slot-7 selection rules (issue #209). Reads the REPLICATED mask, not the local

--- a/core/players/Player.tscn
+++ b/core/players/Player.tscn
@@ -152,7 +152,7 @@ platform_floor_layers = 1
 script = ExtResource("1_nipvj")
 
 [node name="NameTag" type="Label3D" parent="."]
-transform = Transform3D(1, 0, 1.42109e-14, 0, 1, 0, 0, 0, 1, 0, 2.3, 0)
+transform = Transform3D(1, 0, 1.42109e-14, 0, 1, 0, 0, 0, 1, 0, 3.4, 0)
 billboard = 1
 no_depth_test = true
 text = "PlayerName"
@@ -174,7 +174,7 @@ light_energy = 4.0
 omni_range = 9.0
 
 [node name="HealthTag" type="Sprite3D" parent="."]
-transform = Transform3D(-0.18, 0, 6.34182e-08, 0, 0.1008, 0, -2.71793e-08, 0, -0.42, 0, 2.1, 0)
+transform = Transform3D(-0.18, 0, 6.34182e-08, 0, 0.1008, 0, -2.71793e-08, 0, -0.42, 0, 3.2, 0)
 billboard = 1
 no_depth_test = true
 texture = SubResource("ViewportTexture_udl6m")

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -308,6 +308,7 @@ public partial class Hud : Control
     rows.AddChild (column);
     column.AddChild (SettingToggle ("Hold to crouch", Settings.HoldToCrouch, isEnabled => { Settings.HoldToCrouch = isEnabled; Player.Local?.RefreshCrouchMode(); }));
     column.AddChild (SettingToggle ("Hold to scope", Settings.HoldToScope, isEnabled => { Settings.HoldToScope = isEnabled; Player.Local?.RefreshScopeMode(); }));
+    column.AddChild (SettingToggle ("Hold to emote", Settings.HoldToDance, isEnabled => { Settings.HoldToDance = isEnabled; Player.Local?.RefreshDanceMode(); }));
     column.AddChild (SettingToggle ("Show music player", Settings.ShowMusicPlayer, isEnabled => { Settings.ShowMusicPlayer = isEnabled; GetNode <MusicPlayer> ("MusicPlayer").ApplyVisibilitySetting(); }));
     column.AddChild (SettingToggle ("Show chat", Settings.ShowChat, isEnabled => Settings.ShowChat = isEnabled));
     column.AddChild (SettingToggle ("Show game messages", Settings.ShowMessages, isEnabled => { Settings.ShowMessages = isEnabled; _messageScroller.ApplyVisibilitySetting(); }));

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -105,6 +105,14 @@ public static class Settings
     set => Set ("hold_to_scope", value);
   }
 
+  // Emote as hold-while-pressed instead of the default toggle (Aaron, 2026-08-23):
+  // hold G to groove, release to stop; toggle mode stays the default.
+  public static bool HoldToDance
+  {
+    get => GetBool ("hold_to_dance", false);
+    set => Set ("hold_to_dance", value);
+  }
+
   // Chat box visibility (issue #297): hiding it never blocks receiving - lines
   // still land in the Tab history; T just won't open the input line.
   public static bool ShowChat


### PR DESCRIPTION
Aaron's live-feedback batch, consolidated into one PR (supersedes #372, #373 & #374, which close in its favor - one review cycle instead of three):

- **Darts 2x again**: 84 -> 168 m/s - nearly hitscan (the v0.8.84 doubling was still too slow).
- **Poisoned overhead bar is actually GREEN**: the #194 tint existed but `GetThemeStylebox` returns a stylebox SHARED across every player's bar & the ALWAYS-sync setters made every unpoisoned tick stomp it back to red - last writer wins. Per-instance fill override ends the fight.
- **Emote hold vs toggle setting**: 'Hold to emote' in Settings - G grooves while held, stops on release; toggle stays the default. Same pattern as crouch/scope holds.
- **Crouch stealth**: crouching hides your nametag & health indicator on every other peer - the floating giveaway goes away until you stand.
- **Tags above the head**: the 'white box covering everyone's health bar at round start' decoded - the #333 head (y 2.05-2.95) sat right behind the tags (2.1/2.3), & a fresh round's spawn armor turns every head WHITE; the sphere filled the tags' transparent backgrounds. Tags rise to 3.2/3.4, clear of the head.

Ships with the pending feedback-tuning release (hands revert + #370's knockback carry & fall threshold) per the release-gating rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso