### PR TITLE
Eight more player colors (Jacob)

### DIFF
--- a/core/players/PlayerColors.cs
+++ b/core/players/PlayerColors.cs
@@ -7,7 +7,9 @@ namespace com.forerunnergames.energyshot.players;
 // on purpose - it's exclusively the spawn-armor indicator (issue #114).
 public static class PlayerColors
 {
-  private static readonly string[] Names = { "Blue", "Orange", "Sky Blue", "Green", "Yellow", "Vermilion", "Pink", "Purple", "Teal" };
+  // APPEND-ONLY (the replication rule's spirit): saved & replicated indices must
+  // keep meaning the same color forever. Eight more distinct picks (Jacob, 2026-08-23).
+  private static readonly string[] Names = { "Blue", "Orange", "Sky Blue", "Green", "Yellow", "Vermilion", "Pink", "Purple", "Teal", "Red", "Magenta", "Lime", "Brown", "Navy", "Charcoal", "Mint", "Gold" };
 
   private static readonly Color[] Palette =
   {
@@ -19,7 +21,15 @@ public static class PlayerColors
     new("d55e00"),
     new("cc79a7"),
     new("8f45c9"),
-    new("00bfc4")
+    new("00bfc4"),
+    new("b22222"), // Red: true crimson, well clear of Vermilion's orange lean.
+    new("ff00cc"),
+    new("8bd346"),
+    new("8b5a2b"),
+    new("16216e"),
+    new("3d3d3d"),
+    new("9ff2c8"),
+    new("c9a227")
   };
 
   public static int Count => Palette.Length;


### PR DESCRIPTION
Jacob's ask via Aaron: more player colors. The palette grows 9 -> 17: Red, Magenta, Lime, Brown, Navy, Charcoal, Mint & Gold - appended only, so saved & replicated indices keep meaning the same color forever. White stays excluded as the spawn-armor indicator. (Re-filed: #379 got closed by a premature branch cleanup on my side - same content, rebased.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the available player color palette from 9 to 17 options.
  * Added names and colors for the new palette entries while preserving existing color assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->