### PR TITLE
Playtest: the host anchors in the empty quarter

### DIFF
--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -227,7 +227,14 @@ public partial class PlaytestDriver : Node
     // window - kept wandering onto dart litter, mines & the airplane FIXTURE,
     // where it stole the restock & starved the shooter's census wait): while
     // idling out the clients' phases, re-park every few seconds if displaced.
-    var anchor = Self.GlobalPosition;
+    // The EMPTY QUARTER (the leash's completion - three reds after v0.8.121: the
+    // host, anchored wherever it stood on the crowded deck, kept faithfully
+    // re-parking onto OTHER phases' pickups - the shooter's dropped blowgun twice
+    // & the airplane restock once). The anchor moves to bare ground far from
+    // every phase zone; the club phase clubs it there, litter-free.
+    var anchor = new Vector3 (30.0f, 1.4f, -30.0f);
+    Self.Position = anchor;
+    await Task.Delay (300);
     var leashDeadline = Time.GetTicksMsec() + (ulong)(tailBudgetSeconds * 1000);
 
     while (_world.GetPlayers().Count() > 1 && Time.GetTicksMsec() < leashDeadline)


### PR DESCRIPTION
The leash's completion. Three reds since v0.8.121 decoded to the same villain: the leashed host - anchored wherever it happened to stand on the crowded deck - faithfully re-parking onto OTHER phases' pickups (`[peer 1] weapon award: Blowgun` twice, the airplane restock once), starving their waits.

The anchor moves to the bare ground plane at (30, 1.4, -30): far from every park, fixture & landing zone (15m+ from the victim's landmine ground, 22m from the mine-load ground). The club phase already follows `host.GlobalPosition`, so it calibrates there - litter-free by geography. Driver-only; merges FIRST in the drain since the host is currently eating the other PRs' runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso