### PR TITLE
Sound-effects & music volume sliders in Settings (#301)

### DIFF
--- a/core/audio/AudioBuses.cs
+++ b/core/audio/AudioBuses.cs
@@ -1,0 +1,54 @@
+using Godot;
+
+namespace com.forerunnergames.energyshot.core.audio;
+
+// Volume sliders (issue #301, Escendrix: the effects are too loud): music already
+// rides its own bus (MusicManager); every OTHER AudioStreamPlayer in a subtree is
+// routed onto an SFX bus here, & the two sliders drive the two buses live. 100 = the
+// mix as it was, so the defaults change nothing.
+public static class AudioBuses
+{
+  public const string SfxBusName = "SFX";
+
+  public static void EnsureSfxBus()
+  {
+    if (AudioServer.GetBusIndex (SfxBusName) != -1) return;
+    var busIndex = AudioServer.BusCount;
+    AudioServer.AddBus (busIndex);
+    AudioServer.SetBusName (busIndex, SfxBusName);
+    AudioServer.SetBusSend (busIndex, "Master");
+  }
+
+  // Every player under root that isn't already on the music bus becomes an effect.
+  public static void RouteSfx (Node root)
+  {
+    foreach (var node in Descendants (root))
+    {
+      if (node is AudioStreamPlayer player && player.Bus != MusicManager.BusName) player.Bus = SfxBusName;
+      if (node is AudioStreamPlayer3D player3D && player3D.Bus != MusicManager.BusName) player3D.Bus = SfxBusName;
+    }
+  }
+
+  public static void ApplyVolumes (int sfxPercent, int musicPercent)
+  {
+    SetBusPercent (SfxBusName, sfxPercent);
+    SetBusPercent (MusicManager.BusName, musicPercent);
+  }
+
+  public static float PercentToDb (int percent) => percent <= 0 ? -80.0f : Mathf.LinearToDb (Mathf.Clamp (percent, 0, 100) / 100.0f);
+
+  private static void SetBusPercent (string bus, int percent)
+  {
+    var index = AudioServer.GetBusIndex (bus);
+    if (index != -1) AudioServer.SetBusVolumeDb (index, PercentToDb (percent));
+  }
+
+  private static System.Collections.Generic.IEnumerable <Node> Descendants (Node root)
+  {
+    foreach (var child in root.GetChildren())
+    {
+      yield return child;
+      foreach (var grandchild in Descendants (child)) yield return grandchild;
+    }
+  }
+}

--- a/core/players/Player.cs
+++ b/core/players/Player.cs
@@ -1,6 +1,7 @@
 using com.forerunnergames.energyshot.items;
 using com.forerunnergames.energyshot.utilities;
 using com.forerunnergames.energyshot.weapons;
+using com.forerunnergames.energyshot.core.audio;
 using Godot;
 
 namespace com.forerunnergames.energyshot.players;
@@ -376,6 +377,7 @@ public partial class Player : CharacterBody3D
 
   public override void _Ready()
   {
+    AudioBuses.RouteSfx (this); // Every player sound is an effect (issue #301).
     _spawnRoom = GetNode <Node3D> ("/root/World/SpawnRoom");
     _laserBoltScene = ResourceLoader.Load <PackedScene> ("res://core/weapons/LaserBolt.tscn");
     _bananaProjectileScene = ResourceLoader.Load <PackedScene> ("res://core/weapons/BananaProjectile.tscn");

--- a/core/world/World.cs
+++ b/core/world/World.cs
@@ -4,6 +4,7 @@ using com.forerunnergames.energyshot.players;
 using com.forerunnergames.energyshot.ui;
 using com.forerunnergames.energyshot.ui.hud;
 using com.forerunnergames.energyshot.utilities;
+using com.forerunnergames.energyshot.core.audio;
 using Godot;
 
 namespace com.forerunnergames.energyshot.core.world;
@@ -86,6 +87,9 @@ public partial class World : Node3D
 
   public override void _Ready()
   {
+    AudioBuses.EnsureSfxBus(); // Volume sliders (issue #301): every effect rides the SFX bus.
+    AudioBuses.RouteSfx (this);
+    AudioBuses.ApplyVolumes (Settings.SfxVolume, Settings.MusicVolume);
     DressTheRing(); // The spawn box is a boxing ring (issue #174).
     BackstopTheRing(); // Nobody tunnels out of it (issue #276).
     _onServerDisconnectedCallable = Callable.From (OnServerDisconnected);

--- a/tests/unit/AudioBusesTest.cs
+++ b/tests/unit/AudioBusesTest.cs
@@ -1,0 +1,26 @@
+using com.forerunnergames.energyshot.core.audio;
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+namespace com.forerunnergames.energyshot;
+
+// Volume sliders (issue #301): 100 is the shipped mix, 0 is silence, the middle is quieter.
+[TestSuite]
+public class AudioBusesTest
+{
+  [TestCase]
+  public void FullIsTheShippedMix() => AssertFloat (AudioBuses.PercentToDb (100)).IsEqualApprox (0.0f, 0.001f);
+
+  [TestCase]
+  public void ZeroIsSilence() => AssertFloat (AudioBuses.PercentToDb (0)).IsLessEqual (-80.0f);
+
+  [TestCase]
+  public void HalfIsQuieterButNotSilent()
+  {
+    AssertFloat (AudioBuses.PercentToDb (50)).IsLess (0.0f);
+    AssertFloat (AudioBuses.PercentToDb (50)).IsGreater (-80.0f);
+  }
+
+  [TestCase]
+  public void OverAHundredClampsToTheShippedMix() => AssertFloat (AudioBuses.PercentToDb (150)).IsEqualApprox (0.0f, 0.001f);
+}

--- a/ui/hud/Hud.cs
+++ b/ui/hud/Hud.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using com.forerunnergames.energyshot.core.audio;
 using com.forerunnergames.energyshot.core.world;
 using com.forerunnergames.energyshot.players;
 using com.forerunnergames.energyshot.ui.dialogs;
@@ -154,7 +155,7 @@ public partial class Hud : Control
     _breadIcon = GetNode <TextureRect> ("VBoxContainer/Bread/Icon");
     CreateBreadSounds();
     CreateBreadNotice();
-    _lockOnSound = new AudioStreamPlayer { Stream = ProceduralSounds.LockOn(), MaxPolyphony = 2 }; // Issue #211.
+    _lockOnSound = new AudioStreamPlayer { Stream = ProceduralSounds.LockOn(), MaxPolyphony = 2, Bus = AudioBuses.SfxBusName }; // Issue #211.
     AddChild (_lockOnSound);
     _world.SelfPlayerPunched += OnSelfPlayerPunched;
     _world.SelfPlayerPoisonTicked += () => _poisonPulse = 1.0f; // Issue #261.
@@ -355,6 +356,9 @@ public partial class Hud : Control
     column.AddChild (SettingToggle ("Hold to crouch", Settings.HoldToCrouch, isEnabled => { Settings.HoldToCrouch = isEnabled; Player.Local?.RefreshCrouchMode(); }));
     column.AddChild (SettingToggle ("Hold to scope", Settings.HoldToScope, isEnabled => { Settings.HoldToScope = isEnabled; Player.Local?.RefreshScopeMode(); }));
     column.AddChild (SettingToggle ("Hold to emote", Settings.HoldToDance, isEnabled => { Settings.HoldToDance = isEnabled; Player.Local?.RefreshDanceMode(); }));
+    // Audio (issue #301, Escendrix: the effects are too loud): two live sliders.
+    column.AddChild (SettingSlider ("Sound effects volume", Settings.SfxVolume, percent => { Settings.SfxVolume = percent; AudioBuses.ApplyVolumes (Settings.SfxVolume, Settings.MusicVolume); }));
+    column.AddChild (SettingSlider ("Music volume", Settings.MusicVolume, percent => { Settings.MusicVolume = percent; AudioBuses.ApplyVolumes (Settings.SfxVolume, Settings.MusicVolume); }));
     column.AddChild (SettingToggle ("Show music player", Settings.ShowMusicPlayer, isEnabled => { Settings.ShowMusicPlayer = isEnabled; GetNode <MusicPlayer> ("MusicPlayer").ApplyVisibilitySetting(); }));
     column.AddChild (SettingToggle ("Show chat", Settings.ShowChat, isEnabled => Settings.ShowChat = isEnabled));
     column.AddChild (SettingToggle ("Show game messages", Settings.ShowMessages, isEnabled => { Settings.ShowMessages = isEnabled; _messageScroller.ApplyVisibilitySetting(); }));
@@ -371,6 +375,23 @@ public partial class Hud : Control
   // Full-size rows (Aaron, 2026-08-22: code-built widgets keep coming out tiny):
   // a big label & a real ON/OFF toggle button - no theme-sized check icons, which
   // render microscopic against the 4K design viewport no matter the font.
+  // A 0-100 slider row at 4K size (the UI rule): label, a wide slider, & the live value.
+  private static Control SettingSlider (string text, int initial, System.Action <int> apply)
+  {
+    var row = new HBoxContainer();
+    row.AddThemeConstantOverride ("separation", 40);
+    var label = new Label { Text = text, SizeFlagsHorizontal = SizeFlags.ExpandFill, VerticalAlignment = VerticalAlignment.Center };
+    label.AddThemeFontSizeOverride ("font_size", 60);
+    var value = new Label { Text = $"{initial}%", CustomMinimumSize = new Vector2 (200.0f, 0.0f), HorizontalAlignment = HorizontalAlignment.Right, VerticalAlignment = VerticalAlignment.Center };
+    value.AddThemeFontSizeOverride ("font_size", 60);
+    var slider = new HSlider { MinValue = 0, MaxValue = 100, Step = 5, Value = initial, CustomMinimumSize = new Vector2 (700.0f, 80.0f), SizeFlagsVertical = SizeFlags.ShrinkCenter };
+    slider.ValueChanged += newValue => { value.Text = $"{(int)newValue}%"; apply ((int)newValue); };
+    row.AddChild (label);
+    row.AddChild (slider);
+    row.AddChild (value);
+    return row;
+  }
+
   private static Control SettingToggle (string text, bool initial, System.Action <bool> apply)
   {
     var row = new HBoxContainer();
@@ -462,8 +483,8 @@ public partial class Hud : Control
   // & the interruption are HUD-local.
   private void CreateBreadSounds()
   {
-    _breadDeniedSound = new AudioStreamPlayer { Stream = ProceduralSounds.Denied() };
-    _breadInterruptedSound = new AudioStreamPlayer { Stream = ProceduralSounds.Interrupted() };
+    _breadDeniedSound = new AudioStreamPlayer { Stream = ProceduralSounds.Denied(), Bus = AudioBuses.SfxBusName };
+    _breadInterruptedSound = new AudioStreamPlayer { Stream = ProceduralSounds.Interrupted(), Bus = AudioBuses.SfxBusName };
     AddChild (_breadDeniedSound);
     AddChild (_breadInterruptedSound);
   }

--- a/utilities/Settings.cs
+++ b/utilities/Settings.cs
@@ -105,6 +105,19 @@ public static class Settings
     set => Set ("hold_to_scope", value);
   }
 
+  // Volume sliders (issue #301, Escendrix): 0-100 per bus, 100 = the mix as shipped.
+  public static int SfxVolume
+  {
+    get => GetInt ("sfx_volume", 100);
+    set => Set ("sfx_volume", value);
+  }
+
+  public static int MusicVolume
+  {
+    get => GetInt ("music_volume", 100);
+    set => Set ("music_volume", value);
+  }
+
   // Emote as hold-while-pressed instead of the default toggle (Aaron, 2026-08-23):
   // hold G to groove, release to stop; toggle mode stays the default.
   public static bool HoldToDance


### PR DESCRIPTION
Closes #301 (Escendrix: sound effects are too loud).

- A new **SFX** audio bus: every `AudioStreamPlayer`/`3D` under the world, each player's subtree & the HUD's procedural sounds routes onto it (music already rides its own bus from MusicManager, untouched).
- Two sliders in the Settings dialog - **Sound effects volume** & **Music volume**, 0-100 in steps of 5 - applied live to the buses & persisted in settings.cfg. 100 is the mix as shipped, so defaults change nothing.
- 4K-sized rows per the UI rule (60pt labels, 700px slider, live % readout); the percent-to-dB mapping is unit-tested (full = 0 dB, zero = silence, clamped above 100).

Known escape: a sound created on a fresh node AFTER these routes (e.g. a per-shot 3D player spawned by a projectile) stays on Master - flag any that turn up & they get routed by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso