### PR TITLE
Playtest: the host anchors on Building8's roof

### DIFF
--- a/tests/playtest/PlaytestDriver.cs
+++ b/tests/playtest/PlaytestDriver.cs
@@ -232,7 +232,13 @@ public partial class PlaytestDriver : Node
     // re-parking onto OTHER phases' pickups - the shooter's dropped blowgun twice
     // & the airplane restock once). The anchor moves to bare ground far from
     // every phase zone; the club phase clubs it there, litter-free.
-    var anchor = new Vector3 (30.0f, 1.4f, -30.0f);
+    // Building8's ROOF (the empty quarter wasn't empty enough: a killed body's
+    // slide off the deck grounded its banana near the old ground anchor & the
+    // leashed host ate it - '[peer 1] weapon award: Banana'). Drops land at the
+    // dying body's (x,z), & no body ever dies on this 5x5 roof 45m+ from every
+    // phase zone; the club phase already chases host.GlobalPosition, so it
+    // calibrates up here with real footing.
+    var anchor = new Vector3 (75.0f, 2.6f, 30.0f);
     Self.Position = anchor;
     await Task.Delay (300);
     var leashDeadline = Time.GetTicksMsec() + (ulong)(tailBudgetSeconds * 1000);


### PR DESCRIPTION
The empty quarter (#383) wasn't empty enough: with #370's carry, a killed body slides off the deck & its banana grounds at the body's (x,z) - near the old ground-level anchor, where the leashed host faithfully ate it (`[peer 1] weapon award: Banana`), starving the shooter's death-drop claim (this red hit #384's & #385's runs).

New anchor: **Building8's roof** (75, 2.6, 30) - a 5x5 slab at y=2, 45m+ from every phase zone, & no body ever dies up there, so no drop can ever land within the host's claim range. The club phase already chases `host.GlobalPosition` each swing, so calibration works on the roof with real footing. Driver-only; #385 rebases behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f9z6vQCT73QAcDnUQ2Hso